### PR TITLE
Renovate renovate/com.github.spotbugs-spotbugs-annotations-4.x renovate/org.antlr-antlr-runtime-3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.antlr</groupId>
 			<artifactId>antlr-runtime</artifactId>
-			<version>3.5.2</version>
+			<version>3.5.3</version>
 		</dependency>
 
 		<!-- https://smallrye.io/smallrye-mutiny/2.5.1/tutorials/getting-mutiny/ -->

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
 		<dependency>
 			<groupId>com.github.spotbugs</groupId>
 			<artifactId>spotbugs-annotations</artifactId>
-			<version>4.7.3</version>
+			<version>4.8.3</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Closes #107, #106

- Update dependency com.github.spotbugs:spotbugs-annotations to v4.8.3
- Update dependency org.antlr:antlr-runtime to v3.5.3
