### PR TITLE
DeduceTypes2: Split into separate classes

### DIFF
--- a/annotations/src/main/java/com/cloudogu/blog/Scope.java
+++ b/annotations/src/main/java/com/cloudogu/blog/Scope.java
@@ -40,7 +40,7 @@ public final class Scope {
 	private          ZonedDateTime date;
 	private          String        packageName;
 	private          String        sourceClassName;
-	private @NotNull List<Field>   fields = new ArrayList<>();
+	private @NotNull  List<Field>   fields = new ArrayList<>();
 
 	Scope(String packageName, String sourceClassName) {
 		this.date            = ZonedDateTime.now();
@@ -48,11 +48,11 @@ public final class Scope {
 		this.sourceClassName = sourceClassName;
 	}
 
-	public @NotNull String getComment() {
+	public @NotNull  String getComment() {
 		return COMMENT;
 	}
 
-	public @NotNull String getDate() {
+	public @NotNull  String getDate() {
 		return date.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
 	}
 
@@ -64,23 +64,23 @@ public final class Scope {
 		return sourceClassName;
 	}
 
-	public @NotNull String getSourceClassNameWithPackage() {
+	public @NotNull  String getSourceClassNameWithPackage() {
 		return packageName + "." + sourceClassName;
 	}
 
-	public @NotNull String getTargetClassNameWithPackage() {
+	public @NotNull  String getTargetClassNameWithPackage() {
 		return packageName + "." + getTargetClassName();
 	}
 
-	public @NotNull String getTargetClassName() {
+	public @NotNull  String getTargetClassName() {
 		return sourceClassName + "JsonWriter";
 	}
 
-	public @NotNull DecoratedCollection<Field> getFields() {
+	public @NotNull  DecoratedCollection<Field> getFields() {
 		return new DecoratedCollection(fields);
 	}
 
-	public void addGetter(@NotNull String getter) {
+	public void addGetter(@NotNull  String getter) {
 		String fieldName = getter.substring(3);
 		char   firstChar = fieldName.charAt(0);
 		fieldName = Character.toLowerCase(firstChar) + fieldName.substring(1);

--- a/annotations/src/main/java/com/cloudogu/blog/ToJsonProcessor.java
+++ b/annotations/src/main/java/com/cloudogu/blog/ToJsonProcessor.java
@@ -62,7 +62,7 @@ public class ToJsonProcessor extends AbstractProcessor {
 	}
 
 	@Override
-	public boolean process(@NotNull Set<? extends TypeElement> annotations, @NotNull RoundEnvironment roundEnv) {
+	public boolean process(@NotNull  Set<? extends TypeElement> annotations, @NotNull  RoundEnvironment roundEnv) {
 		for (TypeElement annotation : annotations) {
 			for (Element element : roundEnv.getElementsAnnotatedWith(annotation)) {
 				try {
@@ -83,11 +83,11 @@ public class ToJsonProcessor extends AbstractProcessor {
 		}
 	}
 
-	private void error(@NotNull IOException e) {
+	private void error(@NotNull  IOException e) {
 		processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "failed to write extension file: " + e.getMessage());
 	}
 
-	private void writeJsonWriterClass(Element element, @NotNull Scope scope) throws IOException {
+	private void writeJsonWriterClass(Element element, @NotNull  Scope scope) throws IOException {
 		Filer          filer      = processingEnv.getFiler();
 		JavaFileObject fileObject = filer.createSourceFile(scope.getTargetClassNameWithPackage(), element);
 		try (Writer writer = fileObject.openWriter()) {
@@ -95,7 +95,7 @@ public class ToJsonProcessor extends AbstractProcessor {
 		}
 	}
 
-	private @NotNull Scope createModel(@NotNull TypeElement element) {
+	private @NotNull  Scope createModel(@NotNull  TypeElement element) {
 		String packageName     = getPackageName(element);
 		String sourceClassName = getSimpleNameAsString(element);
 
@@ -104,11 +104,11 @@ public class ToJsonProcessor extends AbstractProcessor {
 		return scope;
 	}
 
-	private String getPackageName(@NotNull TypeElement classElement) {
+	private String getPackageName(@NotNull  TypeElement classElement) {
 		return ((PackageElement) classElement.getEnclosingElement()).getQualifiedName().toString();
 	}
 
-	private String getSimpleNameAsString(@NotNull Element element) {
+	private String getSimpleNameAsString(@NotNull  Element element) {
 		return element.getSimpleName().toString();
 	}
 
@@ -116,7 +116,7 @@ public class ToJsonProcessor extends AbstractProcessor {
 		return element instanceof TypeElement;
 	}
 
-	private void appendFields(TypeElement element, @NotNull Scope scope) {
+	private void appendFields(TypeElement element, @NotNull  Scope scope) {
 		if (isTypeElement(element)) {
 			for (String getterMethod : getAllGetterMethodNames(element)) {
 				scope.addGetter(getterMethod);
@@ -124,7 +124,7 @@ public class ToJsonProcessor extends AbstractProcessor {
 		}
 	}
 
-	private @NotNull List<String> getAllGetterMethodNames(TypeElement typeElement) {
+	private @NotNull  List<String> getAllGetterMethodNames(TypeElement typeElement) {
 		return processingEnv.getElementUtils().getAllMembers(typeElement)
 				.stream()
 				.filter(el -> el.getKind() == ElementKind.METHOD)

--- a/eclipse-formatter.xml
+++ b/eclipse-formatter.xml
@@ -30,6 +30,8 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
 	<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="82"/>
+	<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="1"/>
+	<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>

--- a/eclipse-formatter.xml
+++ b/eclipse-formatter.xml
@@ -29,7 +29,7 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+	<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="82"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/ApacheOptionsProcessor.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/ApacheOptionsProcessor.java
@@ -1,15 +1,14 @@
 package tripleo.elijah.comp;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.comp.i.*;
-import tripleo.elijah.comp.impl.CC_SetSilent;
-import tripleo.elijah.comp.internal.CompilationImpl;
-import tripleo.elijah.util.Ok;
-import tripleo.elijah.util.Operation;
-import tripleo.vendor.org_apache_commons_cli.*;
+import java.util.*;
 
-import java.util.List;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.comp.impl.*;
+import tripleo.elijah.comp.internal.*;
+import tripleo.elijah.util.*;
+import tripleo.vendor.org_apache_commons_cli.*;
 
 public class ApacheOptionsProcessor implements OptionsProcessor {
 	private final CommandLineParser clp     = new DefaultParser();
@@ -22,7 +21,7 @@ public class ApacheOptionsProcessor implements OptionsProcessor {
 	}
 
 	public Operation<Ok> process(final @NotNull Compilation c,
-								 final @NotNull List<CompilerInput> aInputs,
+			final @NotNull List<CompilerInput> aInputs,
 								 final ICompilationBus aCb) {
 		try {
 			final CommandLine cmd = clp.parse(options, aInputs);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/EvaPipeline.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/EvaPipeline.java
@@ -7,8 +7,13 @@
  */
 package tripleo.elijah.comp;
 
+import static tripleo.elijah.util.Helpers.*;
+
+import java.util.*;
+
 import org.jdeferred2.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.comp.i.extra.*;
@@ -26,19 +31,15 @@ import tripleo.elijah.stages.gen_generic.pipeline_impl.*;
 import tripleo.elijah.util.*;
 import tripleo.elijah_elevated.comp.backbone.*;
 
-import java.util.*;
-
-import static tripleo.elijah.util.Helpers.*;
-
 /**
  * Created 8/21/21 10:16 PM
  */
 public class EvaPipeline extends PipelineMember implements AccessBus.AB_LgcListener {
 	private final          CompilationEnclosure       ce;
-	private final @NotNull IPipelineAccess            pa;
-	private final @NotNull DefaultGenerateResultSink  grs;
+	private final @NotNull IPipelineAccess pa;
+	private final @NotNull DefaultGenerateResultSink grs;
 	private final @NotNull DoubleLatch<List<EvaNode>> latch2;
-	private final @NotNull List<FunctionStatement>    functionStatements = new ArrayList<>();
+	private final @NotNull List<FunctionStatement> functionStatements = new ArrayList<>();
 	private                CB_Output                  _processOutput;
 	private                Object/*CR_State*/         _processState;
 	@SuppressWarnings("unused")

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/ModuleBuilder.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/ModuleBuilder.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.comp;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.contexts.*;
 import tripleo.elijah.g.*;
 import tripleo.elijah.lang.i.*;
@@ -32,7 +33,7 @@ public class ModuleBuilder {
 			}
 
 			final @Nullable Compilation compilation = (Compilation) mod.getCompilation();
-			final @NotNull LivingRepo   world       = compilation.world();
+			final @NotNull LivingRepo world = compilation.world();
 			world.addModule(mod, _fn, compilation);
 		}
 		return mod;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/PipelineLogic.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/PipelineLogic.java
@@ -8,10 +8,17 @@
  */
 package tripleo.elijah.comp;
 
-import com.google.common.collect.*;
-import io.reactivex.rxjava3.annotations.*;
+import static tripleo.elijah.util.Helpers0.*;
+
+import java.util.*;
+import java.util.function.*;
+
 import org.jdeferred2.*;
 import org.jetbrains.annotations.*;
+
+import com.google.common.collect.*;
+
+import io.reactivex.rxjava3.annotations.*;
 import tripleo.elijah.*;
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.comp.i.extra.*;
@@ -29,17 +36,12 @@ import tripleo.elijah.world.i.*;
 import tripleo.elijah.world.impl.*;
 import tripleo.elijah_elevated.comp.backbone.*;
 
-import java.util.*;
-import java.util.function.*;
-
-import static tripleo.elijah.util.Helpers0.*;
-
 /**
  * Created 12/30/20 2:14 AM
  */
 public class PipelineLogic implements EventualRegister, GPipelineLogic {
-	public final @NotNull  GeneratePhase            generatePhase;
-	public final @NotNull  DeducePhase              dp;
+	public final @NotNull GeneratePhase generatePhase;
+	public final @NotNull DeducePhase dp;
 	final @NonNull         ModMap                   modMap     = new ModMap();
 	private final          ICompilationAccess       ca;
 	private final @NonNull ModuleCompletableProcess mcp        = new ModuleCompletableProcess();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/WriteMakefilePipeline.xtend-
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/WriteMakefilePipeline.xtend-
@@ -31,7 +31,7 @@ public class WriteMakefilePipeline implements PipelineMember, Consumer<Supplier<
 			sb.append(s);
 		}
 
-		public @NotNull String getText() {
+		public @NotNull  String getText() {
 			return sb.toString();
 		}
 	}
@@ -48,7 +48,7 @@ public class WriteMakefilePipeline implements PipelineMember, Consumer<Supplier<
 
 	}
 
-	private void process(final @NotNull G aG, final @NotNull List<EOT_OutputFile> aL) {
+	private void process(final @NotNull  G aG, final @NotNull  List<EOT_OutputFile> aL) {
 		final StringBuilder sb = new StringBuilder();
 
 		for (EOT_OutputFile off : aL) {
@@ -74,7 +74,7 @@ public class WriteMakefilePipeline implements PipelineMember, Consumer<Supplier<
 		aG.append(sb.toString());
 	}
 
-	private void process1(final @NotNull G aG) {
+	private void process1(final @NotNull  G aG) {
 		aG.append_string("\tcc \\\n");
 		for (String object : aG.objects) {
 			aG.append_string("\t\tB/%s \\\n".formatted(object));
@@ -84,7 +84,7 @@ public class WriteMakefilePipeline implements PipelineMember, Consumer<Supplier<
 	}
 
 	@Override
-	public void run(@NotNull CR_State st, CB_Output aOutput) throws Exception {
+	public void run(@NotNull  CR_State st, CB_Output aOutput) throws Exception {
 		final Compilation c = st.ca().getCompilation();
 		var cot = c.getOutputTree();
 
@@ -97,7 +97,7 @@ public class WriteMakefilePipeline implements PipelineMember, Consumer<Supplier<
 	}
 
 	@NotNull
-	EOT_OutputFile testable_part(final @NotNull List<EOT_OutputFile> list1) {
+	EOT_OutputFile testable_part(final @NotNull  List<EOT_OutputFile> list1) {
 		var list = list1.stream().filter(off -> off.getType() == EOT_OutputType.SOURCES).collect(Collectors.toList());
 
 		var sb = new StringBuilder();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/WriteMesonPipeline.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/WriteMesonPipeline.java
@@ -8,34 +8,37 @@
  */
 package tripleo.elijah.comp;
 
-import com.google.common.collect.*;
-import org.jetbrains.annotations.*;
-import tripleo.elijah.ci.*;
-import tripleo.elijah.comp.i.*;
-import tripleo.elijah.comp.i.extra.*;
-import tripleo.elijah.comp.nextgen.i.CP_Path;
-import tripleo.elijah.g.*;
-import tripleo.elijah.nextgen.outputstatement.*;
-import tripleo.elijah.nextgen.outputtree.*;
-import tripleo.elijah.stages.functionality.f292.F292_WriteRoot;
-import tripleo.elijah.stages.gen_generic.*;
-import tripleo.elijah.util.Ok;
-import tripleo.elijah.util.io.*;
-import tripleo.elijah_prolific.v.V;
+import static tripleo.elijah.util.Helpers.*;
 
 import java.io.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.regex.*;
 
-import static tripleo.elijah.util.Helpers.*;
+import org.jetbrains.annotations.*;
+
+import com.google.common.collect.*;
+
+import tripleo.elijah.ci.*;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.comp.i.extra.*;
+import tripleo.elijah.comp.nextgen.i.*;
+import tripleo.elijah.g.*;
+import tripleo.elijah.nextgen.outputstatement.*;
+import tripleo.elijah.nextgen.outputtree.*;
+import tripleo.elijah.stages.functionality.f292.*;
+import tripleo.elijah.stages.gen_generic.*;
+import tripleo.elijah.util.*;
+import tripleo.elijah.util.io.*;
+import tripleo.elijah_prolific.v.*;
 
 /**
  * Created 9/13/21 11:58 PM
  */
-public class WriteMesonPipeline extends PipelineMember implements @NotNull Consumer<Supplier<Old_GenerateResult>>, GPipelineMember {
+public class WriteMesonPipeline extends PipelineMember
+		implements @NotNull Consumer<Supplier<Old_GenerateResult>>, GPipelineMember {
 	final                  Pattern         pullPat = Pattern.compile("/[^/]+/(.+)");
-	private final @NotNull Compilation     c;
+	private final @NotNull Compilation c;
 	private final @NotNull IPipelineAccess pa;
 	private final          WritePipeline   writePipeline;
 	@NotNull
@@ -146,7 +149,7 @@ public class WriteMesonPipeline extends PipelineMember implements @NotNull Consu
 	}
 
 	private void write_root(@NotNull Multimap<CompilerInstructions, String> lsp_outputs,
-							@NotNull List<String> aDep_dirs) throws IOException {
+			@NotNull List<String> aDep_dirs) throws IOException {
 		final CP_Path path2_ = getPath2("meson.build");
 
 		path2_.getPathPromise().then(path2 -> {
@@ -180,7 +183,8 @@ public class WriteMesonPipeline extends PipelineMember implements @NotNull Consu
 			path.getPathPromise().then(pp -> {
 				final MesonFile mesonFile = new MesonFile(this, aSub_dir, lsp_outputs, compilerInstructions, path);
 
-				@NotNull final EG_Statement stmt = mesonFile;
+				@NotNull
+				final EG_Statement stmt = mesonFile;
 
 				mesonFile.getPath().getPathPromise().then(ppp -> {
 
@@ -221,7 +225,8 @@ public class WriteMesonPipeline extends PipelineMember implements @NotNull Consu
 			sb.append(String.format("%s_dep = declare_dependency( link_with: %s )", "Prelude", "Prelude")); // include_directories
 			sb.append("\n");
 
-			@NotNull final EG_Statement stmt = EG_Statement.of(sb.toString(), EX_Explanation.withMessage("WriteMesonPipeline"));
+			@NotNull
+			final EG_Statement stmt = EG_Statement.of(sb.toString(), EX_Explanation.withMessage("WriteMesonPipeline"));
 			final String         s   = ppath.toString();
 
 			V.asv(V.e.WMP_write_prelude, ""+ppath);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/WriteOutputTreePipeline.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/WriteOutputTreePipeline.java
@@ -1,40 +1,31 @@
 package tripleo.elijah.comp;
 
-import tripleo.elijah.comp.functionality.f291.U;
-import tripleo.elijah.comp.i.CB_Output;
-import tripleo.elijah.comp.i.extra.IPipelineAccess;
-import tripleo.elijah.comp.internal.CompilationImpl;
-
-import tripleo.elijah.g.GPipelineAccess;
-import tripleo.elijah.g.GPipelineMember;
-
-import tripleo.elijah.comp.nextgen.i.CP_Path;
-import tripleo.elijah.comp.nextgen.i.CP_Paths;
-import tripleo.elijah.comp.nextgen.i.CP_RootType;
-
-import tripleo.elijah.nextgen.outputstatement.EG_Naming;
-import tripleo.elijah.nextgen.outputstatement.EG_SequenceStatement;
-import tripleo.elijah.nextgen.outputstatement.EG_SingleStatement;
-import tripleo.elijah.nextgen.outputstatement.EG_Statement;
-import tripleo.elijah.nextgen.outputtree.*;
-import tripleo.elijah.nextgen.ER_Node;
-
-import tripleo.elijah.stages.logging.ElLog;
-import tripleo.elijah.nextgen.comp_model.CM_UleLog;
-
-import io.smallrye.mutiny.tuples.Functions;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.stages.logging.LogEntry;
-import tripleo.elijah.util.Ok;
+import static tripleo.elijah.util.Helpers.*;
 
 import java.util.*;
 
-import static tripleo.elijah.util.Helpers.*;
+import org.jetbrains.annotations.*;
+
+import io.smallrye.mutiny.tuples.*;
+import tripleo.elijah.comp.functionality.f291.*;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.comp.i.extra.*;
+import tripleo.elijah.comp.internal.*;
+import tripleo.elijah.comp.nextgen.i.*;
+import tripleo.elijah.g.*;
+import tripleo.elijah.nextgen.*;
+import tripleo.elijah.nextgen.comp_model.*;
+import tripleo.elijah.nextgen.outputstatement.*;
+import tripleo.elijah.nextgen.outputtree.*;
+import tripleo.elijah.stages.logging.*;
+import tripleo.elijah.util.*;
 
 public class WriteOutputTreePipeline extends PipelineMember implements GPipelineMember {
 	private final int WRITE_OUTPUT_TREE__ADD_NODE_OUTPUT = 106;
 
-	private static void addLogs(final @NotNull Functions.TriConsumer<List, EOT_FileNameProvider, EG_Statement> outputSink, final List<ElLog> logs) {
+	private static void addLogs(
+			final @NotNull Functions.TriConsumer<List, EOT_FileNameProvider, EG_Statement> outputSink,
+			final List<ElLog> logs) {
 		final String s1 = logs.get(0).getFileName();
 
 		for (final ElLog log : logs) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/WritePipeline.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/WritePipeline.java
@@ -10,12 +10,20 @@ package tripleo.elijah.comp;
 
 //import com.google.common.base.Preconditions;
 
+import static tripleo.elijah.util.Helpers.*;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+import org.jetbrains.annotations.*;
+
 import com.google.common.collect.*;
+
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.Observer;
 import io.reactivex.rxjava3.disposables.Disposable;
 import lombok.*;
-import org.jetbrains.annotations.*;
 import tripleo.elijah.*;
 import tripleo.elijah.comp.graph.i.*;
 import tripleo.elijah.comp.i.*;
@@ -28,12 +36,6 @@ import tripleo.elijah.stages.logging.*;
 import tripleo.elijah.stages.write_stage.pipeline_impl.*;
 import tripleo.elijah.util.*;
 
-import java.util.*;
-import java.util.function.*;
-import java.util.stream.*;
-
-import static tripleo.elijah.util.Helpers.*;
-
 /**
  * Created 8/21/21 10:19 PM
  */
@@ -41,8 +43,8 @@ public class WritePipeline extends PipelineMember implements Consumer<Supplier<G
 	@Getter
 	private final          Eventual<GenerateResult> generateResultPromise = new Eventual<>();
 	@Getter
-	private final @NotNull WritePipelineSharedState                   st;
-	private final @NotNull CompletedItemsHandler                      cih;
+	private final @NotNull WritePipelineSharedState st;
+	private final @NotNull CompletedItemsHandler cih;
 	private final @NotNull DoubleLatch<GenerateResult> latch;
 	private WP_Flow.OPS ops;
 	private final CK_Monitor monitor;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/_U.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/_U.java
@@ -1,15 +1,17 @@
 package tripleo.elijah.comp;
 
-import org.jetbrains.annotations.*;
-import tripleo.elijah.nextgen.comp_model.*;
-import tripleo.elijah_elevated.comp.input.*;
-
 import java.util.*;
 import java.util.stream.*;
 
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.nextgen.comp_model.*;
+import tripleo.elijah_elevated.comp.input.*;
+
 public class _U {
 
-	public static @NotNull List<@NotNull CompilerInput> stringListToInputList(final @NotNull List<String> args, final @NotNull Compilation aCompilation) {
+	public static @NotNull List<@NotNull CompilerInput> stringListToInputList(final @NotNull List<String> args,
+			final @NotNull Compilation aCompilation) {
 		final List<CompilerInput> inputs = args.stream()
 				.map(s -> {
 					final CompilerInput    input = new CompilerInput_(s, Optional.of(aCompilation));

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/functionality/f203/ChooseDirectoryNameBehavior.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/functionality/f203/ChooseDirectoryNameBehavior.java
@@ -4,5 +4,6 @@ import org.jetbrains.annotations.NotNull;
 import tripleo.wrap.File;
 
 public interface ChooseDirectoryNameBehavior {
-	@NotNull File chooseDirectory();
+	@NotNull
+	File chooseDirectory();
 }

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/i/CompFactory.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/i/CompFactory.java
@@ -1,26 +1,22 @@
 package tripleo.elijah.comp.i;
 
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.comp.*;
-import tripleo.elijah.comp.graph.i.CK_Monitor;
-import tripleo.elijah.comp.graph.i.CK_ObjectTree;
-import tripleo.elijah.comp.internal.CompilationImpl;
-import tripleo.elijah.comp.internal.PW_CompilerController;
-import tripleo.elijah.comp.internal.Startable;
-import tripleo.elijah.comp.nextgen.CX_ParseElijahFile;
-import tripleo.elijah.comp.nextgen.i.CP_Path;
-import tripleo.elijah.comp.nextgen.inputtree.EIT_ModuleInput;
-import tripleo.elijah.comp.nextgen.pw.PW_PushWorkQueue;
-import tripleo.elijah.comp.specs.ElijahCache;
-import tripleo.elijah.lang.i.OS_Module;
-import tripleo.elijah.lang.i.Qualident;
-import tripleo.elijah.nextgen.comp_model.CM_UleLog;
-import tripleo.elijah.nextgen.inputtree.EIT_InputTree;
-import tripleo.elijah.nextgen.outputtree.EOT_OutputTree;
-import tripleo.elijah.world.i.LivingRepo;
-import tripleo.elijah.world.i.WorldModule;
+import java.util.*;
 
-import java.util.List;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.comp.*;
+import tripleo.elijah.comp.graph.i.*;
+import tripleo.elijah.comp.internal.*;
+import tripleo.elijah.comp.nextgen.*;
+import tripleo.elijah.comp.nextgen.i.*;
+import tripleo.elijah.comp.nextgen.inputtree.*;
+import tripleo.elijah.comp.nextgen.pw.*;
+import tripleo.elijah.comp.specs.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.nextgen.comp_model.*;
+import tripleo.elijah.nextgen.inputtree.*;
+import tripleo.elijah.nextgen.outputtree.*;
+import tripleo.elijah.world.i.*;
 
 public interface CompFactory {
 
@@ -58,13 +54,17 @@ public interface CompFactory {
 
 	CX_ParseElijahFile.ElijahSpecReader defaultElijahSpecReader(CP_Path aLocalPrelude);
 
-	@NotNull CK_Monitor createCkMonitor();
+	@NotNull
+	CK_Monitor createCkMonitor();
 
-	@NotNull PW_CompilerController createPwController(CompilationImpl aCompilation);
+	@NotNull
+	PW_CompilerController createPwController(CompilationImpl aCompilation);
 
-	@NotNull Finally_ createFinally();
+	@NotNull
+	Finally_ createFinally();
 
-	@NotNull LivingRepo getLivingRepo();
+	@NotNull
+	LivingRepo getLivingRepo();
 
 	CompilerInputMaster createCompilerInputMaster();
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CB_FindCIs.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CB_FindCIs.java
@@ -1,17 +1,16 @@
 package tripleo.elijah.comp.internal;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.comp.Compilation;
-import tripleo.elijah.comp.CompilerInput;
-import tripleo.elijah.comp.i.*;
-import tripleo.elijah.comp.percy.CN_CompilerInputWatcher;
-import tripleo.elijah.nextgen.comp_model.CM_CompilerInput;
-import tripleo.elijah.util.Maybe;
-import tripleo.wrap.File;
+import java.nio.file.*;
+import java.util.*;
 
-import java.nio.file.NotDirectoryException;
-import java.util.List;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.comp.*;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.comp.percy.*;
+import tripleo.elijah.nextgen.comp_model.*;
+import tripleo.elijah.util.*;
+import tripleo.wrap.*;
 
 class CB_FindCIs implements CB_Action {
 	private final CompilationRunner   compilationRunner;
@@ -61,8 +60,8 @@ class CB_FindCIs implements CB_Action {
 	}
 
 	private void _processInput(final @NotNull CompilationClosure c,
-							   final @NotNull ErrSink aErrSink,
-							   final @NotNull CompilerInput input) {
+			final @NotNull ErrSink aErrSink,
+			final @NotNull CompilerInput input) {
 		// FIXME 24/01/09 oop
 		switch (input.ty()) {
 		case NULL, SOURCE_ROOT -> {}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CB_ForwardingOutput.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CB_ForwardingOutput.java
@@ -12,7 +12,7 @@ public class CB_ForwardingOutput implements CB_Output {
 	}
 
 	//@Override
-	//public @NotNull List<CB_OutputString> get() {
+	// public @NotNull List<CB_OutputString> get() {
 	//	return output.get();
 	//}
 	//

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CB_StartCompilationRunnerAction.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CB_StartCompilationRunnerAction.java
@@ -1,16 +1,16 @@
 package tripleo.elijah.comp.internal;
 
-import lombok.Getter;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.ci.CompilerInstructions;
+import static tripleo.elijah.util.Helpers.*;
+
+import java.util.*;
+
+import org.jetbrains.annotations.*;
+
+import lombok.*;
+import tripleo.elijah.ci.*;
 import tripleo.elijah.comp.i.*;
-import tripleo.elijah.comp.i.extra.IPipelineAccess;
-import tripleo.elijah.util.Operation;
-
-import java.util.List;
-
-import static tripleo.elijah.util.Helpers.List_of;
+import tripleo.elijah.comp.i.extra.*;
+import tripleo.elijah.util.*;
 
 class CB_StartCompilationRunnerAction implements CB_Action, CB_Process {
 	static                 boolean              started;
@@ -22,7 +22,7 @@ class CB_StartCompilationRunnerAction implements CB_Action, CB_Process {
 
 	@Contract(pure = true)
 	public CB_StartCompilationRunnerAction(final CompilationRunner aCompilationRunner,
-	                                       final @NotNull IPipelineAccess aPa,
+			final @NotNull IPipelineAccess aPa,
 	                                       final CompilerInstructions aRootCI) {
 		compilationRunner = aCompilationRunner;
 		pa                = aPa;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CD_CompilationRunnerStart.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CD_CompilationRunnerStart.java
@@ -1,12 +1,12 @@
 package tripleo.elijah.comp.internal;
 
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.ci.CompilerInstructions;
-import tripleo.elijah.comp.i.CB_Output;
-import tripleo.elijah.comp.i.CompilerDriven;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.ci.*;
+import tripleo.elijah.comp.i.*;
 
 public interface CD_CompilationRunnerStart extends CompilerDriven {
 	void start(final @NotNull CompilerInstructions aCompilerInstructions,
-			   final @NotNull CR_State crState,
-			   final @NotNull CB_Output out);
+			final @NotNull CR_State crState,
+			final @NotNull CB_Output out);
 }

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CD_CompilationRunnerStart_1.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CD_CompilationRunnerStart_1.java
@@ -1,17 +1,17 @@
 package tripleo.elijah.comp.internal;
 
-import lombok.Getter;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.ci.CompilerInstructions;
+import static tripleo.elijah.util.Helpers.*;
+
+import java.util.*;
+
+import org.jetbrains.annotations.*;
+
+import lombok.*;
+import tripleo.elijah.ci.*;
 import tripleo.elijah.comp.graph.i.*;
-import tripleo.elijah.comp.i.CB_Output;
-import tripleo.elijah_elevated.comp.backbone.CompilationEnclosure;
+import tripleo.elijah.comp.i.*;
 import tripleo.elijah.util.*;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static tripleo.elijah.util.Helpers.List_of;
+import tripleo.elijah_elevated.comp.backbone.*;
 
 public class CD_CompilationRunnerStart_1 implements CD_CompilationRunnerStart {
 	private       CK_Steps        steps;
@@ -24,9 +24,9 @@ public class CD_CompilationRunnerStart_1 implements CD_CompilationRunnerStart {
 
 	@Override
 	public void start(final @NotNull CompilerInstructions aRootCI,
-					  final @NotNull CR_State crState,
-					  final @NotNull CB_Output out) {
-		//final @NotNull CK_Monitor monitor = compilationEnclosure.getDefaultMonitor();
+			final @NotNull CR_State crState,
+			final @NotNull CB_Output out) {
+		// final @NotNull CK_Monitor monitor = compilationEnclosure.getDefaultMonitor();
 
 		stepContext = new CD_CRS_StepsContext(crState, out);
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CD_FindStdLibImpl.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CD_FindStdLibImpl.java
@@ -1,19 +1,18 @@
 package tripleo.elijah.comp.internal;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.ci.CompilerInstructions;
-import tripleo.elijah.comp.graph.i.CK_SourceFile;
-import tripleo.elijah.comp.i.*;
-import tripleo.elijah.comp.nextgen.i.CP_Path;
-import tripleo.elijah.comp.nextgen.i.CP_StdlibPath;
-import tripleo.elijah.comp.nextgen.impl.CK_SourceFileFactory;
-import tripleo.elijah.g.GCR_State;
-import tripleo.elijah.util.Mode;
-import tripleo.elijah.util.Operation2;
-import tripleo.wrap.File;
+import java.util.function.*;
 
-import java.util.function.Consumer;
+import org.apache.commons.lang3.tuple.*;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.ci.*;
+import tripleo.elijah.comp.graph.i.*;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.comp.nextgen.i.*;
+import tripleo.elijah.comp.nextgen.impl.*;
+import tripleo.elijah.g.*;
+import tripleo.elijah.util.*;
+import tripleo.wrap.*;
 
 public class CD_FindStdLibImpl implements CD_FindStdLib {
 
@@ -26,15 +25,16 @@ public class CD_FindStdLibImpl implements CD_FindStdLib {
 
 	//@Override
 	public void findStdLib(final @NotNull CR_State crState,
-						   final @NotNull String aPreludeName,
-						   final @NotNull Consumer<Operation2<CompilerInstructions>> coci) {
+			final @NotNull String aPreludeName,
+			final @NotNull Consumer<Operation2<CompilerInstructions>> coci) {
 		final CompilationRunner  compilationRunner = crState.runner();
 		final CompilationClosure cc                = compilationRunner._accessCompilation().getCompilationClosure();
 		final CP_StdlibPath      slr               = cc.getCompilation().paths().stdlibRoot();
 		final CP_Path            pl                = slr.child("lib-" + aPreludeName);
 		final CP_Path            sle               = pl.child("stdlib.ez");
 
-		@NotNull Operation2<CompilerInstructions> result = null;
+		@NotNull
+		Operation2<CompilerInstructions> result = null;
 
 		try {
 			final File local_stdlib = sle.toFile();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CK_ProcessInitialAction.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CK_ProcessInitialAction.java
@@ -1,11 +1,11 @@
 package tripleo.elijah.comp.internal;
 
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.ci.CompilerInstructions;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.ci.*;
 import tripleo.elijah.comp.graph.i.*;
-import tripleo.elijah.comp.i.CB_Output;
-import tripleo.elijah.util.Ok;
-import tripleo.elijah.util.Operation;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.util.*;
 
 public class CK_ProcessInitialAction implements CK_Action {
 	private final CompilerInstructions rootCI;
@@ -32,7 +32,7 @@ public class CK_ProcessInitialAction implements CK_Action {
 	}
 
 	//@Override
-	//public @NotNull String name() {
+	// public @NotNull String name() {
 	//	return "process initial";
 	//}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CR_State.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CR_State.java
@@ -9,10 +9,15 @@
  */
 package tripleo.elijah.comp.internal;
 
+import java.lang.reflect.*;
+import java.util.*;
+import java.util.function.*;
+
 import org.apache.commons.lang3.tuple.*;
 import org.jdeferred2.*;
 import org.jdeferred2.impl.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.comp.*;
 import tripleo.elijah.comp.graph.i.*;
@@ -33,10 +38,6 @@ import tripleo.elijah.util.*;
 import tripleo.elijah_elevated.comp.backbone.*;
 import tripleo.elijah_elevated_durable.aware.*;
 import tripleo.elijah_prolific.v.*;
-
-import java.lang.reflect.*;
-import java.util.*;
-import java.util.function.*;
 
 public class CR_State implements GCR_State {
 
@@ -79,7 +80,7 @@ public class CR_State implements GCR_State {
 		// private final DeducePipeline dpl;
 		private final @NotNull ICompilationAccess ca;
 		private                IPipelineAccess    pa;
-		private @NotNull       PipelineLogic      pipelineLogic;
+		private @NotNull PipelineLogic pipelineLogic;
 
 		public ProcessRecordImpl(final @NotNull ICompilationAccess ca0) {
 			ca = ca0;
@@ -117,16 +118,16 @@ public class CR_State implements GCR_State {
 	}
 
 	class ProcessRecord_PipelineAccess implements IPipelineAccess {
-		private final @NotNull List<EvaNode>                                         _l_classes         = new ArrayList<>();
-		private final @NotNull List<EvaClass>                                        activeClasses      = new ArrayList<>();
-		private final @NotNull List<EvaNamespace>                                    activeNamespaces   = new ArrayList<>();
+		private final @NotNull List<EvaNode> _l_classes = new ArrayList<>();
+		private final @NotNull List<EvaClass> activeClasses = new ArrayList<>();
+		private final @NotNull List<EvaNamespace> activeNamespaces = new ArrayList<>();
 		private final          DeferredObject<EvaPipeline, Void, Void>               EvaPipelinePromise = new DeferredObject<>();
 		private final          Map<OS_Module, DeferredObject<GenerateC, Void, Void>> gc2m_map           = new HashMap<>();
 		@SuppressWarnings("rawtypes")
-		private final @NotNull Map<Provenance, Pair<Class, Class>>                   installs           = new HashMap<>();
+		private final @NotNull Map<Provenance, Pair<Class, Class>> installs = new HashMap<>();
 		private final Eventual<List<EvaNode>> _p_EvaNodeList = new Eventual<>();
 		private final          List<NG_OutputItem>                                   outputs            = new ArrayList<NG_OutputItem>();
-		private final @NotNull DeferredObject<PipelineLogic, Void, Void>             ppl                = new DeferredObject<>();
+		private final @NotNull DeferredObject<PipelineLogic, Void, Void> ppl = new DeferredObject<>();
 		@NotNull
 		List<BaseEvaFunction> activeFunctions = new ArrayList<BaseEvaFunction>();
 		private AccessBus           _ab;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CW_inputIsDirectory.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CW_inputIsDirectory.java
@@ -1,15 +1,15 @@
 package tripleo.elijah.comp.internal;
 
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.comp.CompilerInput;
-import tripleo.elijah.comp.i.CompilationClosure;
-import tripleo.elijah.comp.queries.CompilerInstructions_Result;
-import tripleo.elijah.comp.queries.QuerySearchEzFiles;
-import tripleo.wrap.File;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.comp.*;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.comp.queries.*;
+import tripleo.wrap.*;
 
 public class CW_inputIsDirectory {
 	public static void apply(final @NotNull CompilerInput input,
-							 final @NotNull CompilationClosure cc,
+			final @NotNull CompilationClosure cc,
 							 final File ff) {
 		final File                        directory = input.getFileForDirectory();
 		final QuerySearchEzFiles          q         = new QuerySearchEzFiles(cc);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CW_inputIsEzFile.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CW_inputIsEzFile.java
@@ -1,14 +1,14 @@
 package tripleo.elijah.comp.internal;
 
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.comp.CompilerInput;
-import tripleo.elijah.comp.i.CompilationClosure;
-import tripleo.elijah.comp.i.ILazyCompilerInstructions;
-import tripleo.elijah.util.Maybe;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.comp.*;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.util.*;
 
 public class CW_inputIsEzFile {
 	public static void apply(final @NotNull CompilerInput input,
-							 final @NotNull CompilationClosure cc) {
+			final @NotNull CompilationClosure cc) {
 		final ILazyCompilerInstructions        ilci = ILazyCompilerInstructions_.of(input, cc);
 		final Maybe<ILazyCompilerInstructions> m4   = Maybe.of(ilci);
 		input.accept_ci(m4);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CX_realParseElijjahFile2.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CX_realParseElijjahFile2.java
@@ -1,22 +1,17 @@
 package tripleo.elijah.comp.internal;
 
-import org.jetbrains.annotations.NotNull;
+import java.io.*;
+import java.util.*;
 
-import tripleo.elijah.DebugFlags;
-import tripleo.elijah.comp.Compilation;
+import org.jetbrains.annotations.*;
 
-import tripleo.elijah.lang.i.OS_Module;
-import tripleo.elijah.world.i.WorldModule;
-
-import tripleo.elijah.comp.nextgen.CX_ParseElijahFile;
-import tripleo.elijah.comp.specs.ElijahCache;
-import tripleo.elijah.comp.specs.ElijahSpec;
-
-import tripleo.elijah.util.Operation2;
-
-import java.io.IOException;
-import java.util.Optional;
-
+import tripleo.elijah.*;
+import tripleo.elijah.comp.*;
+import tripleo.elijah.comp.nextgen.*;
+import tripleo.elijah.comp.specs.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.util.*;
+import tripleo.elijah.world.i.*;
 import tripleo.wrap.File;
 
 public enum CX_realParseElijjahFile2 {
@@ -29,7 +24,8 @@ public enum CX_realParseElijjahFile2 {
 	 * 4. Create WorldModule and World#addModule2 <br/>
 	 * 5. Return success <br/>
 	 */
-	public static Operation2<OS_Module> realParseElijjahFile2(final ElijahSpec spec, final @NotNull ElijahCache aElijahCache, final @NotNull Compilation aC) {
+	public static Operation2<OS_Module> realParseElijjahFile2(final ElijahSpec spec,
+			final @NotNull ElijahCache aElijahCache, final @NotNull Compilation aC) {
 		final File file = spec.file();
 
 		final String absolutePath;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CompilationImpl.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CompilationImpl.java
@@ -8,10 +8,15 @@
  */
 package tripleo.elijah.comp.internal;
 
-import com.google.common.base.*;
-import io.reactivex.rxjava3.core.Observer;
+import java.util.*;
+import java.util.function.Supplier;
+
 import org.apache.commons.lang3.tuple.*;
 import org.jetbrains.annotations.*;
+
+import com.google.common.base.*;
+
+import io.reactivex.rxjava3.core.Observer;
 import tripleo.elijah.*;
 import tripleo.elijah.ci.*;
 import tripleo.elijah.comp.*;
@@ -42,9 +47,6 @@ import tripleo.elijah.world.i.*;
 import tripleo.elijah_elevated.comp.backbone.*;
 import tripleo.elijah_elevated_durable.aware.*;
 import tripleo.elijah_elevated_durable.comp.*;
-
-import java.util.*;
-import java.util.function.Supplier;
 
 public class CompilationImpl implements Compilation, EventualRegister {
 	private final List<CN_CompilerInputWatcher>                                  _ciws;
@@ -86,7 +88,7 @@ public class CompilationImpl implements Compilation, EventualRegister {
 	private          boolean                             _inside;
 	private          CompilerInput       __advisement;
 	private final    ICompilationAccess3 _compilationAccess3;
-	private @NotNull CK_Monitor          defaultMonitor;
+	private @NotNull CK_Monitor defaultMonitor;
 	private          CPX_Signals                         cpxSignals;
 	private          Eventual<CP_Paths>                  _p_pathsEventual = new Eventual<>();
 
@@ -188,7 +190,7 @@ public class CompilationImpl implements Compilation, EventualRegister {
 
 	@Override
 	public void feedInputs(final @NotNull List<CompilerInput> aCompilerInputs,
-						   final @NotNull CompilerController ctl) {
+			final @NotNull CompilerController ctl) {
 		if (aCompilerInputs.isEmpty()) {
 			ctl.printUsage();
 			return;
@@ -289,7 +291,8 @@ public class CompilationImpl implements Compilation, EventualRegister {
 	}
 
 	@Override
-	public Operation<Ok> hasInstructions(final @NotNull List<CompilerInstructions> cis, final @NotNull IPipelineAccess pa) {
+	public Operation<Ok> hasInstructions(final @NotNull List<CompilerInstructions> cis,
+			final @NotNull IPipelineAccess pa) {
 		if (DebugFlags._pancake_lcm_gate) {
 			assert cis.size() > 0;
 
@@ -511,7 +514,8 @@ public class CompilationImpl implements Compilation, EventualRegister {
 	}
 
 	@Override
-	public Operation<Ok> hasInstructions2(@NotNull final List<CompilerInstructions> cis, @NotNull final IPipelineAccess pa) {
+	public Operation<Ok> hasInstructions2(@NotNull final List<CompilerInstructions> cis,
+			@NotNull final IPipelineAccess pa) {
 		return hasInstructions(cis, get_pa());
 	}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CompilationRunner.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/CompilationRunner.java
@@ -1,7 +1,10 @@
 package tripleo.elijah.comp.internal;
 
-import lombok.*;
+import java.util.function.*;
+
 import org.jetbrains.annotations.*;
+
+import lombok.*;
 import tripleo.elijah.ci.*;
 import tripleo.elijah.comp.*;
 import tripleo.elijah.comp.caches.*;
@@ -11,20 +14,17 @@ import tripleo.elijah.comp.impl.*;
 import tripleo.elijah.comp.specs.*;
 import tripleo.elijah.g.*;
 import tripleo.elijah.stateful.*;
-import tripleo.elijah.util.*;
-import tripleo.elijah_elevated.comp.backbone.CompilationEnclosure;
-
-import java.util.function.*;
+import tripleo.elijah_elevated.comp.backbone.*;
 
 public class CompilationRunner extends _RegistrationTarget implements ICompilationRunner {
-	public final @NotNull  EzCache                         ezCache;
-	private final @NotNull Compilation                     _compilation;
-	private final @NotNull ICompilationBus                 cb;
+	public final @NotNull EzCache ezCache;
+	private final @NotNull Compilation _compilation;
+	private final @NotNull ICompilationBus cb;
 	@Getter
-	private final @NotNull CR_State                        crState;
+	private final @NotNull CR_State crState;
 	@Getter
-	private final @NotNull IProgressSink                   progressSink;
-	private /*@NotNull*/   CB_StartCompilationRunnerAction startAction;
+	private final @NotNull IProgressSink progressSink;
+	private /* @NotNull */ CB_StartCompilationRunnerAction startAction;
 
 	public CompilationRunner(final @NotNull ICompilationAccess aca, final CR_State aCrState) {
 		this(
@@ -35,7 +35,7 @@ public class CompilationRunner extends _RegistrationTarget implements ICompilati
 	}
 
 	public CompilationRunner(final @NotNull ICompilationAccess aca,
-							 final @NotNull CR_State aCrState,
+			final @NotNull CR_State aCrState,
 							 final Supplier<ICompilationBus> scb) {
 		_compilation = (Compilation) aca.getCompilation();
 
@@ -43,7 +43,7 @@ public class CompilationRunner extends _RegistrationTarget implements ICompilati
 
 		compilationEnclosure.setCompilationAccess(aca);
 
-		//final @NotNull CIS    cis = _compilation._cis();
+		// final @NotNull CIS cis = _compilation._cis();
 		final ICompilationBus compilationBus = compilationEnclosure.getCompilationBus();
 
 		if (compilationBus == null) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/DefaultCompilationBus.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/DefaultCompilationBus.java
@@ -1,33 +1,32 @@
 package tripleo.elijah.comp.internal;
 
-import lombok.Getter;
-import org.awaitility.core.ConditionTimeoutException;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.comp.Compilation;
-import tripleo.elijah.comp.i.*;
-import tripleo.elijah.util.SimplePrintLoggerToRemoveSoon;
-import tripleo.elijah_elevated.comp.backbone.CompilationEnclosure;
-import tripleo.elijah_elevated.comp.compilation_bus.DCB_Startable;
-import tripleo.elijah_elevated.comp.compilation_bus.SingleActionProcess;
+import static org.awaitility.Awaitility.*;
 
-import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.*;
 import java.util.*;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
-import static org.awaitility.Awaitility.await;
+import org.awaitility.core.*;
+import org.jetbrains.annotations.*;
+
+import lombok.*;
+import tripleo.elijah.comp.*;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.util.*;
+import tripleo.elijah_elevated.comp.backbone.*;
+import tripleo.elijah_elevated.comp.compilation_bus.*;
 
 public class DefaultCompilationBus implements ICompilationBus {
 	private final          CB_Monitor        _monitor;
 	@Getter
-	private final @NotNull CompilerDriver    _compilerDriver;
-	private final @NotNull IProgressSink     _defaultProgressSink;
-	private final @NotNull Compilation       c;
+	private final @NotNull CompilerDriver _compilerDriver;
+	private final @NotNull IProgressSink _defaultProgressSink;
+	private final @NotNull Compilation c;
 	private final @NotNull Queue<CB_Process> pq;
-	private final @NotNull List<CB_Process>  alreadyP;
+	private final @NotNull List<CB_Process> alreadyP;
 
 	public DefaultCompilationBus(final @NotNull CompilationEnclosure ace) {
-		c                    = (@NotNull Compilation) ace.getCompilationAccess().getCompilation();
+		c = (@NotNull Compilation) ace.getCompilationAccess().getCompilation();
 		pq                   = new ConcurrentLinkedQueue<>();
 		alreadyP             = new ArrayList<>();
 		_monitor             = new CompilationRunner.__CompRunner_Monitor();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/DefaultProgressSink.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/DefaultProgressSink.java
@@ -1,12 +1,13 @@
 package tripleo.elijah.comp.internal;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.comp.i.*;
 
 public class DefaultProgressSink implements IProgressSink {
 	@Override
 	public void note(final Codes code,
-	                 final @NotNull ProgressSinkComponent component,
+			final @NotNull ProgressSinkComponent component,
 	                 final int type,
 	                 final Object[] params) {
 		// component.note(code, type, params);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/ILazyCompilerInstructions_.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/ILazyCompilerInstructions_.java
@@ -1,22 +1,21 @@
 package tripleo.elijah.comp.internal;
 
-import org.jetbrains.annotations.*;
-import tripleo.elijah.Eventual;
-import tripleo.elijah.ci.CompilerInstructions;
-import tripleo.elijah.comp.CompilerInput;
-import tripleo.elijah.comp.graph.i.CK_SourceFile;
-import tripleo.elijah.comp.i.CompilationClosure;
-import tripleo.elijah.comp.i.ILazyCompilerInstructions;
-import tripleo.elijah.comp.nextgen.impl.CK_SourceFileFactory;
-import tripleo.elijah.util.Mode;
-import tripleo.elijah.util.Operation2;
-
 import java.io.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.*;
+import tripleo.elijah.ci.*;
+import tripleo.elijah.comp.*;
+import tripleo.elijah.comp.graph.i.*;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.comp.nextgen.impl.*;
+import tripleo.elijah.util.*;
 
 public abstract class ILazyCompilerInstructions_ {
 	@Contract(value = "_, _, _ -> new", pure = true)
 	public static void ofEventual(final @NotNull CompilerInput input,
-								  final @NotNull CompilationClosure cc,
+			final @NotNull CompilationClosure cc,
 								  final Eventual<CompilerInstructions> eilci) {
 		final String file_name = input.getInp();
 		final File   f         = new File(file_name);
@@ -39,7 +38,7 @@ public abstract class ILazyCompilerInstructions_ {
 	}
 	@Contract(value = "_, _ -> new", pure = true)
 	public static @NotNull ILazyCompilerInstructions of(final @NotNull CompilerInput input,
-														final @NotNull CompilationClosure cc) {
+			final @NotNull CompilationClosure cc) {
 		final String file_name = input.getInp();
 		final File   f         = new File(file_name);
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/PipelinePlugin.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/PipelinePlugin.java
@@ -1,11 +1,13 @@
 package tripleo.elijah.comp.internal;
 
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.comp.PipelineMember;
-import tripleo.elijah.g.GPipelineAccess;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.comp.*;
+import tripleo.elijah.g.*;
 
 public interface PipelinePlugin {
-	@NotNull PipelineMember instance(@NotNull GPipelineAccess aCe);
+	@NotNull
+	PipelineMember instance(@NotNull GPipelineAccess aCe);
 
 	String name();
 }

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/USE.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/internal/USE.java
@@ -1,28 +1,22 @@
 package tripleo.elijah.comp.internal;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.ci.CompilerInstructions;
-import tripleo.elijah.ci.LibraryStatementPart;
-import tripleo.elijah.ci_impl.LibraryStatementPartImpl;
-import tripleo.elijah.comp.Compilation;
-import tripleo.elijah.comp.caches.DefaultElijahCache;
-import tripleo.elijah.compiler_model.CM_Module;
-import tripleo.elijah.comp.i.CompProgress;
-import tripleo.elijah.comp.i.CompilationClosure;
-import tripleo.elijah.comp.i.ErrSink;
-import tripleo.elijah.comp.i.USE_Reasoning;
-import tripleo.elijah.comp.nextgen.CX_ParseElijahFile;
-import tripleo.elijah.comp.specs.*;
-import tripleo.elijah.diagnostic.Diagnostic;
-import tripleo.elijah.diagnostic.ExceptionDiagnostic;
-import tripleo.elijah.diagnostic.FileNotFoundDiagnostic;
-import tripleo.elijah.lang.i.OS_Module;
-import tripleo.elijah.util.*;
-
 import java.io.*;
-import tripleo.wrap.File;
 import java.util.regex.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.ci.*;
+import tripleo.elijah.ci_impl.*;
+import tripleo.elijah.comp.*;
+import tripleo.elijah.comp.caches.*;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.comp.nextgen.*;
+import tripleo.elijah.comp.specs.*;
+import tripleo.elijah.compiler_model.*;
+import tripleo.elijah.diagnostic.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.util.*;
+import tripleo.wrap.File;
 
 @SuppressWarnings("UnnecessaryLocalVariable")
 public class USE {
@@ -31,8 +25,8 @@ public class USE {
 				|| Pattern.matches(".+\\.elijjah$", file_name);
 		return matches;
 	};
-	private final @NotNull Compilation   c;
-	private final @NotNull ErrSink        errSink;
+	private final @NotNull Compilation c;
+	private final @NotNull ErrSink errSink;
 
 	public ElijahCache getElijahCache() {
 		return elijahCache;
@@ -42,7 +36,7 @@ public class USE {
 
 	@Contract(pure = true)
 	public USE(final @NotNull CompilationClosure cc) {
-		c       = (@NotNull Compilation) cc.getCompilation();
+		c = (@NotNull Compilation) cc.getCompilation();
 		errSink = cc.errSink();
 	}
 
@@ -55,8 +49,8 @@ public class USE {
 	}
 
 	private Operation2<OS_Module> parseElijjahFile(final @NotNull File f,
-	                                               final @NotNull String file_name,
-	                                               final @NotNull LibraryStatementPart lsp) {
+			final @NotNull String file_name,
+			final @NotNull LibraryStatementPart lsp) {
 		logProgress(CompProgress.USE__parseElijjahFile, f.getAbsolutePath());
 
 		if (!f.exists()) {
@@ -70,7 +64,7 @@ public class USE {
 		try {
 			var rdr = new CX_ParseElijahFile.ElijahSpecReader() {
 				@Override
-				public @NotNull Operation<InputStream> get()  {
+				public @NotNull Operation<InputStream> get() {
 					try {
 						final InputStream readFile = c.getIO().readFile(f);
 						return Operation.success(readFile);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/nextgen/CX_ParseElijahFile.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/nextgen/CX_ParseElijahFile.java
@@ -1,7 +1,12 @@
 package tripleo.elijah.comp.nextgen;
 
-import antlr.*;
+import static tripleo.elijah.util.SimplePrintLoggerToRemoveSoon.*;
+
+import java.io.*;
+
 import org.jetbrains.annotations.*;
+
+import antlr.*;
 import tripleo.elijah.comp.*;
 import tripleo.elijah.comp.graph.i.*;
 import tripleo.elijah.comp.i.*;
@@ -11,11 +16,7 @@ import tripleo.elijah.diagnostic.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.util.*;
 import tripleo.elijjah.*;
-
-import java.io.*;
 import tripleo.wrap.File;
-
-import static tripleo.elijah.util.SimplePrintLoggerToRemoveSoon.*;
 
 public class CX_ParseElijahFile {
 
@@ -97,13 +98,14 @@ public class CX_ParseElijahFile {
 
 	public static Operation2<OS_Module> __parseEzFile(String file_name,
 													  File file,
-													  @NotNull ElijahSpecReader r,
-													  @NotNull CY_ElijahSpecParser parser) {
+			@NotNull ElijahSpecReader r,
+			@NotNull CY_ElijahSpecParser parser) {
 		final ElijahSpec             spec = new ElijahSpec_(file_name, file, r.get().success());
 		return parser.parse(spec);
 	}
 
 	public interface ElijahSpecReader {
-		@NotNull Operation<InputStream> get();
+		@NotNull
+		Operation<InputStream> get();
 	}
 }

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/nextgen/CX_ParseEzFile.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/nextgen/CX_ParseEzFile.java
@@ -1,27 +1,20 @@
 package tripleo.elijah.comp.nextgen;
 
-import antlr.RecognitionException;
-import antlr.TokenStreamException;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.ci.CompilerInstructions;
-import tripleo.elijah.comp.Compilation;
-import tripleo.elijah.comp.PCon;
-import tripleo.elijah.comp.graph.CM_Ez;
-import tripleo.elijah.comp.i.CY_EzSpecParser;
-import tripleo.elijah.comp.specs.EzCache;
-import tripleo.elijah.comp.specs.EzSpec;
-import tripleo.elijah.comp.specs.EzSpec__;
-import tripleo.elijah.compiler_model.CM_Factory;
-import tripleo.elijah.diagnostic.ExceptionDiagnostic;
-import tripleo.elijah.util.Mode;
-import tripleo.elijah.util.Operation;
-import tripleo.elijah.util.Operation2;
-import tripleo.elijjah.EzLexer;
-import tripleo.elijjah.EzParser;
-import tripleo.wrap.File;
+import java.io.*;
 
-import java.io.IOException;
-import java.io.InputStream;
+import org.jetbrains.annotations.*;
+
+import antlr.*;
+import tripleo.elijah.ci.*;
+import tripleo.elijah.comp.*;
+import tripleo.elijah.comp.graph.*;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.comp.specs.*;
+import tripleo.elijah.compiler_model.*;
+import tripleo.elijah.diagnostic.*;
+import tripleo.elijah.util.*;
+import tripleo.elijjah.*;
+import tripleo.wrap.File;
 
 public enum CX_ParseEzFile {;
 	private static Operation2<CompilerInstructions> calculate(final String aAbsolutePath, final InputStream aInputStream) {
@@ -85,6 +78,7 @@ public enum CX_ParseEzFile {;
 	}
 
 	public interface EzSpecReader {
-		@NotNull Operation<InputStream> get();
+		@NotNull
+		Operation<InputStream> get();
 	}
 }

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/nextgen/CX_realParseEzFile2.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/nextgen/CX_realParseEzFile2.java
@@ -3,9 +3,10 @@ package tripleo.elijah.comp.nextgen;
 public class CX_realParseEzFile2 {
 
 	//@NotNull
-	//public static Operation<CompilerInstructions> realParseEzFile(final @NotNull Compilation c,
-	//                                                              final @NotNull EzSpec ezSpec,
-	//                                                              final @NotNull EzCache ezCache) {
+	// public static Operation<CompilerInstructions> realParseEzFile(final @NotNull
+	// Compilation c,
+	// final @NotNull EzSpec ezSpec,
+	// final @NotNull EzCache ezCache) {
 	//
 	//	final CM_Ez cm = c.megaGrande(ezSpec);
 	//

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/nextgen/impl/CK_SourceFile__SpecifiedEzFile.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/nextgen/impl/CK_SourceFile__SpecifiedEzFile.java
@@ -1,13 +1,15 @@
 package tripleo.elijah.comp.nextgen.impl;
 
-import com.google.common.base.*;
+import java.io.*;
+
 import org.jetbrains.annotations.*;
+
+import com.google.common.base.*;
+
 import tripleo.elijah.ci.*;
 import tripleo.elijah.comp.*;
 import tripleo.elijah.comp.specs.*;
 import tripleo.elijah.util.*;
-
-import java.io.*;
 import tripleo.wrap.File;
 
 public class CK_SourceFile__SpecifiedEzFile extends __CK_SourceFile__AbstractEzFile {
@@ -20,7 +22,7 @@ public class CK_SourceFile__SpecifiedEzFile extends __CK_SourceFile__AbstractEzF
 	@Override
 	public Operation2<CompilerInstructions> process_query() {
 		final IO               io       = compilation.getIO();
-		final @NotNull EzCache ezCache  = compilation.getCompilationEnclosure().getCompilationRunner().ezCache();
+		final @NotNull EzCache ezCache = compilation.getCompilationEnclosure().getCompilationRunner().ezCache();
 		final String fileName = file_name();
 		Preconditions.checkArgument(isEzFile(fileName));
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/notation/GM_GenerateModuleRequest.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/notation/GM_GenerateModuleRequest.java
@@ -1,22 +1,20 @@
 package tripleo.elijah.comp.notation;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.stages.gen_generic.GenerateFiles;
-import tripleo.elijah.stages.gen_generic.GenerateResultEnv;
-import tripleo.elijah.stages.gen_generic.OutputFileFactoryParams;
-import tripleo.elijah.world.i.WorldModule;
+import java.util.*;
+import java.util.function.*;
 
-import java.util.Objects;
-import java.util.function.Supplier;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.stages.gen_generic.*;
+import tripleo.elijah.world.i.*;
 
 public final class GM_GenerateModuleRequest implements GN_Env {
-	private final @NotNull GN_GenerateNodesIntoSink    generateNodesIntoSink;
-	private final @NotNull WorldModule                 mod;
+	private final @NotNull GN_GenerateNodesIntoSink generateNodesIntoSink;
+	private final @NotNull WorldModule mod;
 	private final @NotNull GN_GenerateNodesIntoSinkEnv env;
 
 	public GM_GenerateModuleRequest(@NotNull GN_GenerateNodesIntoSink generateNodesIntoSink,
-									@NotNull WorldModule mod, @NotNull GN_GenerateNodesIntoSinkEnv env) {
+			@NotNull WorldModule mod, @NotNull GN_GenerateNodesIntoSinkEnv env) {
 		this.generateNodesIntoSink = generateNodesIntoSink;
 		this.mod                   = mod;
 		this.env                   = env;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/notation/GN_GenerateNodesIntoSinkEnv.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/notation/GN_GenerateNodesIntoSinkEnv.java
@@ -1,7 +1,11 @@
 package tripleo.elijah.comp.notation;
 
+import java.util.*;
+import java.util.function.*;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.ci.*;
 import tripleo.elijah.comp.i.extra.*;
 import tripleo.elijah.comp.internal.*;
@@ -10,10 +14,7 @@ import tripleo.elijah.stages.gen_generic.*;
 import tripleo.elijah.stages.gen_generic.pipeline_impl.*;
 import tripleo.elijah.stages.logging.*;
 import tripleo.elijah.world.i.*;
-import tripleo.elijah_elevated.comp.backbone.CompilationEnclosure;
-
-import java.util.*;
-import java.util.function.*;
+import tripleo.elijah_elevated.comp.backbone.*;
 
 public final class GN_GenerateNodesIntoSinkEnv implements GN_Env {
 	private final List<ProcessedNode>  lgc;
@@ -60,7 +61,7 @@ public final class GN_GenerateNodesIntoSinkEnv implements GN_Env {
 
 	@NotNull
 	static GenerateFiles getGenerateFiles(final @NotNull OutputFileFactoryParams params, final @NotNull WorldModule wm,
-										  final @NotNull Supplier<GenerateResultEnv> fgs) {
+			final @NotNull Supplier<GenerateResultEnv> fgs) {
 		final GenerateResultEnv fileGen;
 		final OS_Module         mod = wm.module();
 
@@ -87,7 +88,7 @@ public final class GN_GenerateNodesIntoSinkEnv implements GN_Env {
 	@Contract("_, _ -> new")
 	@NotNull
 	OutputFileFactoryParams getParams(final WorldModule mod,
-									  final @NotNull GN_GenerateNodesIntoSink aGNGenerateNodesIntoSink) {
+			final @NotNull GN_GenerateNodesIntoSink aGNGenerateNodesIntoSink) {
 		return new OutputFileFactoryParams(mod, aGNGenerateNodesIntoSink._env().ce());
 	}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/notation/GN_PL_Run2.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/notation/GN_PL_Run2.java
@@ -1,23 +1,21 @@
 package tripleo.elijah.comp.notation;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.Eventual;
-import tripleo.elijah.EventualRegister;
-import tripleo.elijah.comp.PipelineLogic;
-import tripleo.elijah_elevated.comp.backbone.CompilationEnclosure;
-import tripleo.elijah.factory.NonOpinionatedBuilder;
-import tripleo.elijah.lang.i.OS_Module;
-import tripleo.elijah.stages.deduce.DeducePhase;
-import tripleo.elijah.stages.gen_fn.DefaultClassGenerator;
-import tripleo.elijah.stages.gen_fn.IClassGenerator;
-import tripleo.elijah.stages.gen_generic.ICodeRegistrar;
-import tripleo.elijah.stages.inter.ModuleThing;
-import tripleo.elijah.world.i.WorldModule;
-import tripleo.elijah.world.impl.DefaultWorldModule;
+import java.util.*;
+import java.util.function.*;
 
-import java.util.Objects;
-import java.util.function.Consumer;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.*;
+import tripleo.elijah.comp.*;
+import tripleo.elijah.factory.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.stages.deduce.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.gen_generic.*;
+import tripleo.elijah.stages.inter.*;
+import tripleo.elijah.world.i.*;
+import tripleo.elijah.world.impl.*;
+import tripleo.elijah_elevated.comp.backbone.*;
 
 public class GN_PL_Run2 implements GN_Notable, EventualRegister {
 	private final NonOpinionatedBuilder __nob;
@@ -39,7 +37,7 @@ public class GN_PL_Run2 implements GN_Notable, EventualRegister {
 	@Contract(pure = true)
 	public GN_PL_Run2(final PipelineLogic aPipelineLogic, final @NotNull WorldModule aMod,
 			final CompilationEnclosure aCe, final Consumer<WorldModule> aWorldConsumer,
-					  final @NotNull NonOpinionatedBuilder aNob) {
+			final @NotNull NonOpinionatedBuilder aNob) {
 		pipelineLogic = aPipelineLogic;
 		mod = aMod;
 		ce = aCe;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/notation/GN_PL_Run2_Env.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/notation/GN_PL_Run2_Env.java
@@ -1,21 +1,22 @@
 package tripleo.elijah.comp.notation;
 
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.comp.PipelineLogic;
-import tripleo.elijah_elevated.comp.backbone.CompilationEnclosure;
-import tripleo.elijah.world.i.WorldModule;
+import java.util.*;
+import java.util.function.*;
 
-import java.util.Objects;
-import java.util.function.Consumer;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.comp.*;
+import tripleo.elijah.world.i.*;
+import tripleo.elijah_elevated.comp.backbone.*;
 
 public final class GN_PL_Run2_Env implements GN_Env {
-	private final @NotNull PipelineLogic         pipelineLogic;
-	private final @NotNull WorldModule           mod;
-	private final @NotNull CompilationEnclosure  ce;
+	private final @NotNull PipelineLogic pipelineLogic;
+	private final @NotNull WorldModule mod;
+	private final @NotNull CompilationEnclosure ce;
 	private final @NotNull Consumer<WorldModule> worldConsumer;
 
 	public GN_PL_Run2_Env(@NotNull PipelineLogic pipelineLogic, @NotNull WorldModule mod,
-						  @NotNull CompilationEnclosure ce, @NotNull Consumer<WorldModule> worldConsumer) {
+			@NotNull CompilationEnclosure ce, @NotNull Consumer<WorldModule> worldConsumer) {
 		this.pipelineLogic = pipelineLogic;
 		this.mod           = mod;
 		this.ce            = ce;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/queries/QuerySearchEzFiles.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/comp/queries/QuerySearchEzFiles.java
@@ -1,20 +1,19 @@
 package tripleo.elijah.comp.queries;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import tripleo.elijah.ci.CompilerInstructions;
-import tripleo.elijah.comp.Compilation;
-import tripleo.elijah.comp.graph.i.CK_SourceFile;
-import tripleo.elijah.comp.i.CompilationClosure;
-import tripleo.elijah.comp.nextgen.impl.CK_SourceFileFactory;
-import tripleo.elijah.diagnostic.Diagnostic;
-import tripleo.elijah.diagnostic.Locatable;
-import tripleo.elijah.util.Operation2;
-import tripleo.wrap.File;
-
 import java.io.*;
-import java.util.List;
-import java.util.regex.Pattern;
+import java.util.*;
+import java.util.regex.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.ci.*;
+import tripleo.elijah.comp.*;
+import tripleo.elijah.comp.graph.i.*;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.comp.nextgen.impl.*;
+import tripleo.elijah.diagnostic.*;
+import tripleo.elijah.util.*;
+import tripleo.wrap.File;
 
 public class QuerySearchEzFiles {
 	private final          Compilation        c;
@@ -47,28 +46,29 @@ public class QuerySearchEzFiles {
 	}
 
 /*
-	public @NotNull List<Operation2<CompilerInstructions>> process2(final @NotNull File directory) {
-		final List<Operation2<CompilerInstructions>> R       = new ArrayList<>();
-		final ErrSink                                errSink = cc.errSink();
-
-		final String[] list = directory.list(ez_files_filter);
-		if (list != null) {
-			QSEZ_Reasoning reasoning = QSEZ_Reasonings.create(null);
-			List<Operation2<CompilerInstructions>> operation2s = CW_ezDirRequest.apply(
-					list,
-					directory,
-					null,
-					(File file1) -> parseEzFile(file1, file1.toString(), cc),
-					cc,
-					reasoning
-			);
-
-			R.addAll(operation2s);
-		}
-
-		return R;
-	}
-*/
+ * public @NotNull List<Operation2<CompilerInstructions>>
+ * process2(final @NotNull File directory) {
+ * final List<Operation2<CompilerInstructions>> R = new ArrayList<>();
+ * final ErrSink errSink = cc.errSink();
+ * 
+ * final String[] list = directory.list(ez_files_filter);
+ * if (list != null) {
+ * QSEZ_Reasoning reasoning = QSEZ_Reasonings.create(null);
+ * List<Operation2<CompilerInstructions>> operation2s = CW_ezDirRequest.apply(
+ * list,
+ * directory,
+ * null,
+ * (File file1) -> parseEzFile(file1, file1.toString(), cc),
+ * cc,
+ * reasoning
+ * );
+ * 
+ * R.addAll(operation2s);
+ * }
+ * 
+ * return R;
+ * }
+ */
 
 	public static class Diagnostic_9995 implements Diagnostic {
 		private final File file;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/CaseContext.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/CaseContext.java
@@ -10,7 +10,7 @@ package tripleo.elijah.contexts;
 
 import org.jetbrains.annotations.*;
 
-import tripleo.elijah.DebugFlags;
+import tripleo.elijah.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.util.*;
@@ -36,7 +36,7 @@ public class CaseContext extends ContextImpl implements ICaseContext {
 	public LookupResultList lookup(final String name,
 								   final int level,
 								   final LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched,
+			final @NotNull ISearchList alreadySearched,
 								   final boolean one) {
 		alreadySearched.add(carrier.getContext());
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/ClassContext.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/ClassContext.java
@@ -8,13 +8,14 @@
  */
 package tripleo.elijah.contexts;
 
-import org.jetbrains.annotations.*;
-import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.*;
+import static tripleo.elijah.contexts.ClassInfo.ClassInfoType.*;
 
 import java.util.*;
 
-import static tripleo.elijah.contexts.ClassInfo.ClassInfoType.*;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.lang.impl.*;
 
 /**
  * @author Tripleo
@@ -69,8 +70,8 @@ public class ClassContext extends ContextImpl implements IClassContext {
 	@Override
 	public LookupResultList lookup(final @NotNull String name,
 								   final int level,
-								   final @NotNull LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched,
+			final @NotNull LookupResultList Result,
+			final @NotNull ISearchList alreadySearched,
 								   final boolean one) {
 		alreadySearched.add(carrier.getContext());
 		for (final ClassItem item : carrier.getItems()) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/DefFunctionContext.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/DefFunctionContext.java
@@ -8,10 +8,10 @@
  */
 package tripleo.elijah.contexts;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.ContextImpl;
+import tripleo.elijah.lang.impl.*;
 
 /**
  * @author Tripleo
@@ -41,7 +41,7 @@ public class DefFunctionContext extends ContextImpl {
 	 */
 	@Override
 	public LookupResultList lookup(final String name, final int level, final LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched, final boolean one) {
+			final @NotNull ISearchList alreadySearched, final boolean one) {
 //		final LookupResultList Result = new LookupResultListImpl();
 		alreadySearched.add(carrier.getContext());
 		return getParent().lookup(name, level, Result, alreadySearched, one);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/FuncExprContextImpl.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/FuncExprContextImpl.java
@@ -8,11 +8,10 @@
  */
 package tripleo.elijah.contexts;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.ContextImpl;
-import tripleo.elijah.lang.impl.VariableSequenceImpl;
+import tripleo.elijah.lang.impl.*;
 
 /**
  * Created 8/21/20 11:53 PM
@@ -33,7 +32,7 @@ public class FuncExprContextImpl extends ContextImpl implements IFuncExprContext
 
 	@Override
 	public LookupResultList lookup(final String name, final int level, final @NotNull LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched, final boolean one) {
+			final @NotNull ISearchList alreadySearched, final boolean one) {
 		alreadySearched.add(carrier.getContext());
 		for (final FunctionItem item : carrier.getItems()) {
 			if (!(item instanceof ClassStatement) && !(item instanceof NamespaceStatement)

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/FunctionContextImpl.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/FunctionContextImpl.java
@@ -8,12 +8,10 @@
  */
 package tripleo.elijah.contexts;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.BaseFunctionDef;
-import tripleo.elijah.lang.impl.ContextImpl;
-import tripleo.elijah.lang.impl.VariableSequenceImpl;
+import tripleo.elijah.lang.impl.*;
 
 /**
  * @author Tripleo
@@ -43,7 +41,7 @@ public class FunctionContextImpl extends ContextImpl implements IFunctionContext
 
 	@Override
 	public LookupResultList lookup(final String name, final int level, final @NotNull LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched, final boolean one) {
+			final @NotNull ISearchList alreadySearched, final boolean one) {
 		alreadySearched.add(carrier.getContext());
 		for (final FunctionItem item : carrier.getItems()) {
 			if (!(item instanceof ClassStatement) && !(item instanceof NamespaceStatement)

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/IfConditionalContext__.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/IfConditionalContext__.java
@@ -9,6 +9,7 @@
 package tripleo.elijah.contexts;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
 
@@ -26,7 +27,8 @@ public class IfConditionalContext__ extends ContextImpl implements IfConditional
 		_prev_ctx = null; // TOP if statement
 	}
 
-	public IfConditionalContext__(final @NotNull Context ctx, final IfConditional ifConditional, final boolean _ignored) {
+	public IfConditionalContext__(final @NotNull Context ctx, final IfConditional ifConditional,
+			final boolean _ignored) {
 		_prev_ctx = ctx;
 		_parent = ((IfConditionalContext__) ctx)._parent;
 		carrier = ifConditional;
@@ -39,7 +41,7 @@ public class IfConditionalContext__ extends ContextImpl implements IfConditional
 
 	@Override
 	public LookupResultList lookup(final String name, final int level, final @NotNull LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched, final boolean one) {
+			final @NotNull ISearchList alreadySearched, final boolean one) {
 		alreadySearched.add(carrier.getContext());
 		for (final OS_Element/* StatementItem */ item : carrier.getItems()) {
 			if (!(item instanceof ClassStatement) && !(item instanceof NamespaceStatement)

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/ImportContext.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/ImportContext.java
@@ -8,14 +8,15 @@
  */
 package tripleo.elijah.contexts;
 
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.comp.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.lang.nextgen.names.i.*;
 import tripleo.elijah.lang.nextgen.names.impl.*;
-
-import java.util.*;
 
 /**
  * Created 8/15/20 7:09 PM
@@ -38,7 +39,7 @@ public class ImportContext extends ContextImpl implements Context, IImportContex
 		}
 
 		private void checkLast(final String name, final int level, final @NotNull LookupResultList Result,
-							   final @NotNull ISearchList alreadySearched, final @NotNull Compilation compilation) {
+				final @NotNull ISearchList alreadySearched, final @NotNull Compilation compilation) {
 			final IdentExpression last = x.get(x.size() - 1);
 			if (last.getText().equals(name)) {
 				Qualident cl = new QualidentImpl();
@@ -61,8 +62,8 @@ public class ImportContext extends ContextImpl implements Context, IImportContex
 		}
 
 		private void checkLastHelper(final String name, final int level, final @NotNull LookupResultList Result,
-									 final @NotNull ISearchList alreadySearched, final @NotNull Compilation compilation,
-									 final @NotNull Qualident cl) {
+				final @NotNull ISearchList alreadySearched, final @NotNull Compilation compilation,
+				final @NotNull Qualident cl) {
 			final OS_Package aPackage = compilation.getPackage(cl);
 			// LogEvent.logEvent(4003 , ""+aPackage.getElements());
 			for (final OS_Element element : aPackage.getElements()) {
@@ -130,7 +131,7 @@ public class ImportContext extends ContextImpl implements Context, IImportContex
 
 	@Override
 	public LookupResultList lookup(final String name, final int level, final @NotNull LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched, final boolean one) {
+			final @NotNull ISearchList alreadySearched, final boolean one) {
 		alreadySearched.add(this);
 //		tripleo.elijah.util.Stupidity.println_err_2("2002 "+importStatement.importList());
 		Compilation compilation = compilation();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/LoopContextImpl.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/LoopContextImpl.java
@@ -12,6 +12,7 @@
 package tripleo.elijah.contexts;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.util.*;
@@ -37,7 +38,7 @@ public class LoopContextImpl extends ContextImpl implements ILoopContext {
 
 	@Override
 	public LookupResultList lookup(final @NotNull String name, final int level, final @NotNull LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched, final boolean one) {
+			final @NotNull ISearchList alreadySearched, final boolean one) {
 		alreadySearched.add(carrier.getContext());
 
 		if (carrier.getIterNameToken() != null) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/MatchConditionalContext.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/MatchConditionalContext.java
@@ -8,10 +8,10 @@
  */
 package tripleo.elijah.contexts;
 
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.ContextImpl;
-import tripleo.elijah.lang.impl.VariableSequenceImpl;
+import tripleo.elijah.lang.impl.*;
 
 /**
  * Created 10/6/20 4:22 PM
@@ -32,7 +32,7 @@ public class MatchConditionalContext extends ContextImpl {
 
 	@Override
 	public LookupResultList lookup(final @NotNull String name, final int level, final @NotNull LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched, final boolean one) {
+			final @NotNull ISearchList alreadySearched, final boolean one) {
 		alreadySearched.add(carrier.getContext());
 
 		if (carrier instanceof final @NotNull MatchArm_TypeMatch carrier2) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/MatchContext__.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/MatchContext__.java
@@ -8,9 +8,10 @@
  */
 package tripleo.elijah.contexts;
 
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.ContextImpl;
+import tripleo.elijah.lang.impl.*;
 
 /**
  * Created 9/24/20 6:11 PM
@@ -31,7 +32,7 @@ public class MatchContext__ extends ContextImpl implements MatchContext {
 
 	@Override
 	public LookupResultList lookup(final String name, final int level, final LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched, final boolean one) {
+			final @NotNull ISearchList alreadySearched, final boolean one) {
 		alreadySearched.add(carrier.getContext());
 
 		/*

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/ModuleContext__.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/ModuleContext__.java
@@ -8,11 +8,10 @@
  */
 package tripleo.elijah.contexts;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.AliasStatementImpl;
-import tripleo.elijah.lang.impl.ContextImpl;
+import tripleo.elijah.lang.impl.*;
 
 /**
  * @author Tripleo
@@ -39,7 +38,7 @@ public class ModuleContext__ extends ContextImpl implements ModuleContext {
 
 	@Override
 	public LookupResultList lookup(final String name, final int level, final @NotNull LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched, final boolean one) {
+			final @NotNull ISearchList alreadySearched, final boolean one) {
 		alreadySearched.add(carrier.getContext());
 		// TODO look all this up in a table, not by iteration
 		for (final ModuleItem item : carrier.getItems()) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/NamespaceContext__.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/NamespaceContext__.java
@@ -11,11 +11,10 @@
  */
 package tripleo.elijah.contexts;
 
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.AliasStatementImpl;
-import tripleo.elijah.lang.impl.ContextImpl;
-import tripleo.elijah.lang.impl.VariableSequenceImpl;
+import tripleo.elijah.lang.impl.*;
 
 /**
  * @author Tripleo
@@ -45,8 +44,8 @@ public class NamespaceContext__ extends ContextImpl implements NamespaceContext 
 	@Override
 	public LookupResultList lookup(final String name,
 								   final int level,
-								   final @NotNull LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched,
+			final @NotNull LookupResultList Result,
+			final @NotNull ISearchList alreadySearched,
 								   final boolean one) {
 		alreadySearched.add(carrier.getContext());
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/PackageContext.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/PackageContext.java
@@ -8,9 +8,10 @@
  */
 package tripleo.elijah.contexts;
 
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.ContextImpl;
+import tripleo.elijah.lang.impl.*;
 
 /**
  * Created 8/15/20 6:32 PM
@@ -31,7 +32,7 @@ public class PackageContext extends ContextImpl implements IPackageContext {
 
 	@Override
 	public LookupResultList lookup(final String name, final int level, final @NotNull LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched, final boolean one) {
+			final @NotNull ISearchList alreadySearched, final boolean one) {
 		alreadySearched.add(this);
 		for (OS_Element element : carrier.getElements()) {
 			if (element instanceof final @NotNull OS_NamedElement element2) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/PropertyStatementContext.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/PropertyStatementContext.java
@@ -8,9 +8,10 @@
  */
 package tripleo.elijah.contexts;
 
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.ContextImpl;
+import tripleo.elijah.lang.impl.*;
 
 /**
  * Created 12/26/20 2:24 AM
@@ -32,7 +33,7 @@ public class PropertyStatementContext extends ContextImpl {
 
 	@Override
 	public LookupResultList lookup(final @NotNull String name, final int level, final @NotNull LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched, final boolean one) {
+			final @NotNull ISearchList alreadySearched, final boolean one) {
 		alreadySearched.add(carrier.getContext());
 
 		if (name.equals("get")) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/SingleIdentContext.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/SingleIdentContext.java
@@ -1,8 +1,9 @@
 package tripleo.elijah.contexts;
 
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.ContextImpl;
+import tripleo.elijah.lang.impl.*;
 
 /**
  * Created 8/30/20 6:51 PM
@@ -24,7 +25,7 @@ public class SingleIdentContext extends ContextImpl {
 
 	@Override
 	public LookupResultList lookup(final String name, final int level, final @NotNull LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched, final boolean one) {
+			final @NotNull ISearchList alreadySearched, final boolean one) {
 		alreadySearched.add(element.getContext());
 
 		if (carrier != null && carrier.getText().equals(name))

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/SyntacticBlockContext.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/SyntacticBlockContext.java
@@ -8,10 +8,10 @@
  */
 package tripleo.elijah.contexts;
 
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.ContextImpl;
-import tripleo.elijah.lang.impl.VariableSequenceImpl;
+import tripleo.elijah.lang.impl.*;
 
 /**
  * Created 8/30/20 1:41 PM
@@ -33,7 +33,7 @@ public class SyntacticBlockContext extends ContextImpl implements ISyntacticBloc
 
 	@Override
 	public LookupResultList lookup(final String name, final int level, final @NotNull LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched, final boolean one) {
+			final @NotNull ISearchList alreadySearched, final boolean one) {
 		alreadySearched.add(carrier.getContext());
 
 		for (final FunctionItem item : carrier.getItems()) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/VarContext.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/VarContext.java
@@ -8,10 +8,10 @@
  */
 package tripleo.elijah.contexts;
 
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.ContextImpl;
-import tripleo.elijah.lang.impl.VariableSequenceImpl;
+import tripleo.elijah.lang.impl.*;
 
 /**
  * Created 8/30/20 1:39 PM
@@ -33,7 +33,7 @@ public class VarContext extends ContextImpl {
 
 	@Override
 	public LookupResultList lookup(final String name, final int level, final @NotNull LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched, final boolean one) {
+			final @NotNull ISearchList alreadySearched, final boolean one) {
 		alreadySearched.add(carrier.getContext());
 
 		for (final VariableStatement vs : carrier.items()) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/WithContext.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/contexts/WithContext.java
@@ -8,10 +8,10 @@
  */
 package tripleo.elijah.contexts;
 
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.ContextImpl;
-import tripleo.elijah.lang.impl.VariableSequenceImpl;
+import tripleo.elijah.lang.impl.*;
 
 /**
  * Created 8/30/20 1:42 PM
@@ -33,7 +33,7 @@ public class WithContext extends ContextImpl implements IWithContext {
 
 	@Override
 	public LookupResultList lookup(final String name, final int level, final @NotNull LookupResultList Result,
-								   final @NotNull ISearchList alreadySearched, final boolean one) {
+			final @NotNull ISearchList alreadySearched, final boolean one) {
 		alreadySearched.add(carrier.getContext());
 
 		for (final FunctionItem item : carrier.getItems()) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/entrypoints/EntryPointProcessor.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/entrypoints/EntryPointProcessor.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.entrypoints;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.comp.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
@@ -81,7 +82,7 @@ public interface EntryPointProcessor {
 
 			final @NotNull FunctionInvocation fi = deducePhase.newFunctionInvocation((BaseFunctionDef) f, null, ci);
 //				fi.setPhase(deducePhase);
-			final @NotNull WlGenerateFunction job1 = new WlGenerateFunction(generateFunctions, fi, cr);
+final @NotNull WlGenerateFunction job1 = new WlGenerateFunction(generateFunctions, fi, cr);
 			wl.addJob(job1);
 		}
 	}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/lang/impl/ConstructStatementImpl.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/lang/impl/ConstructStatementImpl.java
@@ -8,6 +8,7 @@
 package tripleo.elijah.lang.impl;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang2.*;
 
@@ -22,8 +23,8 @@ public class ConstructStatementImpl implements ConstructStatement {
 	private final @NotNull OS_Element parent;
 
 	public ConstructStatementImpl(@NotNull final OS_Element aParent,
-								  @NotNull final Context aContext,
-								  @NotNull final IExpression aExpr,
+			@NotNull final Context aContext,
+			@NotNull final IExpression aExpr,
 								  @Nullable final String aConstructorName,
 								  @Nullable final ExpressionList aExpressionList) {
 		parent          = aParent;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/lang/impl/DefFunctionDefImpl.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/lang/impl/DefFunctionDefImpl.java
@@ -7,17 +7,15 @@
  */
 package tripleo.elijah.lang.impl;
 
-import tripleo.elijah.UnintendedUseException;
+import java.util.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.*;
 import tripleo.elijah.contexts.*;
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang2.ElElementVisitor;
-import tripleo.elijah.util.NotImplementedException;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.ArrayList;
-import java.util.List;
+import tripleo.elijah.lang2.*;
+import tripleo.elijah.util.*;
 
 /*
  * Created on Aug 30, 2005 8:43:27 PM
@@ -25,7 +23,7 @@ import java.util.List;
 public class DefFunctionDefImpl extends BaseFunctionDef implements tripleo.elijah.lang.i.DefFunctionDef {
 
 	private final          OS_Element         parent;
-	private final @NotNull List<FunctionItem> _items      = new ArrayList<FunctionItem>();
+	private final @NotNull List<FunctionItem> _items = new ArrayList<FunctionItem>();
 	private                IExpression        _expr;
 	private @Nullable      TypeName           _returnType = null;
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/lang/impl/ExpressionBuilder.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/lang/impl/ExpressionBuilder.java
@@ -13,11 +13,9 @@
  */
 package tripleo.elijah.lang.impl;
 
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.lang.i.ExpressionKind;
-import tripleo.elijah.lang.i.IBinaryExpression;
-import tripleo.elijah.lang.i.IExpression;
-import tripleo.elijah.lang.i.OS_Type;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.lang.i.*;
 
 public class ExpressionBuilder {
 
@@ -30,7 +28,8 @@ public class ExpressionBuilder {
 		};
 	}
 
-	public static @NotNull IBinaryExpression build(final IExpression left, final ExpressionKind aType, final IExpression aExpression) {
+	public static @NotNull IBinaryExpression build(final IExpression left, final ExpressionKind aType,
+			final IExpression aExpression) {
 		return new BasicBinaryExpressionImpl(left, aType, aExpression);
 	}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/lang/impl/IdentExpressionImpl.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/lang/impl/IdentExpressionImpl.java
@@ -8,15 +8,16 @@
  */
 package tripleo.elijah.lang.impl;
 
-import antlr.*;
+import java.io.*;
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
+import antlr.*;
 import tripleo.elijah.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.nextgen.names.i.*;
 import tripleo.elijah.util.*;
-
-import java.io.*;
-import java.util.*;
 
 /**
  * @author Tripleo(sb)
@@ -25,9 +26,9 @@ import java.util.*;
  */
 public class IdentExpressionImpl implements IdentExpression {
 
-	private final @NotNull EN_Name  name;
-	private @NotNull       Attached _a;
-	private @NotNull       Token    text;
+	private final @NotNull EN_Name name;
+	private @NotNull Attached _a;
+	private @NotNull Token text;
 	private @Nullable      String   _fileName;
 
 	public IdentExpressionImpl(final @NotNull Token r1, @NotNull String aFilename) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/lang/impl/ProcedureCallExpressionImpl.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/lang/impl/ProcedureCallExpressionImpl.java
@@ -8,9 +8,9 @@
  */
 package tripleo.elijah.lang.impl;
 
-import tripleo.elijah.lang.i.*;
+import org.jetbrains.annotations.*;
 
-import org.jetbrains.annotations.NotNull;
+import tripleo.elijah.lang.i.*;
 
 // TODO is ExpressionList an IExpression?
 public class ProcedureCallExpressionImpl implements ProcedureCallExpression {
@@ -107,7 +107,7 @@ public class ProcedureCallExpressionImpl implements ProcedureCallExpression {
 		throw new IllegalArgumentException();
 	}
 
-	//public @NotNull String getReturnTypeString() {
+	// public @NotNull String getReturnTypeString() {
 	//	return "int"; // TODO hardcoded
 	//}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/lang/impl/VariableStatementImpl.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/lang/impl/VariableStatementImpl.java
@@ -8,15 +8,13 @@
  */
 package tripleo.elijah.lang.impl;
 
+import java.io.*;
+import java.util.*;
+
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang2.ElElementVisitor;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
+import tripleo.elijah.lang2.*;
 
 public class VariableStatementImpl implements OS_Element, tripleo.elijah.lang.i.VariableStatement {
 
@@ -25,7 +23,7 @@ public class VariableStatementImpl implements OS_Element, tripleo.elijah.lang.i.
 	private           IExpression            initialValue = LangGlobals.UNASSIGNED;
 	private           IdentExpression        name;
 	private           TypeModifiers          typeModifiers;
-	private @NotNull  TypeName               typeName     = new VariableTypeNameImpl();
+	private @NotNull TypeName typeName = new VariableTypeNameImpl();
 
 	public VariableStatementImpl(final VariableSequence aSequence) {
 		_parent = aSequence;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/lang/types/OS_FuncTypeImpl.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/lang/types/OS_FuncTypeImpl.java
@@ -12,14 +12,15 @@
  */
 package tripleo.elijah.lang.types;
 
+import java.text.*;
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.stages.deduce.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.util.*;
-
-import java.text.*;
-import java.util.*;
 
 public class OS_FuncTypeImpl extends __Abstract_OS_Type implements OS_FuncType {
 
@@ -33,7 +34,7 @@ public class OS_FuncTypeImpl extends __Abstract_OS_Type implements OS_FuncType {
 		public GClosure_OS_FuncType_resolvedFunction(@NotNull GenType genType,
 													 TypeName aGenericTypeName,
 													 DeduceTypes2 deduceTypes2,
-													 @NotNull DeducePhase phase) {
+				@NotNull DeducePhase phase) {
 			this.genType = genType;
 			genericTypeName = aGenericTypeName;
 			this.deduceTypes2 = deduceTypes2;
@@ -88,7 +89,7 @@ public class OS_FuncTypeImpl extends __Abstract_OS_Type implements OS_FuncType {
 
 	@NotNull
 	public ClassInvocation resolvedFunction(final @NotNull GenType genType, final TypeName aGenericTypeName,
-											final DeduceTypes2 deduceTypes2, final @NotNull DeducePhase phase) {
+			final DeduceTypes2 deduceTypes2, final @NotNull DeducePhase phase) {
 		// TODO what to do here?
 		final OS_Element ele = function_def;
 		final @Nullable ClassStatement best = (ClassStatement) ele.getParent();// genType.resolved.getClassOf();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/nextgen/inputtree/EIT_ModuleInputImpl.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/nextgen/inputtree/EIT_ModuleInputImpl.java
@@ -1,30 +1,24 @@
 package tripleo.elijah.nextgen.inputtree;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.ci.*;
-import tripleo.elijah.comp.Compilation;
-import tripleo.elijah.comp.EvaPipeline;
-import tripleo.elijah_elevated.comp.backbone.CompilationEnclosure;
-import tripleo.elijah.comp.nextgen.inputtree.EIT_ModuleInput;
-import tripleo.elijah.comp.notation.GM_GenerateModule;
-import tripleo.elijah.comp.notation.GM_GenerateModuleRequest;
-import tripleo.elijah.comp.notation.GN_GenerateNodesIntoSink;
-import tripleo.elijah.comp.notation.GN_GenerateNodesIntoSinkEnv;
-import tripleo.elijah.g.GModuleGenerationRequest;
-import tripleo.elijah.lang.i.ModuleItem;
-import tripleo.elijah.lang.i.OS_Module;
-import tripleo.elijah.nextgen.model.SM_Module;
-import tripleo.elijah.nextgen.model.SM_ModuleItem;
-import tripleo.elijah.stages.gen_c.GenerateC;
-import tripleo.elijah.stages.gen_fn.EvaNode;
-import tripleo.elijah.stages.gen_generic.*;
-import tripleo.elijah.stages.gen_generic.pipeline_impl.DefaultGenerateResultSink;
-import tripleo.elijah.work.*;
-import tripleo.elijah.world.i.WorldModule;
-
 import java.util.*;
-import java.util.function.Consumer;
+import java.util.function.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.ci.*;
+import tripleo.elijah.comp.*;
+import tripleo.elijah.comp.nextgen.inputtree.*;
+import tripleo.elijah.comp.notation.*;
+import tripleo.elijah.g.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.nextgen.model.*;
+import tripleo.elijah.stages.gen_c.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.gen_generic.*;
+import tripleo.elijah.stages.gen_generic.pipeline_impl.*;
+import tripleo.elijah.work.*;
+import tripleo.elijah.world.i.*;
+import tripleo.elijah_elevated.comp.backbone.*;
 
 public class EIT_ModuleInputImpl implements EIT_ModuleInput {
 	private final Compilation c;
@@ -64,8 +58,8 @@ public class EIT_ModuleInputImpl implements EIT_ModuleInput {
 
 	private void doGenerate(final List<EvaNode> nodes,
 						   final WorkManager wm,
-						   final @NotNull Consumer<GenerateResult> resultConsumer,
-						   final @NotNull CompilationEnclosure ce) {
+			final @NotNull Consumer<GenerateResult> resultConsumer,
+			final @NotNull CompilationEnclosure ce) {
 		// 0. get lang
 		final String lang = langOfModule();
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/nextgen/inputtree/EIT_ModuleList_.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/nextgen/inputtree/EIT_ModuleList_.java
@@ -1,10 +1,10 @@
 package tripleo.elijah.nextgen.inputtree;
 
-import tripleo.elijah.g.*;
-import tripleo.elijah.world.i.*;
-
 import java.util.*;
 import java.util.stream.*;
+
+import tripleo.elijah.g.*;
+import tripleo.elijah.world.i.*;
 
 //import org.jetbrains.annotations.*;
 //import tripleo.elijah.comp.*;
@@ -24,7 +24,7 @@ import java.util.stream.*;
 public class EIT_ModuleList_ implements EIT_ModuleList {
 	private final List<WorldModule> mods = Collections.EMPTY_LIST; //new ArrayList<>();
 
-//	private void __process__PL__each(final @NotNull _ProcessParams plp) {
+	// private void __process__PL__each(final @NotNull _ProcessParams plp) {
 //		final List<EvaNode> resolved_nodes = new ArrayList<EvaNode>();
 //
 //		final WorldModule mod = plp.getMod();
@@ -78,9 +78,9 @@ public class EIT_ModuleList_ implements EIT_ModuleList {
 	}
 
 //	public void process__PL(final Function<WorldModule, GenerateFunctions> ggf,
-//			final @NotNull PipelineLogic pipelineLogic) {
+// final @NotNull PipelineLogic pipelineLogic) {
 //		for (final WorldModule mod : mods) {
-//			final @NotNull EntryPointList epl = null; // mod.entryPoints;
+// final @NotNull EntryPointList epl = null; // mod.entryPoints;
 //
 //			//
 //			//
@@ -104,7 +104,7 @@ public class EIT_ModuleList_ implements EIT_ModuleList {
 //			final GenerateFunctions gfm = ggf.apply(mod);
 //
 //			final DeducePhase deducePhase = pipelineLogic.dp;
-//			// final DeducePhase.@NotNull GeneratedClasses lgc =
+// // final DeducePhase.@NotNull GeneratedClasses lgc =
 //			// deducePhase.generatedClasses;
 //
 //			final _ProcessParams plp = new _ProcessParams(mod, pipelineLogic, gfm, epl, deducePhase);
@@ -120,17 +120,19 @@ public class EIT_ModuleList_ implements EIT_ModuleList {
 	}
 
 	//	private static class _ProcessParams {
-//		private final @NotNull DeducePhase deducePhase;
+	// private final @NotNull DeducePhase deducePhase;
 //		@NotNull
 //		private final EntryPointList epl;
-//		private final @NotNull GenerateFunctions gfm;
+// private final @NotNull GenerateFunctions gfm;
 //		private final WorldModule mod;
-//		private final @NotNull PipelineLogic pipelineLogic;
+// private final @NotNull PipelineLogic pipelineLogic;
 //
 //		@Contract(pure = true)
-//		private _ProcessParams(@NotNull final WorldModule aModule, @NotNull final PipelineLogic aPipelineLogic,
-//				@NotNull final GenerateFunctions aGenerateFunctions, @NotNull final EntryPointList aEntryPointList,
-//				@NotNull final DeducePhase aDeducePhase) {
+// private _ProcessParams(@NotNull final WorldModule aModule, @NotNull final
+// PipelineLogic aPipelineLogic,
+// @NotNull final GenerateFunctions aGenerateFunctions, @NotNull final
+// EntryPointList aEntryPointList,
+// @NotNull final DeducePhase aDeducePhase) {
 //			mod = aModule;
 //			pipelineLogic = aPipelineLogic;
 //			gfm = aGenerateFunctions;
@@ -147,7 +149,7 @@ public class EIT_ModuleList_ implements EIT_ModuleList {
 //		}
 //
 //		@Contract(pure = true)
-//		public DeducePhase.@NotNull GeneratedClasses getLgc() {
+// public DeducePhase.@NotNull GeneratedClasses getLgc() {
 //			return deducePhase.generatedClasses;
 //		}
 //
@@ -157,12 +159,12 @@ public class EIT_ModuleList_ implements EIT_ModuleList {
 //		}
 //
 //		@Contract(pure = true)
-//		public ElLog.@NotNull Verbosity getVerbosity() {
+// public ElLog.@NotNull Verbosity getVerbosity() {
 //			return pipelineLogic.getVerbosity();
 //		}
 //
 //		@Contract(pure = true)
-//		public @NotNull Supplier<WorkManager> getWorkManagerSupplier() {
+// public @NotNull Supplier<WorkManager> getWorkManagerSupplier() {
 //			return () -> pipelineLogic.generatePhase.getWm();
 //		}
 //

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/nextgen/output/NG_OutputClass.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/nextgen/output/NG_OutputClass.java
@@ -1,6 +1,11 @@
 package tripleo.elijah.nextgen.output;
 
+import static tripleo.elijah.util.Helpers.*;
+
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.nextgen.outputtree.*;
 import tripleo.elijah.stages.garish.*;
 import tripleo.elijah.stages.gen_c.*;
@@ -8,10 +13,6 @@ import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.gen_generic.*;
 import tripleo.elijah.stages.generate.*;
 import tripleo.elijah.util.*;
-
-import java.util.*;
-
-import static tripleo.elijah.util.Helpers.*;
 
 public class NG_OutputClass implements NG_OutputItem {
 	private GarishClass   garishClass;
@@ -34,7 +35,7 @@ public class NG_OutputClass implements NG_OutputItem {
 
 	@Override
 	public EOT_FileNameProvider outName(final @NotNull OutputStrategyC aOutputStrategyC,
-										final GenerateResult.@NotNull TY ty) {
+			final GenerateResult.@NotNull TY ty) {
 		final EvaClass x = (EvaClass) garishClass.getLiving().evaNode();
 
 		return aOutputStrategyC.nameForClass1(x, ty);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/nextgen/output/NG_OutputClassStatement.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/nextgen/output/NG_OutputClassStatement.java
@@ -1,8 +1,9 @@
 package tripleo.elijah.nextgen.output;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.comp.*;
-import tripleo.elijah.comp.nextgen.inputtree.EIT_ModuleInput;
+import tripleo.elijah.comp.nextgen.inputtree.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.nextgen.inputtree.*;
 import tripleo.elijah.nextgen.outputstatement.*;
@@ -16,7 +17,7 @@ public class NG_OutputClassStatement implements NG_OutputStatement {
 	private final @NotNull NG_OutDep moduleDependency;
 
 	public NG_OutputClassStatement(final @NotNull BufferTabbedOutputStream aBufferTabbedOutputStream,
-	                               final @NotNull OS_Module aModuleDependency,
+			final @NotNull OS_Module aModuleDependency,
 	                               final TY aTy) {
 		buf              = aBufferTabbedOutputStream.getBuffer();
 		ty               = aTy;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/nextgen/output/NG_OutputFunction.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/nextgen/output/NG_OutputFunction.java
@@ -1,14 +1,15 @@
 package tripleo.elijah.nextgen.output;
 
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.nextgen.outputstatement.*;
 import tripleo.elijah.nextgen.outputtree.*;
 import tripleo.elijah.stages.gen_c.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.gen_generic.*;
 import tripleo.elijah.stages.generate.*;
-
-import java.util.*;
 
 public class NG_OutputFunction implements NG_OutputItem {
 	private List<C2C_Result> collect;
@@ -33,7 +34,7 @@ public class NG_OutputFunction implements NG_OutputItem {
 
 	@Override
 	public EOT_FileNameProvider outName(final @NotNull OutputStrategyC aOutputStrategyC,
-										final GenerateResult.@NotNull TY ty) {
+			final GenerateResult.@NotNull TY ty) {
 		if (gf instanceof EvaFunction) {
 			return aOutputStrategyC.nameForFunction1((EvaFunction) gf, ty);
 		} else {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/nextgen/output/NG_OutputNamespace.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/nextgen/output/NG_OutputNamespace.java
@@ -1,17 +1,18 @@
 package tripleo.elijah.nextgen.output;
 
-import org.jetbrains.annotations.NotNull;
+import static tripleo.elijah.util.Helpers.*;
+
+import java.util.*;
+
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.nextgen.outputtree.*;
-import tripleo.elijah.stages.garish.GarishNamespace;
-import tripleo.elijah.stages.gen_c.GenerateC;
-import tripleo.elijah.stages.gen_fn.EvaNamespace;
-import tripleo.elijah.stages.gen_generic.GenerateResult;
-import tripleo.elijah.stages.generate.OutputStrategyC;
-import tripleo.elijah.util.BufferTabbedOutputStream;
-
-import java.util.List;
-
-import static tripleo.elijah.util.Helpers.List_of;
+import tripleo.elijah.stages.garish.*;
+import tripleo.elijah.stages.gen_c.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.gen_generic.*;
+import tripleo.elijah.stages.generate.*;
+import tripleo.elijah.util.*;
 
 public class NG_OutputNamespace implements NG_OutputItem {
 	private GarishNamespace garishNamespace;
@@ -41,7 +42,7 @@ public class NG_OutputNamespace implements NG_OutputItem {
 
 	@Override
 	public EOT_FileNameProvider outName(final @NotNull OutputStrategyC aOutputStrategyC,
-										final GenerateResult.@NotNull TY ty) {
+			final GenerateResult.@NotNull TY ty) {
 		final EvaNamespace x = garishNamespace.getLiving().evaNode();
 
 		return aOutputStrategyC.nameForNamespace1(x, ty);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/nextgen/output/NG_OutputNamespaceStatement.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/nextgen/output/NG_OutputNamespaceStatement.java
@@ -1,8 +1,9 @@
 package tripleo.elijah.nextgen.output;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.comp.*;
-import tripleo.elijah.comp.nextgen.inputtree.EIT_ModuleInput;
+import tripleo.elijah.comp.nextgen.inputtree.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.nextgen.inputtree.*;
 import tripleo.elijah.nextgen.outputstatement.*;
@@ -12,11 +13,11 @@ import tripleo.util.buffer.*;
 
 public class NG_OutputNamespaceStatement implements NG_OutputStatement {
 	private final          TY                       ty;
-	private final @NotNull NG_OutDep                moduleDependency;
+	private final @NotNull NG_OutDep moduleDependency;
 	private final          Buffer                   buf;
 
 	public NG_OutputNamespaceStatement(final BufferTabbedOutputStream aBufferTabbedOutputStream,
-	                                   final @NotNull OS_Module aModule,
+			final @NotNull OS_Module aModule,
 	                                   final TY aTY) {
 		buf              = aBufferTabbedOutputStream.getBuffer();
 		ty               = aTY;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/nextgen/outputtree/EOT_OutputFileImpl.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/nextgen/outputtree/EOT_OutputFileImpl.java
@@ -1,10 +1,11 @@
 package tripleo.elijah.nextgen.outputtree;
 
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.nextgen.inputtree.*;
 import tripleo.elijah.nextgen.outputstatement.*;
-
-import java.util.*;
 
 public class EOT_OutputFileImpl implements EOT_OutputFile {
 	private final @NotNull EOT_FileNameProvider _filename;
@@ -14,7 +15,7 @@ public class EOT_OutputFileImpl implements EOT_OutputFile {
 	public List<EIT_Input_HashSourceFile_Triple> x;
 
 	public EOT_OutputFileImpl(final @NotNull List<EIT_Input> inputs, final @NotNull EOT_FileNameProvider filename,
-							  final @NotNull EOT_OutputType type, final @NotNull EG_Statement sequence) {
+			final @NotNull EOT_OutputType type, final @NotNull EG_Statement sequence) {
 		_filename = filename;
 		_type = type;
 		_sequence = sequence;
@@ -22,7 +23,7 @@ public class EOT_OutputFileImpl implements EOT_OutputFile {
 	}
 
 	public EOT_OutputFileImpl(final @NotNull List<EIT_Input> inputs, final @NotNull String filename,
-							  final @NotNull EOT_OutputType type, final @NotNull EG_Statement sequence) {
+			final @NotNull EOT_OutputType type, final @NotNull EG_Statement sequence) {
 		this(inputs, new _U_OF.DefaultFileNameProvider(filename), type, sequence);
 	}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/ClassInvocation.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/ClassInvocation.java
@@ -8,16 +8,17 @@
  */
 package tripleo.elijah.stages.deduce;
 
+import java.util.*;
+import java.util.function.*;
+
 import org.jdeferred2.*;
 import org.jdeferred2.impl.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.g.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.types.*;
 import tripleo.elijah.stages.gen_fn.*;
-
-import java.util.*;
-import java.util.function.*;
 
 /**
  * Created 3/5/21 3:51 AM
@@ -99,7 +100,7 @@ public class ClassInvocation implements IInvocation, GClassInvocation {
 		constructorName = aConstructorName;
 	}
 
-	private DeduceTypes2.DeduceTypes2Injector _inj() {
+	private DeduceTypes2Injector _inj() {
 		return _dt2s.get()._inj();
 	}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/ClassInvocationMake.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/ClassInvocationMake.java
@@ -1,17 +1,16 @@
 package tripleo.elijah.stages.deduce;
 
-import org.jdeferred2.DoneCallback;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import tripleo.elijah.Eventual;
-import tripleo.elijah.ReadySupplier_1;
-import tripleo.elijah.diagnostic.ExceptionDiagnostic;
-import tripleo.elijah.lang.i.*;
-import tripleo.elijah.stages.gen_fn.GenType;
-import tripleo.elijah.util.Operation;
-import tripleo.elijah_fluffy.util.EventualExtract;
+import java.util.*;
 
-import java.util.List;
+import org.jdeferred2.*;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.*;
+import tripleo.elijah.diagnostic.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.util.*;
+import tripleo.elijah_fluffy.util.*;
 
 public enum ClassInvocationMake {
 	;
@@ -66,9 +65,10 @@ public enum ClassInvocationMake {
 		return EventualExtract.of(ev);
 	}
 
-	public static DeduceTypes2.DeduceTypes2Injector.DerivedClassInvocation2 withGenericPart2(final ClassStatement aClassStatement, final String aO, final NormalTypeName aNormalTypeName, final DeduceTypes2 aDeduceTypes2) {
+	public static DeduceTypes2Injector.DerivedClassInvocation2 withGenericPart2(final ClassStatement aClassStatement,
+			final String aO, final NormalTypeName aNormalTypeName, final DeduceTypes2 aDeduceTypes2) {
 		@NotNull final Operation<ClassInvocation> x = withGenericPart(aClassStatement, aO, aNormalTypeName, aDeduceTypes2);
-		final DeduceTypes2.DeduceTypes2Injector.DerivedClassInvocation2 result = new DeduceTypes2.DeduceTypes2Injector.DerivedClassInvocation2() {
+		final DeduceTypes2Injector.DerivedClassInvocation2 result = new DeduceTypes2Injector.DerivedClassInvocation2() {
 			@Override
 			public void into(final Eventual<IInvocation> ev) {
 				switch (x.mode()) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/ClassInvocationMake.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/ClassInvocationMake.java
@@ -18,14 +18,14 @@ public enum ClassInvocationMake {
 	public static @NotNull Operation<ClassInvocation> withGenericPart(@NotNull ClassStatement best,
 																	  String constructorName,
 																	  @Nullable NormalTypeName aTyn1,
-																	  @NotNull DeduceTypes2 dt2) {
+			@NotNull DeduceTypes2 dt2) {
 		Eventual<Operation<ClassInvocation>> ev = dt2.eventual("ClassInvocationMake::withGenericPart");
 
 		if (aTyn1 == null) {
 			// throw new IllegalStateException("blank typename");
 		}
 
-		final @NotNull GenericPart      genericPart = dt2._inj().new_GenericPart(best, aTyn1);
+		final @NotNull GenericPart genericPart = dt2._inj().new_GenericPart(best, aTyn1);
 		final @Nullable ClassInvocation clsinv      = dt2._inj().new_ClassInvocation(best, constructorName, new ReadySupplier_1<>(dt2));
 
 		if (genericPart.hasGenericPart()) {
@@ -67,7 +67,8 @@ public enum ClassInvocationMake {
 
 	public static DeduceTypes2Injector.DerivedClassInvocation2 withGenericPart2(final ClassStatement aClassStatement,
 			final String aO, final NormalTypeName aNormalTypeName, final DeduceTypes2 aDeduceTypes2) {
-		@NotNull final Operation<ClassInvocation> x = withGenericPart(aClassStatement, aO, aNormalTypeName, aDeduceTypes2);
+		@NotNull
+		final Operation<ClassInvocation> x = withGenericPart(aClassStatement, aO, aNormalTypeName, aDeduceTypes2);
 		final DeduceTypes2Injector.DerivedClassInvocation2 result = new DeduceTypes2Injector.DerivedClassInvocation2() {
 			@Override
 			public void into(final Eventual<IInvocation> ev) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/CtorConnector.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/CtorConnector.java
@@ -1,0 +1,34 @@
+package tripleo.elijah.stages.deduce;
+
+import java.util.*;
+
+import tripleo.elijah.stages.gen_fn.*;
+
+class CtorConnector implements IVariableConnector {
+	private final IEvaConstructor evaConstructor;
+	private final DeduceTypes2 deduceTypes2;
+
+	public CtorConnector(final IEvaConstructor aEvaConstructor, final DeduceTypes2 aDeduceTypes2) {
+		evaConstructor = aEvaConstructor;
+		deduceTypes2 = aDeduceTypes2;
+	}
+
+	@Override
+	public void connect(final VariableTableEntry aVte, final String aName) {
+		PromiseExpectation<EvaClass> pe_evaClass = deduceTypes2._inj().new_PromiseExpectation(evaConstructor,
+				"evaConstructor.onGenClass", deduceTypes2);
+
+		evaConstructor.onGenClass((EvaClass aGeneratedClass) -> {
+			pe_evaClass.satisfy(aGeneratedClass);
+
+			final List<VarTableEntry> vt = (aGeneratedClass).varTable;
+
+			for (VarTableEntry gc_vte : vt) {
+				if (gc_vte.nameToken.getText().equals(aName)) {
+					gc_vte.connect(aVte, evaConstructor);
+					break;
+				}
+			}
+		});
+	}
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DE3_ActivePTE.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DE3_ActivePTE.java
@@ -23,7 +23,7 @@ import tripleo.elijah.world.i.*;
 
 class DE3_ActivePTE implements DE3_Active {
 	private final          DeduceTypes2                      deduceTypes2;
-	private final @NotNull ProcTableEntry                    pte;
+	private final @NotNull ProcTableEntry pte;
 	private final          ClassInvocation                   ci;
 	private final @NotNull List<Reactivable> ables;
 	private final DeduceTypes2Injector __inj;
@@ -43,7 +43,7 @@ class DE3_ActivePTE implements DE3_Active {
 	                      final EvaClass node,
 	                      final DeducePhase deducePhase,
 	                      final GenerateResultSink resultSink,
-	                      final @NotNull Eventual<GenerateResultEnv> efg) {
+			final @NotNull Eventual<GenerateResultEnv> efg) {
 		efg.then(fg -> {
 			final DeducePhase.GeneratedClasses classes = deducePhase.generatedClasses;
 			final int                          size1   = classes.size();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DE3_ActivePTE.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DE3_ActivePTE.java
@@ -1,7 +1,13 @@
 package tripleo.elijah.stages.deduce;
 
+import static tripleo.elijah.util.Helpers.*;
+
+import java.util.*;
+import java.util.function.*;
+
 import org.apache.commons.lang3.tuple.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.comp.notation.*;
@@ -15,17 +21,12 @@ import tripleo.elijah.stages.logging.*;
 import tripleo.elijah.work.*;
 import tripleo.elijah.world.i.*;
 
-import java.util.*;
-import java.util.function.*;
-
-import static tripleo.elijah.util.Helpers.*;
-
 class DE3_ActivePTE implements DE3_Active {
 	private final          DeduceTypes2                      deduceTypes2;
 	private final @NotNull ProcTableEntry                    pte;
 	private final          ClassInvocation                   ci;
-	private final @NotNull List<Reactivable>                 ables;
-	private final          DeduceTypes2.DeduceTypes2Injector __inj;
+	private final @NotNull List<Reactivable> ables;
+	private final DeduceTypes2Injector __inj;
 
 	public DE3_ActivePTE(final @NotNull DeduceTypes2 aDeduceTypes2, final @NotNull ProcTableEntry pte,
 	                     final ClassInvocation classInvocation) {
@@ -63,7 +64,7 @@ class DE3_ActivePTE implements DE3_Active {
 		});
 	}
 
-	private DeduceTypes2.DeduceTypes2Injector _inj() {
+	private DeduceTypes2Injector _inj() {
 		return __inj;
 	}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DT_Function.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DT_Function.java
@@ -1,0 +1,24 @@
+package tripleo.elijah.stages.deduce;
+
+import java.util.*;
+
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.stages.gen_fn.*;
+
+interface DT_Function {
+	List<VariableTableEntry> vte_list();
+
+	List<IdentTableEntry> idte_list();
+
+	List<ProcTableEntry> prte_list();
+
+	BaseEvaFunction get();
+
+	List<ConstantTableEntry> cte_list();
+
+	void add_proc_table_listeners();
+
+	void resolve_ident_table(final Context aContext);
+
+	void resolve_arguments_table(Context aContext);
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DW_onExitFunction.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DW_onExitFunction.java
@@ -30,14 +30,16 @@ class DW_onExitFunction {
 		//
 		// resolve var table. moved from `E'
 		//
-		for (@NotNull VariableTableEntry vte : generatedFunction.vte_list) {
+		for (@NotNull
+		VariableTableEntry vte : generatedFunction.vte_list) {
 			vte.resolve_var_table_entry_for_exit_function();
 		}
 
 	}
 
 	public void runRunnables() {
-		for (@NotNull Runnable runnable : deduceTypes2.onRunnables) {
+		for (@NotNull
+		Runnable runnable : deduceTypes2.onRunnables) {
 			runnable.run();
 		}
 	}
@@ -65,7 +67,8 @@ class DW_onExitFunction {
 		//
 		// ATTACH A TYPE TO IDTE'S
 		//
-		for (@NotNull final IdentTableEntry ite : generatedFunction.idte_list) {
+		for (@NotNull
+		final IdentTableEntry ite : generatedFunction.idte_list) {
 			final DeduceElement3_IdentTableEntry ite_de = ite.getDeduceElement3(deduceTypes2, generatedFunction);
 			ite_de._ctxts(aFd_ctx, aContext);
 			ite_de.mvState(null, DeduceElement3_IdentTableEntry.ST.EXIT_GET_TYPE);
@@ -88,10 +91,11 @@ class DW_onExitFunction {
 				deduceTypes2);
 		deps.subscribeTypes(generatedFunction.dependentTypesSubject());
 		deps.subscribeFunctions(generatedFunction.dependentFunctionSubject());
-//                                              for (@NotNull GenType genType : generatedFunction.dependentTypes()) {
+		// for (@NotNull GenType genType : generatedFunction.dependentTypes()) {
 //                                                      deps.action_type(genType, workManager);
 //                                              }
-//                                              for (@NotNull FunctionInvocation dependentFunction : generatedFunction.dependentFunctions()) {
+// for (@NotNull FunctionInvocation dependentFunction :
+// generatedFunction.dependentFunctions()) {
 //                                                      deps.action_function(dependentFunction, workManager);
 //                                              }
 		final int x = workManager.totalSize();
@@ -230,7 +234,8 @@ class DW_onExitFunction {
 		}
 	}
 
-	@NotNull DeduceElement3_ProcTableEntry convertPTE(final @NotNull ProcTableEntry pte) {
+	@NotNull
+	DeduceElement3_ProcTableEntry convertPTE(final @NotNull ProcTableEntry pte) {
 		final DeduceElement3_ProcTableEntry de3_pte = pte.getDeduceElement3(deduceTypes2, generatedFunction);
 		return de3_pte;
 	}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DW_onExitFunction.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DW_onExitFunction.java
@@ -1,6 +1,10 @@
 package tripleo.elijah.stages.deduce;
 
+import java.util.*;
+import java.util.function.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.stages.deduce.nextgen.*;
 import tripleo.elijah.stages.deduce.post_bytecode.*;
@@ -8,9 +12,6 @@ import tripleo.elijah.stages.deduce.tastic.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.work.*;
-
-import java.util.*;
-import java.util.function.*;
 
 class DW_onExitFunction {
 	private final DeduceTypes2    deduceTypes2;
@@ -73,15 +74,18 @@ class DW_onExitFunction {
 
 	void resolveEachTypename() {
 		// TODO why are we doing this?
-		final DeduceTypes2.Resolve_each_typename ret = deduceTypes2._inj().new_Resolve_each_typename(deduceTypes2.phase, deduceTypes2, deduceTypes2._errSink());
+		final Resolve_each_typename ret = deduceTypes2._inj().new_Resolve_each_typename(deduceTypes2.phase,
+				deduceTypes2, deduceTypes2._errSink());
 		for (final TypeTableEntry typeTableEntry : generatedFunction.tte_list) {
 			ret.action(typeTableEntry);
 		}
 	}
 
 	void doDependencySubscriptions() {
-		final @NotNull WorkManager               workManager = deduceTypes2.wm;// _inj().new_WorkManager();
-		@NotNull final DeduceTypes2.Dependencies deps        = deduceTypes2._inj().new_Dependencies(/* this, *//* phase, this, errSink */workManager, deduceTypes2);
+		final @NotNull WorkManager workManager = deduceTypes2.wm;// _inj().new_WorkManager();
+		@NotNull
+		final Dependencies deps = deduceTypes2._inj().new_Dependencies(/* this, *//* phase, this, errSink */workManager,
+				deduceTypes2);
 		deps.subscribeTypes(generatedFunction.dependentTypesSubject());
 		deps.subscribeFunctions(generatedFunction.dependentFunctionSubject());
 //                                              for (@NotNull GenType genType : generatedFunction.dependentTypes()) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceClient1.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceClient1.java
@@ -42,7 +42,7 @@ public class DeduceClient1 {
 	}
 
 	public void genCI(final @NotNull GenType aResult, final TypeName aNonGenericTypeName) {
-		aResult.genCI(aNonGenericTypeName, dt2, dt2.errSink, dt2.phase);
+		aResult.genCI(aNonGenericTypeName, dt2, dt2._errSink(), dt2.phase);
 	}
 
 	public void genCIForGenType2(final @NotNull GenType genType) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceClient1.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceClient1.java
@@ -1,0 +1,72 @@
+package tripleo.elijah.stages.deduce;
+
+import java.util.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.lang.impl.*;
+import tripleo.elijah.stages.deduce.declarations.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.instructions.*;
+
+public class DeduceClient1 {
+	private final DeduceTypes2 dt2;
+
+	@Contract(pure = true)
+	public DeduceClient1(DeduceTypes2 aDeduceTypes2) {
+		dt2 = aDeduceTypes2;
+	}
+
+	public DeduceTypes2 _deduceTypes2() {
+		return dt2;
+	}
+
+	public DeduceTypes2Injector _inj() {
+		return dt2._inj();
+	}
+
+	public @Nullable OS_Element _resolveAlias(@NotNull AliasStatementImpl aAliasStatement) {
+		return DeduceLookupUtils._resolveAlias(aAliasStatement, dt2);
+	}
+
+	public @NotNull DeferredMember deferred_member(DeduceElementWrapper aParent, IInvocation aInvocation,
+			VariableStatementImpl aVariableStatement, @NotNull IdentTableEntry aIdentTableEntry) {
+		return dt2.deferred_member(aParent, aInvocation, aVariableStatement, aIdentTableEntry);
+	}
+
+	public void found_element_for_ite(BaseEvaFunction aGeneratedFunction, @NotNull IdentTableEntry aIte,
+			OS_Element aX, Context aCtx) {
+		dt2.found_element_for_ite(aGeneratedFunction, aIte, aX, aCtx, dt2.central());
+	}
+
+	public void genCI(final @NotNull GenType aResult, final TypeName aNonGenericTypeName) {
+		aResult.genCI(aNonGenericTypeName, dt2, dt2.errSink, dt2.phase);
+	}
+
+	public void genCIForGenType2(final @NotNull GenType genType) {
+		genType.genCIForGenType2(dt2);
+	}
+
+	public @Nullable IInvocation getInvocationFromBacklink(InstructionArgument aInstructionArgument) {
+		return dt2.getInvocationFromBacklink(aInstructionArgument);
+	}
+
+	public @NotNull List<TypeTableEntry> getPotentialTypesVte(@NotNull VariableTableEntry aVte) {
+		return dt2.getPotentialTypesVte(aVte);
+	}
+
+	public void LOG_err(String aS) {
+		dt2.LOG.err(aS);
+	}
+
+	public @Nullable ClassInvocation registerClassInvocation(final @NotNull ClassStatement aClassStatement,
+			final String aS) {
+		return dt2.phase.registerClassInvocation(aClassStatement, aS, new ReadySupplier_1<>(dt2));
+	}
+
+	public @NotNull GenType resolve_type(@NotNull OS_Type aType, Context aCtx) throws ResolveError {
+		return dt2.resolve_type(aType, aCtx);
+	}
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceClient2.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceClient2.java
@@ -18,7 +18,7 @@ public class DeduceClient2 {
 	}
 
 	public @NotNull ClassInvocation genCI(@NotNull GenType genType, TypeName typeName) {
-		return genType.genCI(typeName, deduceTypes2, deduceTypes2.errSink, deduceTypes2.phase);
+		return genType.genCI(typeName, deduceTypes2, deduceTypes2._errSink(), deduceTypes2.phase);
 	}
 
 	public @NotNull ElLog getLOG() {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceClient2.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceClient2.java
@@ -1,0 +1,43 @@
+package tripleo.elijah.stages.deduce;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.logging.*;
+
+public class DeduceClient2 {
+	private final DeduceTypes2 deduceTypes2;
+
+	public DeduceClient2(DeduceTypes2 deduceTypes2) {
+		this.deduceTypes2 = deduceTypes2;
+	}
+
+	public DeduceTypes2 deduceTypes2() {
+		return deduceTypes2;
+	}
+
+	public @NotNull ClassInvocation genCI(@NotNull GenType genType, TypeName typeName) {
+		return genType.genCI(typeName, deduceTypes2, deduceTypes2.errSink, deduceTypes2.phase);
+	}
+
+	public @NotNull ElLog getLOG() {
+		return deduceTypes2.LOG;
+	}
+
+	public @NotNull FunctionInvocation newFunctionInvocation(FunctionDef constructorDef, ProcTableEntry pte,
+			@NotNull IInvocation ci) {
+		return deduceTypes2.newFunctionInvocation(constructorDef, pte, ci, deduceTypes2.phase);
+	}
+
+	public @Nullable ClassInvocation registerClassInvocation(@NotNull ClassInvocation ci) {
+		RegisterClassInvocation_env env = new RegisterClassInvocation_env(ci, () -> deduceTypes2,
+				() -> deduceTypes2.phase);
+
+		return deduceTypes2.phase.registerClassInvocation(env);
+	}
+
+	public NamespaceInvocation registerNamespaceInvocation(NamespaceStatement namespaceStatement) {
+		return deduceTypes2.phase.registerNamespaceInvocation(namespaceStatement);
+	}
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceClient3.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceClient3.java
@@ -1,0 +1,87 @@
+package tripleo.elijah.stages.deduce;
+
+import java.util.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.lang.impl.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.instructions.*;
+import tripleo.elijah.stages.logging.*;
+import tripleo.elijah.work.*;
+
+public class DeduceClient3 {
+	final DeduceTypes2 deduceTypes2;
+
+	public DeduceClient3(final DeduceTypes2 aDeduceTypes2) {
+		deduceTypes2 = aDeduceTypes2;
+	}
+
+	public DeduceTypes2 _deduceTypes2() {
+		return deduceTypes2;
+	}
+
+	public void addJobs(final WorkList aWl) {
+		deduceTypes2.wm.addJobs(aWl);
+	}
+
+	public void found_element_for_ite(final BaseEvaFunction generatedFunction, final @NotNull IdentTableEntry ite,
+			final @Nullable OS_Element y, final Context ctx) {
+		deduceTypes2.found_element_for_ite(generatedFunction, ite, y, ctx, deduceTypes2.central());
+	}
+
+	public void genCIForGenType2(final @NotNull GenType genType) {
+		genType.genCIForGenType2(deduceTypes2);
+	}
+
+	public @NotNull GenerateFunctions getGenerateFunctions(final @NotNull OS_Module aModule) {
+		return deduceTypes2.getGenerateFunctions(aModule);
+	}
+
+	public IInvocation getInvocation(final @NotNull EvaFunction aGeneratedFunction) {
+		return deduceTypes2.getInvocation(aGeneratedFunction);
+	}
+
+	public @NotNull ElLog getLOG() {
+		return deduceTypes2.LOG;
+	}
+
+	public @NotNull DeducePhase getPhase() {
+		return deduceTypes2.phase;
+	}
+
+	public @NotNull List<TypeTableEntry> getPotentialTypesVte(final @NotNull VariableTableEntry aVte) {
+		return deduceTypes2.getPotentialTypesVte(aVte);
+	}
+
+	public LookupResultList lookupExpression(final @NotNull IExpression aExp, final @NotNull Context aContext)
+			throws ResolveError {
+		return DeduceLookupUtils.lookupExpression(aExp, aContext, deduceTypes2);
+	}
+
+	public @NotNull FunctionInvocation newFunctionInvocation(final BaseFunctionDef aFunctionDef,
+			final ProcTableEntry aPte, final @NotNull IInvocation aInvocation) {
+		return deduceTypes2.newFunctionInvocation(aFunctionDef, aPte, aInvocation, deduceTypes2.phase);
+	}
+
+	public @NotNull IElementHolder newGenericElementHolderWithType(final @NotNull OS_Element aElement,
+			final @NotNull TypeName aTypeName) {
+		final OS_Type typeName;
+		if (aTypeName.isNull())
+			typeName = null;
+		else
+			typeName = this.deduceTypes2._inj().new_OS_UserType(aTypeName);
+		return this.deduceTypes2._inj().new_GenericElementHolderWithType(aElement, typeName, deduceTypes2);
+	}
+
+	public @NotNull GenType resolve_type(final @NotNull OS_Type aType, final Context aContext) throws ResolveError {
+		return deduceTypes2.resolve_type(aType, aContext);
+	}
+
+	public void resolveIdentIA2_(final @NotNull Context aEctx, final IdentIA aIdentIA,
+			final @Nullable List<InstructionArgument> aInstructionArgumentList,
+			final @NotNull BaseEvaFunction aGeneratedFunction, final @NotNull FoundElement aFoundElement) {
+		deduceTypes2.resolveIdentIA2_(aEctx, aIdentIA, aInstructionArgumentList, aGeneratedFunction, aFoundElement);
+	}
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceClient4.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceClient4.java
@@ -15,10 +15,8 @@ import tripleo.elijah.stages.logging.*;
 
 public class DeduceClient4 {
 	private final DeduceTypes2 deduceTypes2;
-	private final DeduceTypes2 deduceTypes2;
 
-	public DeduceClient4(final DeduceTypes2 aDeduceTypes2, final DeduceTypes2 aDeduceTypes2) {
-		deduceTypes2 = aDeduceTypes2;
+	public DeduceClient4(final DeduceTypes2 aDeduceTypes2) {
 		deduceTypes2 = aDeduceTypes2;
 	}
 
@@ -48,7 +46,7 @@ public class DeduceClient4 {
 	}
 
 	public ClassInvocation genCI(final @NotNull GenType aType, final TypeName aGenericTypeName) {
-		return aType.genCI(aGenericTypeName, deduceTypes2, deduceTypes2.errSink, deduceTypes2.phase);
+		return aType.genCI(aGenericTypeName, deduceTypes2, __errSink(), deduceTypes2.phase);
 	}
 
 	public DeduceTypes2 get() {
@@ -56,7 +54,7 @@ public class DeduceClient4 {
 	}
 
 	public ErrSink getErrSink() {
-		return deduceTypes2.errSink;
+		return __errSink();
 	}
 
 	public IInvocation getInvocation(final @NotNull EvaFunction aGeneratedFunction) {
@@ -140,7 +138,11 @@ public class DeduceClient4 {
 	}
 
 	public void reportDiagnostic(final ResolveError aResolveError) {
-		deduceTypes2.errSink.reportDiagnostic(aResolveError);
+		__errSink().reportDiagnostic(aResolveError);
+	}
+
+	private ErrSink __errSink() {
+		return deduceTypes2._errSink();
 	}
 
 	public @NotNull GenType resolve_type(final @NotNull OS_Type aTy, final Context aCtx) throws ResolveError {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceClient4.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceClient4.java
@@ -1,0 +1,154 @@
+package tripleo.elijah.stages.deduce;
+
+import java.util.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.*;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.lang.impl.*;
+import tripleo.elijah.stages.deduce.declarations.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.instructions.*;
+import tripleo.elijah.stages.logging.*;
+
+public class DeduceClient4 {
+	private final DeduceTypes2 deduceTypes2;
+	private final DeduceTypes2 deduceTypes2;
+
+	public DeduceClient4(final DeduceTypes2 aDeduceTypes2, final DeduceTypes2 aDeduceTypes2) {
+		deduceTypes2 = aDeduceTypes2;
+		deduceTypes2 = aDeduceTypes2;
+	}
+
+	public @Nullable OS_Element _resolveAlias(final @NotNull AliasStatement aAliasStatement) {
+		return DeduceLookupUtils._resolveAlias(aAliasStatement, deduceTypes2);
+	}
+
+	public @Nullable OS_Element _resolveAlias2(final @NotNull AliasStatementImpl aAliasStatement)
+			throws ResolveError {
+		return DeduceLookupUtils._resolveAlias2(aAliasStatement, deduceTypes2);
+	}
+
+	public @NotNull DeferredMemberFunction deferred_member_function(final OS_Element aParent,
+			final IInvocation aInvocation, final @NotNull FunctionDef aFunctionDef,
+			final @NotNull FunctionInvocation aFunctionInvocation) {
+		return deduceTypes2.deferred_member_function(aParent, aInvocation, aFunctionDef, aFunctionInvocation);
+	}
+
+	public void forFunction(final @NotNull FunctionInvocation aFunctionInvocation,
+			final @NotNull ForFunction aForFunction) {
+		deduceTypes2.forFunction(aFunctionInvocation, aForFunction);
+	}
+
+	public void found_element_for_ite(final BaseEvaFunction aGeneratedFunction,
+			final @NotNull IdentTableEntry aEntry, final OS_Element aE, final Context aCtx) {
+		deduceTypes2.found_element_for_ite(aGeneratedFunction, aEntry, aE, aCtx, deduceTypes2.central());
+	}
+
+	public ClassInvocation genCI(final @NotNull GenType aType, final TypeName aGenericTypeName) {
+		return aType.genCI(aGenericTypeName, deduceTypes2, deduceTypes2.errSink, deduceTypes2.phase);
+	}
+
+	public DeduceTypes2 get() {
+		return deduceTypes2;
+	}
+
+	public ErrSink getErrSink() {
+		return deduceTypes2.errSink;
+	}
+
+	public IInvocation getInvocation(final @NotNull EvaFunction aGeneratedFunction) {
+		return deduceTypes2.getInvocation(aGeneratedFunction);
+	}
+
+	public @NotNull ElLog getLOG() {
+		return deduceTypes2.LOG;
+	}
+
+	public @NotNull OS_Module getModule() {
+		return deduceTypes2.module;
+	}
+
+	public @NotNull DeducePhase getPhase() {
+		return deduceTypes2.phase;
+	}
+
+	public @NotNull List<TypeTableEntry> getPotentialTypesVte(final @NotNull EvaFunction aGeneratedFunction,
+			final @NotNull InstructionArgument aVte_ia) {
+		return deduceTypes2.getPotentialTypesVte(aGeneratedFunction, aVte_ia);
+	}
+
+	public OS_Type gt(final @NotNull GenType aType) {
+		return deduceTypes2.gt(aType);
+	}
+
+	public void implement_calls(final @NotNull BaseEvaFunction aGeneratedFunction, final @NotNull Context aParent,
+			final @NotNull InstructionArgument aArg, final @NotNull ProcTableEntry aPte,
+			final int aInstructionIndex) {
+		if (aGeneratedFunction.deferred_calls.contains(aInstructionIndex)) {
+			deduceTypes2.LOG.err("Call is deferred "/* +gf.getInstruction(pc) */ + " " + aPte);
+			return;
+		}
+		Implement_Calls_ ic = deduceTypes2._inj().new_Implement_Calls_(aGeneratedFunction, aParent, aArg, aPte,
+				aInstructionIndex, deduceTypes2);
+		ic.action();
+	}
+
+	public @Nullable OS_Element lookup(final @NotNull IdentExpression aElement, final @NotNull Context aContext)
+			throws ResolveError {
+		return DeduceLookupUtils.lookup(aElement, aContext, deduceTypes2);
+	}
+
+	public LookupResultList lookupExpression(final @NotNull IExpression aExpression,
+			final @NotNull Context aContext) throws ResolveError {
+		return DeduceLookupUtils.lookupExpression(aExpression, aContext, deduceTypes2);
+	}
+
+	public @NotNull FunctionInvocation newFunctionInvocation(final FunctionDef aElement, final ProcTableEntry aPte,
+			final @NotNull IInvocation aInvocation) {
+		return deduceTypes2.newFunctionInvocation(aElement, aPte, aInvocation, deduceTypes2.phase);
+	}
+
+	public void onFinish(final Runnable aRunnable) {
+		deduceTypes2.onFinish(aRunnable);
+	}
+
+	public <T> @NotNull PromiseExpectation<T> promiseExpectation(final BaseEvaFunction aGeneratedFunction,
+			final String aName) {
+		return deduceTypes2.promiseExpectation(aGeneratedFunction, aName);
+	}
+
+	public void register_and_resolve(final @NotNull VariableTableEntry aVte,
+			final @NotNull ClassStatement aClassStatement) {
+		deduceTypes2.register_and_resolve(aVte, aClassStatement);
+	}
+
+	public @NotNull ClassInvocation registerClassInvocation(final @NotNull ClassInvocation aCi) {
+		return deduceTypes2.phase.registerClassInvocation(aCi);
+	}
+
+	public @Nullable ClassInvocation registerClassInvocation(final @NotNull ClassStatement aClassStatement,
+			final String constructorName) {
+		return deduceTypes2.phase.registerClassInvocation(aClassStatement, constructorName,
+				new ReadySupplier_1<>(deduceTypes2));
+	}
+
+	public NamespaceInvocation registerNamespaceInvocation(final NamespaceStatement aNamespaceStatement) {
+		return deduceTypes2.phase.registerNamespaceInvocation(aNamespaceStatement);
+	}
+
+	public void reportDiagnostic(final ResolveError aResolveError) {
+		deduceTypes2.errSink.reportDiagnostic(aResolveError);
+	}
+
+	public @NotNull GenType resolve_type(final @NotNull OS_Type aTy, final Context aCtx) throws ResolveError {
+		return deduceTypes2.resolve_type(aTy, aCtx);
+	}
+
+	public void resolveIdentIA_(final @NotNull Context aCtx, final @NotNull IdentIA aIdentIA,
+			final @NotNull BaseEvaFunction aGeneratedFunction, final @NotNull FoundElement aFoundElement) {
+		deduceTypes2.resolveIdentIA_(aCtx, aIdentIA, aGeneratedFunction, aFoundElement);
+	}
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceLocalVariable.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceLocalVariable.java
@@ -9,9 +9,13 @@
  */
 package tripleo.elijah.stages.deduce;
 
+import java.util.*;
+import java.util.stream.*;
+
 import org.jdeferred2.*;
 import org.jdeferred2.impl.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.lang.types.*;
@@ -20,9 +24,6 @@ import tripleo.elijah.stages.deduce.post_bytecode.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.util.*;
-
-import java.util.*;
-import java.util.stream.*;
 
 /**
  * Created 11/30/21 1:32 AM
@@ -103,7 +104,7 @@ public class DeduceLocalVariable {
 			assert self2 instanceof IntegerIA;
 			Self = deduceTypes2._inj().new_DeduceTypes2_OS_SpecialVariable(((IntegerIA) self2).getEntry(),
 					VariableTableType.SELF, generatedFunction);
-			((DeduceTypes2.OS_SpecialVariable) Self).memberInvocation = deduceTypes2._inj().new_MemberInvocation(b,
+			((OS_SpecialVariable) Self).memberInvocation = deduceTypes2._inj().new_MemberInvocation(b,
 					MemberInvocation.Role.INHERITED);
 			break;
 		default:
@@ -165,7 +166,7 @@ public class DeduceLocalVariable {
 			assert self2 instanceof IntegerIA;
 			Self = deduceTypes2._inj().new_DeduceTypes2_OS_SpecialVariable(((IntegerIA) self2).getEntry(),
 					VariableTableType.SELF, generatedFunction);
-			((DeduceTypes2.OS_SpecialVariable) Self).memberInvocation = deduceTypes2._inj().new_MemberInvocation(b,
+			((OS_SpecialVariable) Self).memberInvocation = deduceTypes2._inj().new_MemberInvocation(b,
 					MemberInvocation.Role.INHERITED);
 			break;
 		default:

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceLookupUtils.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceLookupUtils.java
@@ -8,7 +8,10 @@
  */
 package tripleo.elijah.stages.deduce;
 
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.contexts.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
@@ -17,8 +20,6 @@ import tripleo.elijah.lang2.*;
 import tripleo.elijah.stages.deduce.post_bytecode.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.util.*;
-
-import java.util.*;
 
 /**
  * Created 3/7/21 1:13 AM
@@ -96,8 +97,8 @@ public enum DeduceLookupUtils {
 			final @NotNull DeduceElement3_IdentTableEntry de3_ite,
 			final @NotNull IFunctionContext aFunctionContext) {
 		final IdentExpression                   identExpression      = de3_ite.principal.getIdent();
-		final DeduceTypes2                      deduceTypes2         = de3_ite.principal._deduceTypes2();
-		final DeduceTypes2.DeduceTypes2Injector deduceTypes2Injector = deduceTypes2._inj();
+		final DeduceTypes2 deduceTypes2 = de3_ite.principal._deduceTypes2();
+		final DeduceTypes2Injector deduceTypes2Injector = deduceTypes2._inj();
 		//final IdentTableEntry ite = deduceTypes2Injector.new_IdentTableEntry(0, identExpression,
 		//																	 identExpression.getContext(),
 		//																	 de3_ite.generatedFunction);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceLookupUtils.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceLookupUtils.java
@@ -444,8 +444,8 @@ public enum DeduceLookupUtils {
 	}
 
 	public static LookupResultList lookupExpression(final @NotNull IExpression left,
-													final @NotNull Context ctx,
-													final @NotNull DeduceTypes2 deduceTypes2) throws ResolveError {
+			final @NotNull Context ctx,
+			final @NotNull DeduceTypes2 deduceTypes2) throws ResolveError {
 		switch (left.getKind()) {
 		case QIDENT -> {
 			final IExpression de = Helpers0.qualidentToDotExpression2((Qualident) left);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeducePhase.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeducePhase.java
@@ -9,52 +9,45 @@
  */
 package tripleo.elijah.stages.deduce;
 
-import com.google.common.collect.*;
-import lombok.Getter;
-import org.apache.commons.lang3.tuple.Pair;
-import org.jdeferred2.DoneCallback;
-import org.jdeferred2.impl.DeferredObject;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import tripleo.elijah.Eventual;
-import tripleo.elijah.EventualRegister;
-import tripleo.elijah.comp.Compilation;
-import tripleo.elijah.comp.PipelineLogic;
-import tripleo.elijah.comp.i.ICompilationAccess;
-import tripleo.elijah.comp.i.extra.IPipelineAccess;
-import tripleo.elijah.comp.internal.CompilationImpl;
-import tripleo.elijah.diagnostic.Diagnostic;
-import tripleo.elijah.g.GFunctionMapHook;
-import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.types.OS_UnknownType;
-import tripleo.elijah.nextgen.ClassDefinition;
-import tripleo.elijah.nextgen.ClassDefinition__;
-import tripleo.elijah.nextgen.diagnostic.CouldntGenerateClass;
-import tripleo.elijah.nextgen.reactive.ReactiveDimension;
-import tripleo.elijah.stages.deduce.declarations.DeferredMember;
-import tripleo.elijah.stages.deduce.declarations.DeferredMemberFunction;
-import tripleo.elijah.stages.deduce.nextgen.*;
-import tripleo.elijah.stages.deduce.post_bytecode.DeduceElement3_IdentTableEntry;
-import tripleo.elijah.stages.gen_fn.*;
-import tripleo.elijah.stages.gen_generic.ICodeRegistrar;
-import tripleo.elijah.stages.logging.ElLog;
-import tripleo.elijah.stages.logging.ElLog_;
-import tripleo.elijah.stages.post_deduce.DefaultCodeRegistrar;
-import tripleo.elijah.stateful.State;
-import tripleo.elijah.stateful._RegistrationTarget;
-import tripleo.elijah.util.Maybe;
-import tripleo.elijah.util.NotImplementedException;
-import tripleo.elijah.work.*;
-import tripleo.elijah.world.i.WorldModule;
-import tripleo.elijah_elevated.comp.backbone.CompilationEnclosure;
-import tripleo.elijah_fluffy.util.DefaultEventualRegister;
+import static tripleo.elijah.util.Helpers.*;
 
 import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.*;
 import java.util.function.*;
 
-import static tripleo.elijah.util.Helpers.List_of;
+import org.apache.commons.lang3.tuple.*;
+import org.jdeferred2.*;
+import org.jdeferred2.impl.*;
+import org.jetbrains.annotations.*;
+
+import com.google.common.collect.*;
+
+import lombok.*;
+import tripleo.elijah.*;
+import tripleo.elijah.comp.*;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.comp.i.extra.*;
+import tripleo.elijah.comp.internal.*;
+import tripleo.elijah.diagnostic.*;
+import tripleo.elijah.g.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.lang.types.*;
+import tripleo.elijah.nextgen.*;
+import tripleo.elijah.nextgen.diagnostic.*;
+import tripleo.elijah.nextgen.reactive.*;
+import tripleo.elijah.stages.deduce.declarations.*;
+import tripleo.elijah.stages.deduce.nextgen.*;
+import tripleo.elijah.stages.deduce.post_bytecode.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.gen_generic.*;
+import tripleo.elijah.stages.logging.*;
+import tripleo.elijah.stages.post_deduce.*;
+import tripleo.elijah.stateful.*;
+import tripleo.elijah.util.*;
+import tripleo.elijah.work.*;
+import tripleo.elijah.world.i.*;
+import tripleo.elijah_elevated.comp.backbone.*;
+import tripleo.elijah_fluffy.util.*;
 
 /**
  * Created 12/24/20 3:59 AM
@@ -1006,7 +999,7 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 		<T extends EvaNode> void defaultAction(final T result) {
 			final OS_Element p = deferredMemberFunction.getParent();
 
-			if (p instanceof final DeduceTypes2.@NotNull OS_SpecialVariable specialVariable) {
+			if (p instanceof final @NotNullOS_SpecialVariable specialVariable) {
 				onSpecialVariable(specialVariable);
 				int y = 2;
 			} else if (p instanceof ClassStatement) {
@@ -1042,7 +1035,7 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 			return x;
 		}
 
-		public void onSpecialVariable(final DeduceTypes2.@NotNull OS_SpecialVariable aSpecialVariable) {
+		public void onSpecialVariable(final @NotNull OS_SpecialVariable aSpecialVariable) {
 			final DeduceLocalVariable.MemberInvocation mi = aSpecialVariable.memberInvocation;
 
 			switch (mi.role) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeducePhase.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeducePhase.java
@@ -53,8 +53,8 @@ import tripleo.elijah_fluffy.util.*;
  * Created 12/24/20 3:59 AM
  */
 public class DeducePhase extends _RegistrationTarget implements ReactiveDimension, EventualRegister {
-	public final @NotNull  GeneratedClasses                             generatedClasses;
-	public final @NotNull  GeneratePhase                                generatePhase;
+	public final @NotNull GeneratedClasses generatedClasses;
+	public final @NotNull GeneratePhase generatePhase;
 	final                  Multimap<OS_Module, Consumer<DeduceTypes2>>  iWantModules            = ArrayListMultimap.create();
 	private final          String                                       PHASE                   = "DeducePhase";
 	private @NotNull
@@ -62,8 +62,8 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 	@NotNull
 	public final           List<IFunctionMapHook>                       functionMapHooks        = _inj().new_ArrayList__IFunctionMapHook();
 	@Getter
-	private final @NotNull ICodeRegistrar                               codeRegistrar;
-	private final @NotNull ICompilationAccess                           ca;
+	private final @NotNull ICodeRegistrar codeRegistrar;
+	private final @NotNull ICompilationAccess ca;
 	private final          Map<NamespaceStatement, NamespaceInvocation> namespaceInvocationMap  = _inj()
 			.new_HashMap__NamespaceInvocationMap();
 	private final          ExecutorService                              classGenerator          = Executors.newCachedThreadPool();
@@ -73,16 +73,16 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 	private final          List<FoundElement>                           foundElements           = _inj().new_ArrayList__FoundElement();
 	private final          Multimap<FunctionDef, EvaFunction>           functionMap             = ArrayListMultimap.create();
 	private final          Map<IdentTableEntry, OnType>                 idte_type_callbacks     = _inj().new_HashMap__IdentTableEntry();
-	private final @NotNull ElLog                                        LOG;
-	private final @NotNull PipelineLogic                                pipelineLogic;
+	private final @NotNull ElLog LOG;
+	private final @NotNull PipelineLogic pipelineLogic;
 	private final          List<DE3_Active>                             _actives                = _inj().new_ArrayList__DE3_Active();
-	private final @NotNull Multimap<ClassStatement, ClassInvocation>    classInvocationMultimap = ArrayListMultimap
+	private final @NotNull Multimap<ClassStatement, ClassInvocation> classInvocationMultimap = ArrayListMultimap
 			.create();
-	private final @NotNull List<DeferredMember>                         deferredMembers         = _inj().new_ArrayList__DeferredMember();
-	private final @NotNull Multimap<ClassStatement, OnClass>            onclasses               = ArrayListMultimap.create();
-	private final @NotNull Multimap<OS_Element, ResolvedVariables>      resolved_variables      = ArrayListMultimap.create();
-	private final @NotNull DRS                                          drs                     = _inj().new_DRS();
-	private final @NotNull WAITS                                        waits                   = _inj().new_WAITS();
+	private final @NotNull List<DeferredMember> deferredMembers = _inj().new_ArrayList__DeferredMember();
+	private final @NotNull Multimap<ClassStatement, OnClass> onclasses = ArrayListMultimap.create();
+	private final @NotNull Multimap<OS_Element, ResolvedVariables> resolved_variables = ArrayListMultimap.create();
+	private final @NotNull DRS drs = _inj().new_DRS();
+	private final @NotNull WAITS waits = _inj().new_WAITS();
 	public                 IPipelineAccess                              pa;
 	private EventualRegister der = new DefaultEventualRegister();
 
@@ -91,7 +91,7 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 	}
 
 	public DeducePhase(final @NotNull ICompilationAccess aca, final @NotNull IPipelineAccess pa0,
-	                   final @NotNull PipelineLogic aPipelineLogic) {
+			final @NotNull PipelineLogic aPipelineLogic) {
 		// given
 		pipelineLogic = aPipelineLogic;
 		ca            = aca;
@@ -341,14 +341,14 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 	}
 
 	public void forFunction(@NotNull DeduceTypes2 deduceTypes2,
-	                        @NotNull FunctionInvocation fi,
-	                        @NotNull ForFunction forFunction) {
+			@NotNull FunctionInvocation fi,
+			@NotNull ForFunction forFunction) {
 //		LOG.err("272 forFunction\n\t"+fi.getFunction()+"\n\t"+fi.pte);
 		fi.generateDeferred().then(result -> result.typePromise().then(forFunction::typeDecided));
 	}
 
 	public @NotNull Eventual<ClassDefinition> generateClass2(final GenerateFunctions gf,
-	                                                         final @NotNull ClassInvocation ci,
+			final @NotNull ClassInvocation ci,
 	                                                         final WorkManager wm) {
 		final Eventual<ClassDefinition> ret = new Eventual<>();
 
@@ -379,7 +379,8 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 	}
 
 	public void handleDeferredMemberFunctions() {
-		for (@NotNull final DeferredMemberFunction deferredMemberFunction : deferredMemberFunctions) {
+		for (@NotNull
+		final DeferredMemberFunction deferredMemberFunction : deferredMemberFunctions) {
 			int              y      = 2;
 			final OS_Element parent = deferredMemberFunction.getParent();// .getParent().getParent();
 
@@ -402,7 +403,7 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 
 				namespaceInvocation.resolvePromise().then((final @NotNull EvaNamespace result) -> {
 					final NamespaceInvocation             x  = namespaceInvocation;
-					final @NotNull DeferredMemberFunction z  = deferredMemberFunction;
+					final @NotNull DeferredMemberFunction z = deferredMemberFunction;
 					int                                   yy = 2;
 				});
 			}
@@ -425,7 +426,8 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 	}
 
 	public void handleDeferredMembers() {
-		for (@NotNull final DeferredMember deferredMember : deferredMembers) {
+		for (@NotNull
+		final DeferredMember deferredMember : deferredMembers) {
 			if (deferredMember.getParent().isNamespaceStatement()) {
 				final @NotNull NamespaceStatement parent = (NamespaceStatement) deferredMember.getParent().element();
 				final NamespaceInvocation         nsi    = registerNamespaceInvocation(parent);
@@ -599,7 +601,7 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 	}
 
 	public @NotNull FunctionInvocation newFunctionInvocation(final FunctionDef f, final @Nullable ProcTableEntry aO,
-	                                                         final @NotNull IInvocation ci) {
+			final @NotNull IInvocation ci) {
 		return _inj().new_FunctionInvocation(f, aO, ci, this.generatePhase);
 	}
 
@@ -616,7 +618,8 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 		return rci.registerClassInvocation(aClassInvocation);
 	}
 
-	public @NotNull ClassInvocation registerClassInvocation(final @NotNull ClassStatement aParent, final DeduceTypes2 dtt) {
+	public @NotNull ClassInvocation registerClassInvocation(final @NotNull ClassStatement aParent,
+			final DeduceTypes2 dtt) {
 		Supplier<DeduceTypes2> dt2s;
 		if (dtt == null) {
 			dt2s= new NULL_DeduceTypes2();
@@ -681,7 +684,7 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 			if (evaNode instanceof final @NotNull EvaClass evaClass) {
 				sanityChecks(evaClass.functionMap.values());
 //				sanityChecks(generatedClass.constructors.values()); // TODO reenable
-			} else if (evaNode instanceof final @NotNull EvaNamespace generatedNamespace) {
+} else if (evaNode instanceof final @NotNull EvaNamespace generatedNamespace) {
 				sanityChecks(generatedNamespace.functionMap.values());
 //				sanityChecks(generatedNamespace.constructors.values());
 			}
@@ -781,7 +784,7 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 
 	static class ResolvedVariables {
 		final          IdentTableEntry identTableEntry;
-		final @NotNull OS_Element      parent; // README tripleo.elijah.lang._CommonNC, but that's package-private
+		final @NotNull OS_Element parent; // README tripleo.elijah.lang._CommonNC, but that's package-private
 		final          String          varName;
 
 		public ResolvedVariables(IdentTableEntry aIdentTableEntry, OS_Element aParent, String aVarName) {
@@ -858,7 +861,7 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 		}
 
 		public @NotNull ClassInvocation new_ClassInvocation(final ClassStatement aParent, final String aConstructorName,
-		                                                    final @NotNull Supplier<DeduceTypes2> aDeduceTypes2Supplier) {
+				final @NotNull Supplier<DeduceTypes2> aDeduceTypes2Supplier) {
 			return new ClassInvocation(aParent, aConstructorName, aDeduceTypes2Supplier);
 		}
 
@@ -999,7 +1002,7 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 		<T extends EvaNode> void defaultAction(final T result) {
 			final OS_Element p = deferredMemberFunction.getParent();
 
-			if (p instanceof final @NotNullOS_SpecialVariable specialVariable) {
+			if (p instanceof final @NotNull OS_SpecialVariable specialVariable) {
 				onSpecialVariable(specialVariable);
 				int y = 2;
 			} else if (p instanceof ClassStatement) {
@@ -1140,7 +1143,7 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 		public Eventual<ClassDefinition> getClassInvocationPromise(final @NotNull ClassInvocation aClassInvocation,
 		                                                           @Nullable OS_Module mod,
 		                                                           final @Nullable WorkList wl,
-		                                                           final @NotNull RegisterClassInvocation_env aEnv) {
+				final @NotNull RegisterClassInvocation_env aEnv) {
 			if (mod == null) {
 				mod = aClassInvocation.getKlass().getContext().module();
 			}
@@ -1168,7 +1171,7 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 		}
 
 		private @NotNull ClassInvocation getClassInvocation(final @NotNull ClassInvocation aClassInvocation,
-		                                                    OS_Module mod, final WorkList wl, final @NotNull RegisterClassInvocation_env aEnv) {
+				OS_Module mod, final WorkList wl, final @NotNull RegisterClassInvocation_env aEnv) {
 			if (mod == null)
 				mod = aClassInvocation.getKlass().getContext().module();
 
@@ -1189,7 +1192,7 @@ public class DeducePhase extends _RegistrationTarget implements ReactiveDimensio
 
 		private @NotNull ClassInvocation part2(final @NotNull ClassInvocation aClassInvocation,
 		                                       boolean put,
-		                                       final @NotNull RegisterClassInvocation_env aEnv) {
+				final @NotNull RegisterClassInvocation_env aEnv) {
 			// 2. Check and see if already done
 			Collection<ClassInvocation> cls = classInvocationMultimap.get(aClassInvocation.getKlass());
 			for (@NotNull

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceProcCall.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceProcCall.java
@@ -11,6 +11,7 @@ package tripleo.elijah.stages.deduce;
 
 import org.jdeferred2.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.diagnostic.*;
@@ -34,8 +35,8 @@ public class DeduceProcCall {
 		 * around (invocation.pte is the call site (MainLogic::main))
 		 */
 		public DeclTarget(final @NotNull OS_Element aBest,
-						  final @NotNull OS_Element aDeclAnchor,
-						  final @NotNull DeclAnchor.AnchorType aAnchorType) throws FCA_Stop {
+				final @NotNull OS_Element aDeclAnchor,
+				final @NotNull DeclAnchor.AnchorType aAnchorType) throws FCA_Stop {
 			element = aBest;
 			anchor = _g_deduceTypes2._inj().new_DeclAnchor(aDeclAnchor, aAnchorType);
 			final Eventual<IInvocation> invocationP = new Eventual<>();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceTypeResolve.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceTypeResolve.java
@@ -9,8 +9,11 @@
  */
 package tripleo.elijah.stages.deduce;
 
+import java.util.function.*;
+
 import org.jdeferred2.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.contexts.*;
 import tripleo.elijah.lang.i.*;
@@ -19,8 +22,6 @@ import tripleo.elijah.stages.deduce.post_bytecode.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.util.*;
-
-import java.util.function.*;
 
 /**
  * Created 11/18/21 12:02 PM
@@ -59,7 +60,7 @@ public class DeduceTypeResolve {
 		private void _203_backlink_is_VTE(final @NotNull GenType aGenType, final IElementHolder eh,
 				final @NotNull VariableTableEntry variableTableEntry) {
 			if (eh instanceof final Resolve_Ident_IA.@NotNull GenericElementHolderWithDC eh1) {
-				final DeduceTypes2.DeduceClient3 dc = eh1.getDC();
+				final DeduceClient3 dc = eh1.getDC();
 				dc.genCIForGenType2(aGenType);
 			}
 			// maybe set something in ci to INHERITED, but that's what DeduceProcCall is for
@@ -280,11 +281,11 @@ public class DeduceTypeResolve {
 		}
 	}
 
-	private DeduceTypes2.DeduceTypes2Injector _inj() {
+	private DeduceTypes2Injector _inj() {
 		return _dt2s.get()._inj();
 	}
 
-	private void _inj_then(final DoneCallback<DeduceTypes2.DeduceTypes2Injector> i) {
+	private void _inj_then(final DoneCallback<DeduceTypes2Injector> i) {
 		if (_dt2s instanceof PromiseReadySupplier<DeduceTypes2> prs) {
 			prs.then(q -> i.onDone(q._inj()));
 		}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceTypes2.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceTypes2.java
@@ -277,7 +277,7 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	public void onEnterFunction(final @NotNull BaseEvaFunction generatedFunction1, final Context aContext) {
-		final DT_Function generatedFunction = new _DT_Function(this, generatedFunction1, this);
+		final DT_Function generatedFunction = new _DT_Function(this, generatedFunction1);
 
 		for (VariableTableEntry variableTableEntry : generatedFunction.vte_list()) {
 			variableTableEntry.setDeduceTypes2(this, aContext, generatedFunction.get());
@@ -1141,7 +1141,8 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 		return true;
 	}
 
-	private @NotNull DeferredMember deferred_member(final @NotNull DeduceElementWrapper aParent,
+	@NotNull
+	DeferredMember deferred_member(final @NotNull DeduceElementWrapper aParent,
 			final /* @NotNull */ IInvocation aInvocation, final @NotNull VariableStatementImpl aVariableStatement,
 			final @NotNull IdentTableEntry ite) {
 		@NotNull
@@ -1225,7 +1226,8 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 		return module.getFileName();
 	}
 
-	private @Nullable IInvocation getInvocationFromBacklink(@Nullable InstructionArgument aBacklink) {
+	@Nullable
+	IInvocation getInvocationFromBacklink(@Nullable InstructionArgument aBacklink) {
 		if (aBacklink == null) {
 			return null;
 		} else {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceTypes2.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceTypes2.java
@@ -9,96 +9,78 @@
  */
 package tripleo.elijah.stages.deduce;
 
-import io.reactivex.rxjava3.annotations.NonNull;
-import io.reactivex.rxjava3.core.Observer;
-import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.subjects.Subject;
-import org.jdeferred2.DoneCallback;
-import org.jdeferred2.impl.DeferredObject;
+import java.util.*;
+
+import org.jdeferred2.*;
 import org.jetbrains.annotations.*;
-import tripleo.elijah.Eventual;
-import tripleo.elijah.ReadySupplier_1;
-import tripleo.elijah.comp.i.ErrSink;
-import tripleo.elijah.comp.i.ICompilationAccess;
-import tripleo.elijah.comp.i.extra.IPipelineAccess;
-import tripleo.elijah.diagnostic.Diagnostic;
-import tripleo.elijah.g.GCompilationEnclosure;
-import tripleo.elijah.g.GModuleThing;
+
+import tripleo.elijah.*;
+import tripleo.elijah.comp.i.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.lang.nextgen.names.i.*;
 import tripleo.elijah.lang.nextgen.names.impl.*;
 import tripleo.elijah.lang.types.*;
 import tripleo.elijah.lang2.*;
-import tripleo.elijah.nextgen.ClassDefinition;
-import tripleo.elijah.nextgen.reactive.Reactivable;
-import tripleo.elijah.stages.deduce.Resolve_Ident_IA.DeduceElementIdent;
-import tripleo.elijah.stages.deduce.declarations.DeferredMember;
-import tripleo.elijah.stages.deduce.declarations.DeferredMemberFunction;
+import tripleo.elijah.stages.deduce.Resolve_Ident_IA.*;
+import tripleo.elijah.stages.deduce.declarations.*;
 import tripleo.elijah.stages.deduce.nextgen.*;
 import tripleo.elijah.stages.deduce.post_bytecode.*;
 import tripleo.elijah.stages.deduce.tastic.*;
 import tripleo.elijah.stages.gen_fn.*;
-import tripleo.elijah.stages.gen_generic.ICodeRegistrar;
-import tripleo.elijah.stages.gen_generic.pipeline_impl.DefaultGenerateResultSink;
-import tripleo.elijah.stages.gen_generic.pipeline_impl.GenerateResultSink;
 import tripleo.elijah.stages.instructions.*;
-import tripleo.elijah.stages.inter.ModuleThing;
-import tripleo.elijah.stages.logging.ElLog;
-import tripleo.elijah.stages.logging.ElLog_;
+import tripleo.elijah.stages.inter.*;
+import tripleo.elijah.stages.logging.*;
 import tripleo.elijah.util.*;
 import tripleo.elijah.work.*;
-import tripleo.elijah_elevated.comp.backbone.CompilationEnclosure;
-
-import java.util.*;
-import java.util.function.Supplier;
-import java.util.regex.Pattern;
+import tripleo.elijah_elevated.comp.backbone.*;
 
 /**
  * Created 9/15/20 12:51 PM
  */
 public class DeduceTypes2 implements GDeduceTypes2 {
-	private static final   String                   PHASE = "DeduceTypes2";
-	public final @NotNull  ElLog                    LOG;
-	public final @NotNull  OS_Module                module;
-	public final @NotNull  DeducePhase              phase;
-	public final @NotNull  WorkManager              wm;
-	private final          DeduceTypes2Injector     __inj;
-	private final          Zero                     _p_zero;
-	private final          ITasticMap               _p_tasticMap;
-	private final          DeduceCentral            _p_central;
-	private final  Map<OS_Element, DG_Item> _map_dgs;
-	final @NotNull List<Runnable>           onRunnables;
+	private static final String PHASE = "DeduceTypes2";
+	public final @NotNull ElLog LOG;
+	public final @NotNull OS_Module module;
+	public final @NotNull DeducePhase phase;
+	public final @NotNull WorkManager wm;
+	final @NotNull List<Runnable> onRunnables;
+	final _A_active _a_active = new _A_active(this);
+	private final DeduceTypes2Injector __inj;
+	private final Zero _p_zero;
+	private final ITasticMap _p_tasticMap;
+	private final DeduceCentral _p_central;
+	private final Map<OS_Element, DG_Item> _map_dgs;
 	@SuppressWarnings("FieldCanBeLocal")
-	private final  List<FunctionInvocation> functionInvocations; // TODO never used
-	private final          List<IDeduceResolvable>  _pendingResolves;
-	private final          ErrSink                  errSink;
-	private final          PromiseExpectations      expectations;
-	private final          DeduceCreationContext    _defaultCreationContext;
-	private final @NotNull List<DT_External>        externals;
+	private final List<FunctionInvocation> functionInvocations; // TODO never used
+	private final List<IDeduceResolvable> _pendingResolves;
+	private final ErrSink errSink;
+	private final PromiseExpectations expectations;
+	private final DeduceCreationContext _defaultCreationContext;
+	private final @NotNull List<DT_External> externals;
 
 	public DeduceTypes2(@NotNull OS_Module module, @NotNull DeducePhase phase) {
 		this(module, phase, ElLog_.Verbosity.VERBOSE);
 	}
 
 	public DeduceTypes2(@NotNull OS_Module aModule, @NotNull DeducePhase aDeducePhase, ElLog_.Verbosity aVerbosity) {
-		__inj                   = new DeduceTypes2Injector();
-		wm                      = _inj().new_WorkManager();
-		_p_tasticMap            = _inj().new_TasticMap();
-		_p_central              = _inj().new_DeduceCentral(this);
-		onRunnables             = _inj().new_ArrayList__Runnable();
-		_pendingResolves        = _inj().new_ArrayList__IDeduceResolvable();
-		expectations            = _inj().new_PromiseExpectations(this);
+		__inj = new DeduceTypes2Injector();
+		wm = _inj().new_WorkManager();
+		_p_tasticMap = _inj().new_TasticMap();
+		_p_central = _inj().new_DeduceCentral(this);
+		onRunnables = _inj().new_ArrayList__Runnable();
+		_pendingResolves = _inj().new_ArrayList__IDeduceResolvable();
+		expectations = _inj().new_PromiseExpectations(this);
 		_defaultCreationContext = _inj().new_DefaultDeduceCreationContext(this);
-		externals               = _inj().new_LinkedList__DT_External();
-		functionInvocations     = _inj().new_ArrayList__FunctionInvocation();
-		_map_dgs                = _inj().new_HashMap_DGS();
-		_p_zero                 = _inj().new_Zero(this);
+		externals = _inj().new_LinkedList__DT_External();
+		functionInvocations = _inj().new_ArrayList__FunctionInvocation();
+		_map_dgs = _inj().new_HashMap_DGS();
+		_p_zero = _inj().new_Zero(this);
 
-		this.module  = aModule;
-		this.phase   = aDeducePhase;
+		this.module = aModule;
+		this.phase = aDeducePhase;
 		this.errSink = aModule.getCompilation().getErrSink();
-		this.LOG     = _inj().new_ElLog(aModule.getFileName(), aVerbosity, PHASE);
+		this.LOG = _inj().new_ElLog(aModule.getFileName(), aVerbosity, PHASE);
 		//
 		aDeducePhase.addLog(LOG);
 		//
@@ -133,11 +115,9 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	public DeduceElement3_IdentTableEntry _zero_getIdent(final IdentTableEntry aIdentTableEntryBte,
-														 final BaseEvaFunction aGf, final DeduceTypes2 aDt2) {
+			final BaseEvaFunction aGf, final DeduceTypes2 aDt2) {
 		return _p_zero.getIdent(aIdentTableEntryBte, aGf, aDt2);
 	}
-
-	final _A_active _a_active = new _A_active(this);
 
 	public void activePTE(@NotNull ProcTableEntry aProcTableEntry, ClassInvocation aClassInvocation) {
 		_a_active.activePTE(this, aProcTableEntry, aClassInvocation);
@@ -148,8 +128,8 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	public void addResolvePending(final IDeduceResolvable aResolvable,
-								  final IDeduceElement_old aDeduceElement,
-								  final Holder<OS_Element> aHolder) {
+			final IDeduceElement_old aDeduceElement,
+			final Holder<OS_Element> aHolder) {
 		assert !hasResolvePending(aResolvable);
 
 		_pendingResolves.add(aResolvable);
@@ -161,7 +141,7 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	public void assign_type_to_idte(@NotNull IdentTableEntry ite, @NotNull BaseEvaFunction generatedFunction,
-									@NotNull Context aFunctionContext, @NotNull Context aContext) {
+			@NotNull Context aFunctionContext, @NotNull Context aContext) {
 
 		final DeduceElement3_IdentTableEntry x = ite.getDeduceElement3(this, generatedFunction);
 		x.assign_type_to_idte(aFunctionContext, aContext);
@@ -180,14 +160,14 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	public void deduce_generated_function_base(final @NotNull BaseEvaFunction generatedFunction,
-											   final @NotNull FunctionDef fd,
-											   final @NotNull ModuleThing ignoredAMt) {
+			final @NotNull FunctionDef fd,
+			final @NotNull ModuleThing ignoredAMt) {
 		fix_tables(generatedFunction);
 
 		final Context fd_ctx = fd.getContext();
 		//
 		{
-			ProcTableEntry        pte        = generatedFunction.fi.pte;
+			ProcTableEntry pte = generatedFunction.fi.pte;
 			final @NotNull String pte_string = getPTEString(pte);
 			LOG.info("** deduce_generated_function " + fd.name() + " " + pte_string);// +"
 			// "+((OS_Container)((FunctionDef)fd).getParent()).name());
@@ -207,46 +187,46 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 				@Override
 				public void run() {
 					switch (instruction.getName()) {
-					case E -> onEnterFunction(generatedFunction, context);
-					case X -> onExitFunction(fd_ctx, context, dw);
-					case ES -> {
-					}
-					case XS -> {
-					}
-					case AGN -> do_assign_normal(generatedFunction, fd_ctx, instruction, context);
-					case AGNK -> do_agnk(generatedFunction, instruction);
-					case AGNT -> {
-					}
-					case AGNF -> LOG.info("292 Encountered AGNF");
-					case JE -> LOG.info("296 Encountered JE");
-					case JNE -> {
-					}
-					case JL -> {
-					}
-					case JMP -> {
-					}
-					case CALL -> do_call(generatedFunction, fd, instruction, context);
-					case CALLS -> do_calls(generatedFunction, fd_ctx, instruction);
-					case RET -> {
-					}
-					case YIELD -> {
-					}
-					case TRY -> {
-					}
-					case PC -> {
-					}
-					case CAST_TO -> {
-						// README potentialType info is already added by MatchConditional
-					}
-					case DECL -> {
-						// README for GenerateC, etc: marks the spot where a declaration should go.
-						// Wouldn't be necessary if we had proper Range's
-					}
-					case IS_A -> implement_is_a(generatedFunction, instruction);
-					case NOP -> {
-					}
-					case CONSTRUCT -> implement_construct(generatedFunction, instruction, context);
-					default -> throw new IllegalStateException("Unexpected value: " + instruction.getName());
+						case E -> onEnterFunction(generatedFunction, context);
+						case X -> onExitFunction(fd_ctx, context, dw);
+						case ES -> {
+						}
+						case XS -> {
+						}
+						case AGN -> do_assign_normal(generatedFunction, fd_ctx, instruction, context);
+						case AGNK -> do_agnk(generatedFunction, instruction);
+						case AGNT -> {
+						}
+						case AGNF -> LOG.info("292 Encountered AGNF");
+						case JE -> LOG.info("296 Encountered JE");
+						case JNE -> {
+						}
+						case JL -> {
+						}
+						case JMP -> {
+						}
+						case CALL -> do_call(generatedFunction, fd, instruction, context);
+						case CALLS -> do_calls(generatedFunction, fd_ctx, instruction);
+						case RET -> {
+						}
+						case YIELD -> {
+						}
+						case TRY -> {
+						}
+						case PC -> {
+						}
+						case CAST_TO -> {
+							// README potentialType info is already added by MatchConditional
+						}
+						case DECL -> {
+							// README for GenerateC, etc: marks the spot where a declaration should go.
+							// Wouldn't be necessary if we had proper Range's
+						}
+						case IS_A -> implement_is_a(generatedFunction, instruction);
+						case NOP -> {
+						}
+						case CONSTRUCT -> implement_construct(generatedFunction, instruction, context);
+						default -> throw new IllegalStateException("Unexpected value: " + instruction.getName());
 					}
 				}
 			});
@@ -254,20 +234,6 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 		__post_vte_list_001(generatedFunction);
 		__post_vte_list_002(generatedFunction, fd_ctx);
 		__post_deferred_calls(generatedFunction, fd_ctx);
-	}
-
-	private void logProgressRunnable(final String aS, final ElLog.Progress aProgress, final Runnable aRunnable) {
-		switch (aProgress) {
-		case INFO -> {
-			LOG.info(aS);
-		}
-		case ERR -> {
-			LOG.err(aS);
-		}
-		default -> throw new ProgramIsLikelyWrong("Unexpected value: " + aProgress);
-		}
-
-		aRunnable.run();
 	}
 
 	public void fix_tables(final @NotNull BaseEvaFunction evaFunction) {
@@ -296,8 +262,22 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 		return pte_string;
 	}
 
+	private void logProgressRunnable(final String aS, final ElLog.Progress aProgress, final Runnable aRunnable) {
+		switch (aProgress) {
+			case INFO -> {
+				LOG.info(aS);
+			}
+			case ERR -> {
+				LOG.err(aS);
+			}
+			default -> throw new ProgramIsLikelyWrong("Unexpected value: " + aProgress);
+		}
+
+		aRunnable.run();
+	}
+
 	public void onEnterFunction(final @NotNull BaseEvaFunction generatedFunction1, final Context aContext) {
-		final DT_Function generatedFunction = new _DT_Function(generatedFunction1, this);
+		final DT_Function generatedFunction = new _DT_Function(this, generatedFunction1, this);
 
 		for (VariableTableEntry variableTableEntry : generatedFunction.vte_list()) {
 			variableTableEntry.setDeduceTypes2(this, aContext, generatedFunction.get());
@@ -333,11 +313,11 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	public void onExitFunction(final Context aFd_ctx,
-							   final Context aContext,
-							   final DW_onExitFunction dw) {
+			final Context aContext,
+			final DW_onExitFunction dw) {
 		dw.resolve_var_table();
 		dw.runRunnables();
-//					LOG.info("167 "+generatedFunction);
+		// LOG.info("167 "+generatedFunction);
 
 		dw.attachVTEs();
 		dw.checkVteList();
@@ -360,7 +340,7 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	public void do_assign_normal(final @NotNull BaseEvaFunction generatedFunction, final @NotNull Context aFd_ctx,
-								 final @NotNull Instruction instruction, final @NotNull Context aContext) {
+			final @NotNull Instruction instruction, final @NotNull Context aContext) {
 		// TODO doesn't account for __assign__
 		final InstructionArgument agn_lhs = instruction.getArg(0);
 		if (agn_lhs instanceof IntegerIA lhs_integerIA) {
@@ -371,14 +351,14 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 				final OS_Element[] el1 = new OS_Element[1];
 
 				switch (vte.getVtt()) {
-				case ARG -> {
-					vte.elementPromise(el0 -> el1[0] = el0, null);
-					name = el1[0];
-				}
-				case VAR -> {
-					vte.elementPromise(el0 -> el1[0] = el0, null);
-					name = el1[0];
-				}
+					case ARG -> {
+						vte.elementPromise(el0 -> el1[0] = el0, null);
+						name = el1[0];
+					}
+					case VAR -> {
+						vte.elementPromise(el0 -> el1[0] = el0, null);
+						name = el1[0];
+					}
 				}
 			}
 
@@ -403,7 +383,7 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 				if (cte.type.getAttached() == null) {
 					LOG.info("Null type in CTE " + cte);
 				}
-//		vte.type = cte.type;
+				// vte.type = cte.type;
 				vte.addPotentialType(instruction.getIndex(), cte.type);
 				DebugPrint.addPotentialType(vte, cte);
 			} else if (i2 instanceof IdentIA identIA) {
@@ -419,7 +399,7 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 				throw new NotImplementedException();
 		} else if (agn_lhs instanceof IdentIA arg) {
 			final @NotNull IdentTableEntry agn_lhs_ite = arg.getEntry();
-			final InstructionArgument      agn_rhs_ia  = instruction.getArg(1);
+			final InstructionArgument agn_rhs_ia = instruction.getArg(1);
 			if (agn_rhs_ia instanceof IntegerIA) {
 				final @NotNull VariableTableEntry vte2 = generatedFunction.getVarTableEntry(to_int(agn_rhs_ia));
 				agn_lhs_ite.addPotentialType(instruction.getIndex(), vte2.getTypeTableEntry());
@@ -443,10 +423,10 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	private void do_agnk(final @NotNull BaseEvaFunction generatedFunction, final @NotNull Instruction instruction) {
-		final @NotNull IntegerIA          arg  = (IntegerIA) instruction.getArg(0);
-		final @NotNull VariableTableEntry vte  = generatedFunction.getVarTableEntry(arg.getIndex());
-		final InstructionArgument         i2   = instruction.getArg(1);
-		final @NotNull ConstTableIA       ctia = (ConstTableIA) i2;
+		final @NotNull IntegerIA arg = (IntegerIA) instruction.getArg(0);
+		final @NotNull VariableTableEntry vte = generatedFunction.getVarTableEntry(arg.getIndex());
+		final InstructionArgument i2 = instruction.getArg(1);
+		final @NotNull ConstTableIA ctia = (ConstTableIA) i2;
 
 		{
 			if (vte.getTypeTableEntry().getAttached() != null) {
@@ -456,26 +436,26 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 			if (cte.type.getAttached() == null) {
 				LOG.info("Null type in CTE " + cte);
 			}
-//		vte.type = cte.type;
+			// vte.type = cte.type;
 			vte.addPotentialType(instruction.getIndex(), cte.type);
 			DebugPrint.addPotentialType(vte, cte);
 		}
 	}
 
 	private void do_call(final @NotNull BaseEvaFunction generatedFunction, final @NotNull FunctionDef fd,
-						 final @NotNull Instruction instruction, final @NotNull Context context) {
-		final int                     pte_num = ((ProcIA) instruction.getArg(0)).index();
-		final @NotNull ProcTableEntry pte     = generatedFunction.getProcTableEntry(pte_num);
-//				final InstructionArgument i2 = (instruction.getArg(1));
+			final @NotNull Instruction instruction, final @NotNull Context context) {
+		final int pte_num = ((ProcIA) instruction.getArg(0)).index();
+		final @NotNull ProcTableEntry pte = generatedFunction.getProcTableEntry(pte_num);
+		// final InstructionArgument i2 = (instruction.getArg(1));
 		{
 			final @NotNull IdentIA identIA = (IdentIA) pte.expression_num;
 
 			final IdentTableEntry identTableEntry = identIA.getEntry();
-			var                   idnt            = generatedFunction.getIdent(identTableEntry);
+			var idnt = generatedFunction.getIdent(identTableEntry);
 
 			{
 				ENU_ResolveToFunction rtf = null;
-				var                   x   = identTableEntry.getIdent().getName();
+				var x = identTableEntry.getIdent().getName();
 
 				for (EN_Understanding understanding : x.getUnderstandings()) {
 					if (understanding instanceof ENU_ResolveToFunction rtf1) {
@@ -485,7 +465,7 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 				for (EN_Usage usage : x.getUsages()) {
 					if (usage instanceof EN_DeduceUsage edu) {
 						final ProcTableEntry callable_pte = ((IdentTableEntry) edu.getBte())._callable_pte();
-						var                  e            = callable_pte.__debug_expression;
+						var e = callable_pte.__debug_expression;
 						if (e instanceof DotExpression de) {
 							var r = de.getRight();
 							if (r instanceof IdentExpression ie) {
@@ -496,8 +476,8 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 				}
 			}
 
-			var          xx = generatedFunction._getIdentIAResolvable(identIA);
-			final String x  = xx.getNormalPath(generatedFunction, identIA);
+			var xx = generatedFunction._getIdentIAResolvable(identIA);
+			final String x = xx.getNormalPath(generatedFunction, identIA);
 			LOG.info("298 Calling " + x);
 			resolveIdentIA_(context, identIA, generatedFunction, new FoundElement(phase) {
 
@@ -507,7 +487,7 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 				@Override
 				public void foundElement(OS_Element e) {
 					found_element_for_ite(generatedFunction, identIA.getEntry(), e, context, central());
-//							identIA.getEntry().setCallablePTE(pte); // TODO ??
+					// identIA.getEntry().setCallablePTE(pte); // TODO ??
 
 					pte.setStatus(BaseTableEntry.Status.KNOWN, _inj().new_ConstructableElementHolder(e, identIA));
 					if (fd instanceof DefFunctionDef) {
@@ -538,9 +518,9 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	private void do_calls(final @NotNull BaseEvaFunction generatedFunction, final @NotNull Context fd_ctx,
-						  final @NotNull Instruction instruction) {
-		final int                     i1  = to_int(instruction.getArg(0));
-		final InstructionArgument     i2  = (instruction.getArg(1));
+			final @NotNull Instruction instruction) {
+		final int i1 = to_int(instruction.getArg(0));
+		final InstructionArgument i2 = (instruction.getArg(1));
 		final @NotNull ProcTableEntry fn1 = generatedFunction.getProcTableEntry(i1);
 		{
 			final int pc = instruction.getIndex();
@@ -559,19 +539,19 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	private void implement_is_a(final @NotNull BaseEvaFunction gf, final @NotNull Instruction instruction) {
-		final IntegerIA testing_var_  = (IntegerIA) instruction.getArg(0);
+		final IntegerIA testing_var_ = (IntegerIA) instruction.getArg(0);
 		final IntegerIA testing_type_ = (IntegerIA) instruction.getArg(1);
-		final Label     target_label  = ((LabelIA) instruction.getArg(2)).label;
+		final Label target_label = ((LabelIA) instruction.getArg(2)).label;
 
-		final VariableTableEntry testing_var    = gf.getVarTableEntry(testing_var_.getIndex());
-		final TypeTableEntry     testing_type__ = gf.getTypeTableEntry(testing_type_.getIndex());
+		final VariableTableEntry testing_var = gf.getVarTableEntry(testing_var_.getIndex());
+		final TypeTableEntry testing_type__ = gf.getTypeTableEntry(testing_type_.getIndex());
 
 		GenType genType = testing_type__.genType;
 		if (genType.getResolved() == null) {
 			try {
 				genType.setResolved(resolve_type(genType.getTypeName(), gf.getFD().getContext()).getResolved());
 			} catch (ResolveError aResolveError) {
-//				aResolveError.printStackTrace();
+				// aResolveError.printStackTrace();
 				errSink.reportDiagnostic(aResolveError);
 				return;
 			}
@@ -585,15 +565,14 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 						getGenerateFunctions(module),
 						(ClassInvocation) genType.getCi(),
 						phase.generatedClasses,
-						phase.getCodeRegistrar()
-																);
+						phase.getCodeRegistrar());
 
 				gen.setConsumer(genType::setNode);
 
 				gen.run(null);
 			} else if (genType.getCi() instanceof NamespaceInvocation) {
 				WlGenerateNamespace gen = _inj().new_WlGenerateNamespace(getGenerateFunctions(module),
-																		 (NamespaceInvocation) genType.getCi(), phase.generatedClasses, phase.getCodeRegistrar());
+						(NamespaceInvocation) genType.getCi(), phase.generatedClasses, phase.getCodeRegistrar());
 				gen.run(null);
 				genType.setNode(gen.getResult());
 			}
@@ -629,7 +608,7 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 					vte.getTypeTableEntry().setAttached(gt);
 				} else if (xx instanceof EvaConstructor evaConstructor) {
 					if (gt.getCi() == null) {
-//						gt.ci = evaConstructor.ci;
+						// gt.ci = evaConstructor.ci;
 					}
 
 					gt.setResolved(evaConstructor.fi.getClassInvocation().getKlass().getOS_Type());
@@ -660,7 +639,7 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 				}
 			} else if (vte.getVtt() == VariableTableType.RESULT) {
 
-				int           state    = 0;
+				int state = 0;
 				final OS_Type attached = vte.getTypeTableEntry().getAttached();
 				if (attached.getType() == OS_Type.Type.USER) {
 					try {
@@ -686,20 +665,20 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	private void __post_deferred_calls(final @NotNull BaseEvaFunction generatedFunction,
-									   final @NotNull Context fd_ctx) {
+			final @NotNull Context fd_ctx) {
 		//
 		// NOW CALCULATE DEFERRED CALLS
 		//
 		for (final Integer deferred_call : generatedFunction.deferred_calls) {
 			final Instruction instruction = generatedFunction.getInstruction(deferred_call);
 
-			final int                     i1  = to_int(instruction.getArg(0));
-			final InstructionArgument     i2  = (instruction.getArg(1));
+			final int i1 = to_int(instruction.getArg(0));
+			final InstructionArgument i2 = (instruction.getArg(1));
 			final @NotNull ProcTableEntry fn1 = generatedFunction.getProcTableEntry(i1);
 			{
-//				generatedFunction.deferred_calls.remove(deferred_call);
+				// generatedFunction.deferred_calls.remove(deferred_call);
 				Implement_Calls_ ic = _inj().new_Implement_Calls_(generatedFunction, fd_ctx, i2, fn1,
-																  instruction.getIndex(), this);
+						instruction.getIndex(), this);
 				ic.action();
 			}
 		}
@@ -708,42 +687,33 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	private void resolve_cte_expression(@NotNull ConstantTableEntry cte, Context aContext) {
 		final IExpression initialValue = cte.initialValue;
 		switch (initialValue.getKind()) {
-		case NUMERIC:
-			resolve_cte_expression_builtin(cte, aContext, BuiltInTypes.SystemInteger);
-			break;
-		case STRING_LITERAL:
-			resolve_cte_expression_builtin(cte, aContext, BuiltInTypes.String_);
-			break;
-		case CHAR_LITERAL:
-			resolve_cte_expression_builtin(cte, aContext, BuiltInTypes.SystemCharacter);
-			break;
-		case IDENT: {
-			final OS_Type a = cte.getTypeTableEntry().getAttached();
-			if (a != null) {
-				assert a.getType() != null;
-				if (a.getType() == OS_Type.Type.BUILT_IN && a.getBType() == BuiltInTypes.Boolean) {
-					assert BuiltInTypes.isBooleanText(cte.getName());
-				} else
-					throw new NotImplementedException();
-			} else {
-				assert false;
+			case NUMERIC:
+				resolve_cte_expression_builtin(cte, aContext, BuiltInTypes.SystemInteger);
+				break;
+			case STRING_LITERAL:
+				resolve_cte_expression_builtin(cte, aContext, BuiltInTypes.String_);
+				break;
+			case CHAR_LITERAL:
+				resolve_cte_expression_builtin(cte, aContext, BuiltInTypes.SystemCharacter);
+				break;
+			case IDENT: {
+				final OS_Type a = cte.getTypeTableEntry().getAttached();
+				if (a != null) {
+					assert a.getType() != null;
+					if (a.getType() == OS_Type.Type.BUILT_IN && a.getBType() == BuiltInTypes.Boolean) {
+						assert BuiltInTypes.isBooleanText(cte.getName());
+					} else
+						throw new NotImplementedException();
+				} else {
+					assert false;
+				}
+				break;
 			}
-			break;
+			default: {
+				LOG.err("8192 " + initialValue.getKind());
+				throw new NotImplementedException();
+			}
 		}
-		default: {
-			LOG.err("8192 " + initialValue.getKind());
-			throw new NotImplementedException();
-		}
-		}
-	}
-
-	void resolve_function_return_type(@NotNull BaseEvaFunction generatedFunction) {
-		final DeduceElement3_Function f = _p_zero.get(DeduceTypes2.this, generatedFunction);
-
-		final GenType gt = f.resolve_function_return_type_int(errSink);
-		if (gt != null)
-			// phase.typeDecided((EvaFunction) generatedFunction, gt);
-			generatedFunction.resolveTypeDeferred(gt);
 	}
 
 	public static int to_int(@NotNull final InstructionArgument arg) {
@@ -772,7 +742,7 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	public void do_assign_normal_ident_deferred(final @NotNull BaseEvaFunction generatedFunction,
-												final @NotNull Context aContext, final @NotNull IdentTableEntry aIdentTableEntry) {
+			final @NotNull Context aContext, final @NotNull IdentTableEntry aIdentTableEntry) {
 		if (aIdentTableEntry.type == null) {
 			// TODO 08/28 making a type with a null type
 			aIdentTableEntry.makeType(generatedFunction, TypeTableEntry.Type.TRANSIENT, (OS_Type) null);
@@ -781,12 +751,12 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 		final DR_Ident ident = aIdentTableEntry.__gf.getIdent(aIdentTableEntry);
 		ident.try_resolve_normal(aContext);
 		ident.addResolveObserver(
-				new do_assign_normal_ident_deferred__DT_ResolveObserver(aIdentTableEntry, generatedFunction));
+				new do_assign_normal_ident_deferred__DT_ResolveObserver(this, aIdentTableEntry, generatedFunction));
 	}
 
 	private void do_assign_constant(final @NotNull BaseEvaFunction generatedFunction,
-									final @NotNull Instruction instruction, final @NotNull IdentTableEntry idte,
-									final @NotNull ConstTableIA i2) {
+			final @NotNull Instruction instruction, final @NotNull IdentTableEntry idte,
+			final @NotNull ConstTableIA i2) {
 		if (idte.type != null && idte.type.getAttached() != null) {
 			// TODO check types
 		}
@@ -800,38 +770,37 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 
 	@Deprecated
 	public void resolveIdentIA_(@NotNull Context context, @NotNull IdentIA identIA,
-								@NotNull BaseEvaFunction generatedFunction, @NotNull FoundElement foundElement) {
+			@NotNull BaseEvaFunction generatedFunction, @NotNull FoundElement foundElement) {
 		final @NotNull Resolve_Ident_IA ria = _inj().new_Resolve_Ident_IA(
 				_inj().new_DeduceClient3(this),
 				context,
 				identIA,
 				generatedFunction,
 				foundElement,
-				errSink
-																		 );
-		//try {
-			ria.action();
-//		} catch (final ResolveError aE) {
-//			//throw new RuntimeException(aE);
-//			final String text = aE._ident().getText();
-//			V.asv(V.e.DT2_2304, text);
-////			System.err.printf("** ResolveError: %s not found!%n", text);
-//		}
+				errSink);
+		// try {
+		ria.action();
+		// } catch (final ResolveError aE) {
+		// //throw new RuntimeException(aE);
+		// final String text = aE._ident().getText();
+		// V.asv(V.e.DT2_2304, text);
+		//// System.err.printf("** ResolveError: %s not found!%n", text);
+		// }
 	}
 
 	public void found_element_for_ite(BaseEvaFunction generatedFunction, @NotNull IdentTableEntry ite,
-									  @Nullable OS_Element y, Context ctx, final DeduceCentral central) {
+			@Nullable OS_Element y, Context ctx, final DeduceCentral central) {
 		if (y != ite.getResolvedElement()) {
 			SimplePrintLoggerToRemoveSoon
 					.println_err_2(String.format("2571 Setting FoundElement for ite %s to %s when it is already %s",
-												 ite, y, ite.getResolvedElement()));
+							ite, y, ite.getResolvedElement()));
 		}
 
 		var env = _inj().new_DT_Env(LOG, errSink, central);
 
 		@NotNull
 		Found_Element_For_ITE fefi = _inj().new_Found_Element_For_ITE(generatedFunction, ctx, env,
-																	  _inj().new_DeduceClient1(this));
+				_inj().new_DeduceClient1(this));
 		fefi.action(ite);
 	}
 
@@ -840,7 +809,7 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	public IInvocation getInvocation(@NotNull EvaFunction generatedFunction) {
-		final ClassInvocation     classInvocation = generatedFunction.fi.getClassInvocation();
+		final ClassInvocation classInvocation = generatedFunction.fi.getClassInvocation();
 		final NamespaceInvocation ni;
 		if (classInvocation == null) {
 			ni = generatedFunction.fi.getNamespaceInvocation();
@@ -855,7 +824,7 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 
 	@NotNull
 	public FunctionInvocation newFunctionInvocation(FunctionDef aFunctionDef, ProcTableEntry aPte,
-													@NotNull IInvocation aInvocation, @NotNull DeducePhase aDeducePhase) {
+			@NotNull IInvocation aInvocation, @NotNull DeducePhase aDeducePhase) {
 		@NotNull
 		FunctionInvocation fi = aDeducePhase.newFunctionInvocation(aFunctionDef, aPte, aInvocation);
 		// TODO register here
@@ -882,7 +851,7 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	private void resolve_cte_expression_builtin(@NotNull ConstantTableEntry cte, Context aContext,
-												BuiltInTypes aBuiltInType) {
+			BuiltInTypes aBuiltInType) {
 		final OS_Type a = cte.getTypeTableEntry().getAttached();
 		if (a == null || a.getType() != OS_Type.Type.USER_CLASS) {
 			try {
@@ -892,6 +861,15 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 				resolveError.printStackTrace(); // TODO print diagnostic
 			}
 		}
+	}
+
+	void resolve_function_return_type(@NotNull BaseEvaFunction generatedFunction) {
+		final DeduceElement3_Function f = _p_zero.get(DeduceTypes2.this, generatedFunction);
+
+		final GenType gt = f.resolve_function_return_type_int(errSink);
+		if (gt != null)
+			// phase.typeDecided((EvaFunction) generatedFunction, gt);
+			generatedFunction.resolveTypeDeferred(gt);
 	}
 
 	public void deduceClasses(final @NotNull List<EvaNode> lgc) {
@@ -905,8 +883,8 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 
 	public void deduceOneClass(final @NotNull EvaClass aEvaClass) {
 		for (VarTableEntry entry : aEvaClass.varTable) {
-			final OS_Type vt      = entry.varType;
-			GenType       genType = GenType.makeFromOSType(vt, aEvaClass.ci.genericPart(), this, phase, LOG, errSink);
+			final OS_Type vt = entry.varType;
+			GenType genType = GenType.makeFromOSType(vt, aEvaClass.ci.genericPart(), this, phase, LOG, errSink);
 			if (genType != null) {
 				if (genType.getNode() != null) {
 					entry.resolve(genType.getNode());
@@ -931,11 +909,11 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 		// TODO consider using reactive here
 		int size;
 		do {
-			size             = df_helper(generatedClasses, new dfhi_functions());
+			size = df_helper(generatedClasses, new dfhi_functions());
 			generatedClasses = phase.generatedClasses.copy();
 		} while (size > 0);
 		do {
-			size             = df_helper(generatedClasses, new dfhi_constructors());
+			size = df_helper(generatedClasses, new dfhi_constructors());
 			generatedClasses = phase.generatedClasses.copy();
 		} while (size > 0);
 	}
@@ -970,13 +948,16 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	/**
 	 * Deduce functions or constructors contained in classes list
 	 *
-	 * @param aGeneratedClasses assumed to be a list of {@link EvaContainerNC}
-	 * @param dfhi              specifies what to select for:<br>
-	 *                          {@link dfhi_functions} will select all functions
-	 *                          from {@code functionMap}, and <br>
-	 *                          {@link dfhi_constructors} will select all
-	 *                          constructors from {@code constructors}.
-	 * @param <T>               generic parameter taken from {@code dfhi}
+	 * @param aGeneratedClasses
+	 *            assumed to be a list of {@link EvaContainerNC}
+	 * @param dfhi
+	 *            specifies what to select for:<br>
+	 *            {@link dfhi_functions} will select all functions
+	 *            from {@code functionMap}, and <br>
+	 *            {@link dfhi_constructors} will select all
+	 *            constructors from {@code constructors}.
+	 * @param <T>
+	 *            generic parameter taken from {@code dfhi}
 	 * @return the number of deduced functions or constructors, or 0
 	 */
 	<T> int df_helper(@NotNull List<EvaNode> aGeneratedClasses, @NotNull df_helper_i<T> dfhi) {
@@ -998,17 +979,17 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	public void deduce_generated_function(final @NotNull EvaFunction generatedFunction,
-										  final @NotNull ModuleThing aMt) {
+			final @NotNull ModuleThing aMt) {
 		final @NotNull FunctionDef fd = generatedFunction.getFD();
 		deduce_generated_function_base(generatedFunction, fd, aMt);
 	}
 
 	private static void __post_dof_idte_register_resolved(final @NotNull EvaFunction aGeneratedFunction,
-														  final @NotNull DeducePhase aDeducePhase) {
+			final @NotNull DeducePhase aDeducePhase) {
 		for (@NotNull
 		IdentTableEntry identTableEntry : aGeneratedFunction.idte_list) {
 			if (identTableEntry.getResolvedElement() instanceof final @NotNull VariableStatementImpl vs) {
-				OS_Element el  = vs.getParent().getParent();
+				OS_Element el = vs.getParent().getParent();
 				OS_Element el2 = aGeneratedFunction.getFD().getParent();
 				if (el != el2) {
 					if (el instanceof ClassStatement || el instanceof NamespaceStatement)
@@ -1019,16 +1000,18 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 		}
 	}
 
-//	private GeneratedNode makeNode(GenType aGenType) {
-//		if (aGenType.ci instanceof ClassInvocation) {
-//			final ClassInvocation ci = (ClassInvocation) aGenType.ci;
-//			@NotNull GenerateFunctions gen = phase.generatePhase.getGenerateFunctions(ci.getKlass().getContext().module());
-//			WlGenerateClass wlgc = _inj().new_WlGenerateClass(gen, ci, phase.generatedClasses);
-//			wlgc.run(null);
-//			return wlgc.getResult();
-//		}
-//		return null;
-//	}
+	// private GeneratedNode makeNode(GenType aGenType) {
+	// if (aGenType.ci instanceof ClassInvocation) {
+	// final ClassInvocation ci = (ClassInvocation) aGenType.ci;
+	// @NotNull GenerateFunctions gen =
+	// phase.generatePhase.getGenerateFunctions(ci.getKlass().getContext().module());
+	// WlGenerateClass wlgc = _inj().new_WlGenerateClass(gen, ci,
+	// phase.generatedClasses);
+	// wlgc.run(null);
+	// return wlgc.getResult();
+	// }
+	// return null;
+	// }
 
 	private void __post_dof_result_type(final @NotNull EvaFunction aGeneratedFunction) {
 		final @NotNull EvaFunction gf = aGeneratedFunction;
@@ -1056,58 +1039,58 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 				if (a != null) {
 					// see resolve_function_return_type
 					switch (a.getType()) {
-					case USER_CLASS:
-						dof_uc(vte, a);
-						break;
-					case USER:
-						vte.getGenType().setTypeName(a);
-						try {
-							@NotNull
-							GenType rt = resolve_type(a, a.getTypeName().getContext());
-							if (rt.getResolved() != null && rt.getResolved().getType() == OS_Type.Type.USER_CLASS) {
-								if (rt.getResolved().getClassOf().getGenericPart().size() > 0)
-									vte.getGenType().setNonGenericTypeName(a.getTypeName()); // TODO might be wrong
-								dof_uc(vte, rt.getResolved());
+						case USER_CLASS:
+							dof_uc(vte, a);
+							break;
+						case USER:
+							vte.getGenType().setTypeName(a);
+							try {
+								@NotNull
+								GenType rt = resolve_type(a, a.getTypeName().getContext());
+								if (rt.getResolved() != null && rt.getResolved().getType() == OS_Type.Type.USER_CLASS) {
+									if (rt.getResolved().getClassOf().getGenericPart().size() > 0)
+										vte.getGenType().setNonGenericTypeName(a.getTypeName()); // TODO might be wrong
+									dof_uc(vte, rt.getResolved());
+								}
+							} catch (ResolveError aResolveError) {
+								errSink.reportDiagnostic(aResolveError);
 							}
-						} catch (ResolveError aResolveError) {
-							errSink.reportDiagnostic(aResolveError);
-						}
-						break;
-					default:
-						int y3 = 2;
+							break;
+						default:
+							int y3 = 2;
 
-						vte.typePromise().then(gt -> {
-							int y4 = 2;
+							vte.typePromise().then(gt -> {
+								int y4 = 2;
 
-							if (vte.getStatus() == BaseTableEntry.Status.UNCHECKED) {
-								// NOTE curious...
-								int y5 = 25;
+								if (vte.getStatus() == BaseTableEntry.Status.UNCHECKED) {
+									// NOTE curious...
+									int y5 = 25;
 
+									final OS_Element resolvedElement = vte.getResolvedElement();
+
+									if (resolvedElement == null) {
+										// throw new AssertionError();
+									} else {
+										vte.setStatus(BaseTableEntry.Status.KNOWN,
+												_inj().new_GenericElementHolder(resolvedElement));
+									}
+								} else
+									throw new IllegalStateException("Error");
+
+							});
+
+							if (vte.getVtt() == VariableTableType.RESULT) {
 								final OS_Element resolvedElement = vte.getResolvedElement();
 
 								if (resolvedElement == null) {
-//									throw new AssertionError();
+									// throw new AssertionError();
 								} else {
 									vte.setStatus(BaseTableEntry.Status.KNOWN,
-												  _inj().new_GenericElementHolder(resolvedElement));
+											_inj().new_GenericElementHolder(resolvedElement));
 								}
-							} else
-								throw new IllegalStateException("Error");
-
-						});
-
-						if (vte.getVtt() == VariableTableType.RESULT) {
-							final OS_Element resolvedElement = vte.getResolvedElement();
-
-							if (resolvedElement == null) {
-								// throw new AssertionError();
-							} else {
-								vte.setStatus(BaseTableEntry.Status.KNOWN,
-											  _inj().new_GenericElementHolder(resolvedElement));
 							}
-						}
 
-						break;
+							break;
 					}
 				} else {
 					// 08/31 Back to this...
@@ -1141,8 +1124,9 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 		if (evaConstructor.deducedAlready)
 			return false;
 
-		final ICompilationAccess   compilationAccess = aDeducePhase.ca();
-		final CompilationEnclosure ce                = (CompilationEnclosure) compilationAccess.getCompilation().getCompilationEnclosure();
+		final ICompilationAccess compilationAccess = aDeducePhase.ca();
+		final CompilationEnclosure ce = (CompilationEnclosure) compilationAccess.getCompilation()
+				.getCompilationEnclosure();
 
 		final DeduceElement3_Constructor ccc = new DeduceElement3_Constructor(evaConstructor, this, ce);
 
@@ -1158,8 +1142,8 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	private @NotNull DeferredMember deferred_member(final @NotNull DeduceElementWrapper aParent,
-													final /* @NotNull */ IInvocation aInvocation, final @NotNull VariableStatementImpl aVariableStatement,
-													final @NotNull IdentTableEntry ite) {
+			final /* @NotNull */ IInvocation aInvocation, final @NotNull VariableStatementImpl aVariableStatement,
+			final @NotNull IdentTableEntry ite) {
 		@NotNull
 		DeferredMember dm = Objects.requireNonNull(deferred_member(aParent, aInvocation, aVariableStatement));
 		dm.externalRef().then(ite::setExternalRef);
@@ -1167,16 +1151,16 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	private @NotNull DeferredMember deferred_member(final @NotNull DeduceElementWrapper aParent,
-													@Nullable IInvocation aInvocation, VariableStatementImpl aVariableStatement) {
-		final IInvocation    invocation = _deferred_member_invocation(aParent, aInvocation);
-		final DeferredMember dm         = _inj().new_DeferredMember(aParent, invocation, aVariableStatement);
+			@Nullable IInvocation aInvocation, VariableStatementImpl aVariableStatement) {
+		final IInvocation invocation = _deferred_member_invocation(aParent, aInvocation);
+		final DeferredMember dm = _inj().new_DeferredMember(aParent, invocation, aVariableStatement);
 		phase.addDeferredMember(dm);
 		DebugPrint.addDeferredMember(dm);
 		return dm;
 	}
 
 	private IInvocation _deferred_member_invocation(final @NotNull DeduceElementWrapper aParent,
-													final @Nullable IInvocation aInvocation) {
+			final @Nullable IInvocation aInvocation) {
 		final IInvocation invocation;
 		if (aInvocation == null) {
 			if (aParent.isNamespaceStatement()) {
@@ -1193,7 +1177,7 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 
 	@NotNull
 	DeferredMemberFunction deferred_member_function(OS_Element aParent, @Nullable IInvocation aInvocation,
-													@NotNull FunctionDef aFunctionDef, final @NotNull FunctionInvocation aFunctionInvocation) {
+			@NotNull FunctionDef aFunctionDef, final @NotNull FunctionInvocation aFunctionInvocation) {
 		if (aInvocation == null) {
 			if (aParent instanceof NamespaceStatement) {
 				aInvocation = phase.registerNamespaceInvocation((NamespaceStatement) aParent);
@@ -1202,7 +1186,7 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 			}
 		}
 		DeferredMemberFunction dm = _inj().new_DeferredMemberFunction(aParent, aInvocation, aFunctionDef, this,
-																	  aFunctionInvocation);
+				aFunctionInvocation);
 		phase.addDeferredMember(dm);
 		return dm;
 	}
@@ -1252,12 +1236,12 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 
 	@NotNull
 	public List<TypeTableEntry> getPotentialTypesVte(@NotNull EvaFunction generatedFunction,
-													 @NotNull InstructionArgument vte_index) {
+			@NotNull InstructionArgument vte_index) {
 		return getPotentialTypesVte(generatedFunction.getVarTableEntry(to_int(vte_index)));
 	}
 
 	boolean lookup_name_calls(final @NotNull Context ctx, final @NotNull String pn, final @NotNull ProcTableEntry pte) {
-		final LookupResultList     lrl  = ctx.lookup(pn);
+		final LookupResultList lrl = ctx.lookup(pn);
 		final @Nullable OS_Element best = lrl.chooseBest(null); // TODO check arity and arg matching
 		if (best != null) {
 			pte.setStatus(BaseTableEntry.Status.KNOWN, _inj().new_ConstructableElementHolder(best, null)); // TODO why
@@ -1296,28 +1280,27 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	/* static */
 	@NotNull
 	GenType resolve_type(final @NotNull OS_Module module, final @NotNull OS_Type type, final Context ctx)
-	throws ResolveError {
+			throws ResolveError {
 		return ResolveType.resolve_type(module, type, ctx, LOG, this);
 	}
 
 	public void resolveIdentIA_(@NotNull Context context, @NotNull DeduceElementIdent dei,
-								BaseEvaFunction generatedFunction, @NotNull FoundElement foundElement) {
+			BaseEvaFunction generatedFunction, @NotNull FoundElement foundElement) {
 		@NotNull
 		Resolve_Ident_IA ria = _inj().new_Resolve_Ident_IA(_inj().new_DeduceClient3(this), context, dei,
-														   generatedFunction, foundElement, errSink
-														  );
+				generatedFunction, foundElement, errSink);
 		ria.action();
 	}
 
 	public void resolveIdentIA2_(@NotNull Context context, @NotNull IdentIA identIA,
-								 @NotNull EvaFunction generatedFunction, @NotNull FoundElement foundElement) {
+			@NotNull EvaFunction generatedFunction, @NotNull FoundElement foundElement) {
 		final @NotNull List<InstructionArgument> s = BaseEvaFunction._getIdentIAPathList(identIA);
 		resolveIdentIA2_(context, identIA, s, generatedFunction, foundElement);
 	}
 
 	public void resolveIdentIA2_(@NotNull final Context ctx, @Nullable IdentIA identIA,
-								 @Nullable List<InstructionArgument> s, @NotNull final BaseEvaFunction generatedFunction,
-								 @NotNull final FoundElement foundElement) {
+			@Nullable List<InstructionArgument> s, @NotNull final BaseEvaFunction generatedFunction,
+			@NotNull final FoundElement foundElement) {
 		@NotNull
 		Resolve_Ident_IA2 ria2 = _inj().new_Resolve_Ident_IA2(this, errSink, phase, generatedFunction, foundElement);
 		ria2.resolveIdentIA2_(ctx, identIA, s);
@@ -1328,14 +1311,15 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	}
 
 	public DeduceElement3_VariableTableEntry zeroGet(final VariableTableEntry aVte,
-													 final BaseEvaFunction aGeneratedFunction) {
+			final BaseEvaFunction aGeneratedFunction) {
 		return _p_zero.get(aVte, aGeneratedFunction);
 	}
 
-	public TypeName HACKMAYBE_resolve_TypeName(final TypeOfTypeNameImpl aTypeOfTypeName, final Context aCtx) throws ResolveError {
-		//		tripleo.elijah.util.Stupidity.println_out_2(_typeOf.toString());
-		final LookupResultList lrl  = DeduceLookupUtils.lookupExpression(aTypeOfTypeName.typeOf(), aCtx, this);
-		final OS_Element       best = lrl.chooseBest(null);
+	public TypeName HACKMAYBE_resolve_TypeName(final TypeOfTypeNameImpl aTypeOfTypeName, final Context aCtx)
+			throws ResolveError {
+		// tripleo.elijah.util.Stupidity.println_out_2(_typeOf.toString());
+		final LookupResultList lrl = DeduceLookupUtils.lookupExpression(aTypeOfTypeName.typeOf(), aCtx, this);
+		final OS_Element best = lrl.chooseBest(null);
 
 		if (best instanceof VariableStatement) {
 			return ((VariableStatement) best).typeName();
@@ -1363,46 +1347,6 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 		return this.externals;
 	}
 
-	public <T> Eventual<T> eventual(final String aDescription) {
-		final Eventual<T> result = new Eventual<T>() {
-			@Override
-			public String description() {
-				return aDescription;
-			}
-		};
-		result.register(this._phase());
-		return result;
-	}
-
-	public enum ProcessElement {
-		;
-
-		public static void processElement(@Nullable OS_Element el, @NotNull IElementProcessor ep) {
-			if (el == null)
-				ep.elementIsNull();
-			else
-				ep.hasElement(el);
-		}
-	}
-
-	interface DT_Function {
-		List<VariableTableEntry> vte_list();
-
-		List<IdentTableEntry> idte_list();
-
-		List<ProcTableEntry> prte_list();
-
-		BaseEvaFunction get();
-
-		List<ConstantTableEntry> cte_list();
-
-		void add_proc_table_listeners();
-
-		void resolve_ident_table(final Context aContext);
-
-		void resolve_arguments_table(Context aContext);
-	}
-
 	interface df_helper<T> {
 		@NotNull
 		Collection<T> collection();
@@ -1413,1317 +1357,6 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 	interface df_helper_i<T> {
 		@Nullable
 		df_helper<T> get(EvaContainerNC generatedClass);
-	}
-
-	public interface ExpectationBase {
-		String expectationString();
-	}
-
-	public interface IElementProcessor {
-		void elementIsNull();
-
-		void hasElement(OS_Element el);
-	}
-
-	interface IVariableConnector {
-		void connect(VariableTableEntry aVte, String aName);
-	}
-
-	static class CtorConnector implements IVariableConnector {
-		private final IEvaConstructor evaConstructor;
-		private final DeduceTypes2    deduceTypes2;
-
-		public CtorConnector(final IEvaConstructor aEvaConstructor, final DeduceTypes2 aDeduceTypes2) {
-			evaConstructor = aEvaConstructor;
-			deduceTypes2   = aDeduceTypes2;
-		}
-
-		@Override
-		public void connect(final VariableTableEntry aVte, final String aName) {
-			PromiseExpectation<EvaClass> pe_evaClass = deduceTypes2._inj().new_PromiseExpectation(evaConstructor, "evaConstructor.onGenClass", deduceTypes2);
-
-			evaConstructor.onGenClass((EvaClass aGeneratedClass) -> {
-				pe_evaClass.satisfy(aGeneratedClass);
-
-				final List<VarTableEntry> vt = (aGeneratedClass).varTable;
-
-				for (VarTableEntry gc_vte : vt) {
-					if (gc_vte.nameToken.getText().equals(aName)) {
-						gc_vte.connect(aVte, evaConstructor);
-						break;
-					}
-				}
-			});
-		}
-	}
-
-	public static class DeduceClient1 {
-		private final DeduceTypes2 dt2;
-
-		@Contract(pure = true)
-		public DeduceClient1(DeduceTypes2 aDeduceTypes2) {
-			dt2 = aDeduceTypes2;
-		}
-
-		public DeduceTypes2 _deduceTypes2() {
-			return dt2;
-		}
-
-		public DeduceTypes2Injector _inj() {
-			return dt2._inj();
-		}
-
-		public @Nullable OS_Element _resolveAlias(@NotNull AliasStatementImpl aAliasStatement) {
-			return DeduceLookupUtils._resolveAlias(aAliasStatement, dt2);
-		}
-
-		public @NotNull DeferredMember deferred_member(DeduceElementWrapper aParent, IInvocation aInvocation,
-													   VariableStatementImpl aVariableStatement, @NotNull IdentTableEntry aIdentTableEntry) {
-			return dt2.deferred_member(aParent, aInvocation, aVariableStatement, aIdentTableEntry);
-		}
-
-		public void found_element_for_ite(BaseEvaFunction aGeneratedFunction, @NotNull IdentTableEntry aIte,
-										  OS_Element aX, Context aCtx) {
-			dt2.found_element_for_ite(aGeneratedFunction, aIte, aX, aCtx, dt2.central());
-		}
-
-		public void genCI(final @NotNull GenType aResult, final TypeName aNonGenericTypeName) {
-			aResult.genCI(aNonGenericTypeName, dt2, dt2.errSink, dt2.phase);
-		}
-
-		public void genCIForGenType2(final @NotNull GenType genType) {
-			genType.genCIForGenType2(dt2);
-		}
-
-		public @Nullable IInvocation getInvocationFromBacklink(InstructionArgument aInstructionArgument) {
-			return dt2.getInvocationFromBacklink(aInstructionArgument);
-		}
-
-		public @NotNull List<TypeTableEntry> getPotentialTypesVte(@NotNull VariableTableEntry aVte) {
-			return dt2.getPotentialTypesVte(aVte);
-		}
-
-		public void LOG_err(String aS) {
-			dt2.LOG.err(aS);
-		}
-
-		public @Nullable ClassInvocation registerClassInvocation(final @NotNull ClassStatement aClassStatement,
-																 final String aS) {
-			return dt2.phase.registerClassInvocation(aClassStatement, aS, new ReadySupplier_1<>(dt2));
-		}
-
-		public @NotNull GenType resolve_type(@NotNull OS_Type aType, Context aCtx) throws ResolveError {
-			return dt2.resolve_type(aType, aCtx);
-		}
-	}
-
-	public static class DeduceClient2 {
-		private final DeduceTypes2 deduceTypes2;
-
-		public DeduceClient2(DeduceTypes2 deduceTypes2) {
-			this.deduceTypes2 = deduceTypes2;
-		}
-
-		public DeduceTypes2 deduceTypes2() {
-			return deduceTypes2;
-		}
-
-		public @NotNull ClassInvocation genCI(@NotNull GenType genType, TypeName typeName) {
-			return genType.genCI(typeName, deduceTypes2, deduceTypes2.errSink, deduceTypes2.phase);
-		}
-
-		public @NotNull ElLog getLOG() {
-			return deduceTypes2.LOG;
-		}
-
-		public @NotNull FunctionInvocation newFunctionInvocation(FunctionDef constructorDef, ProcTableEntry pte,
-																 @NotNull IInvocation ci) {
-			return deduceTypes2.newFunctionInvocation(constructorDef, pte, ci, deduceTypes2.phase);
-		}
-
-		public @Nullable ClassInvocation registerClassInvocation(@NotNull ClassInvocation ci) {
-			RegisterClassInvocation_env env = new RegisterClassInvocation_env(ci, () -> deduceTypes2, () -> deduceTypes2.phase);
-
-			return deduceTypes2.phase.registerClassInvocation(env);
-		}
-
-		public NamespaceInvocation registerNamespaceInvocation(NamespaceStatement namespaceStatement) {
-			return deduceTypes2.phase.registerNamespaceInvocation(namespaceStatement);
-		}
-	}
-
-	public static class DeduceClient3 {
-		final DeduceTypes2 deduceTypes2;
-
-		public DeduceClient3(final DeduceTypes2 aDeduceTypes2) {
-			deduceTypes2 = aDeduceTypes2;
-		}
-
-		public DeduceTypes2 _deduceTypes2() {
-			return deduceTypes2;
-		}
-
-		public void addJobs(final WorkList aWl) {
-			deduceTypes2.wm.addJobs(aWl);
-		}
-
-		public void found_element_for_ite(final BaseEvaFunction generatedFunction, final @NotNull IdentTableEntry ite,
-										  final @Nullable OS_Element y, final Context ctx) {
-			deduceTypes2.found_element_for_ite(generatedFunction, ite, y, ctx, deduceTypes2.central());
-		}
-
-		public void genCIForGenType2(final @NotNull GenType genType) {
-			genType.genCIForGenType2(deduceTypes2);
-		}
-
-		public @NotNull GenerateFunctions getGenerateFunctions(final @NotNull OS_Module aModule) {
-			return deduceTypes2.getGenerateFunctions(aModule);
-		}
-
-		public IInvocation getInvocation(final @NotNull EvaFunction aGeneratedFunction) {
-			return deduceTypes2.getInvocation(aGeneratedFunction);
-		}
-
-		public @NotNull ElLog getLOG() {
-			return deduceTypes2.LOG;
-		}
-
-		public @NotNull DeducePhase getPhase() {
-			return deduceTypes2.phase;
-		}
-
-		public @NotNull List<TypeTableEntry> getPotentialTypesVte(final @NotNull VariableTableEntry aVte) {
-			return deduceTypes2.getPotentialTypesVte(aVte);
-		}
-
-		public LookupResultList lookupExpression(final @NotNull IExpression aExp, final @NotNull Context aContext)
-		throws ResolveError {
-			return DeduceLookupUtils.lookupExpression(aExp, aContext, deduceTypes2);
-		}
-
-		public @NotNull FunctionInvocation newFunctionInvocation(final BaseFunctionDef aFunctionDef,
-																 final ProcTableEntry aPte, final @NotNull IInvocation aInvocation) {
-			return deduceTypes2.newFunctionInvocation(aFunctionDef, aPte, aInvocation, deduceTypes2.phase);
-		}
-
-		public @NotNull IElementHolder newGenericElementHolderWithType(final @NotNull OS_Element aElement,
-																	   final @NotNull TypeName aTypeName) {
-			final OS_Type typeName;
-			if (aTypeName.isNull())
-				typeName = null;
-			else
-				typeName = this.deduceTypes2._inj().new_OS_UserType(aTypeName);
-			return this.deduceTypes2._inj().new_GenericElementHolderWithType(aElement, typeName, deduceTypes2);
-		}
-
-		public @NotNull GenType resolve_type(final @NotNull OS_Type aType, final Context aContext) throws ResolveError {
-			return deduceTypes2.resolve_type(aType, aContext);
-		}
-
-		public void resolveIdentIA2_(final @NotNull Context aEctx, final IdentIA aIdentIA,
-									 final @Nullable List<InstructionArgument> aInstructionArgumentList,
-									 final @NotNull BaseEvaFunction aGeneratedFunction, final @NotNull FoundElement aFoundElement) {
-			deduceTypes2.resolveIdentIA2_(aEctx, aIdentIA, aInstructionArgumentList, aGeneratedFunction, aFoundElement);
-		}
-	}
-
-	// TODO 10/14 mix of injector and factory ;)
-	public static class DeduceTypes2Injector {
-		public __Add_Proc_Table_Listeners new___Add_Proc_Table_Listeners() {
-			return new __Add_Proc_Table_Listeners();
-		}
-
-		public BaseTableEntry.StatusListener new__StatusListener__BTE_203(final DeduceTypeResolve aDeduceTypeResolve) {
-			return aDeduceTypeResolve.new _StatusListener__BTE_203();
-		}
-
-		public BaseTableEntry.StatusListener new__StatusListener__BTE_86(final DeduceTypeResolve aDeduceTypeResolve) {
-			return aDeduceTypeResolve.new _StatusListener__BTE_86();
-		}
-
-		public List<Reactivable> new_ArrayList__Ables() {
-			return new ArrayList<>();
-		}
-
-		public List<DE3_Active> new_ArrayList__DE3_Active() {
-			return new ArrayList<>();
-		}
-
-		public List<FunctionInvocation> new_ArrayList__FunctionInvocation() {
-			return new ArrayList<>();
-		}
-
-		public List<IDeduceResolvable> new_ArrayList__IDeduceResolvable() {
-			return new ArrayList<>();
-		}
-
-		public List<Runnable> new_ArrayList__Runnable() {
-			return new ArrayList<>();
-		}
-
-		public List<TypeTableEntry> new_ArrayList__TypeTableEntry(final Collection<TypeTableEntry> aTypeTableEntries) {
-			return new ArrayList<>(aTypeTableEntries);
-		}
-
-		public CantDecideType new_CantDecideType(final VariableTableEntry aVte,
-												 final Collection<TypeTableEntry> aTypeTableEntries) {
-			return new CantDecideType(aVte, aTypeTableEntries);
-		}
-
-		public ClassInvocation.CI_GenericPart new_CI_GenericPart(final List<TypeName> aGenericPart,
-																 final ClassInvocation aClassInvocation) {
-			return aClassInvocation.new CI_GenericPart(aGenericPart);
-		}
-
-		public ClassInvocation new_ClassInvocation(final ClassStatement aClassOf, final String aO,
-												   final @NotNull Supplier<DeduceTypes2> aDeduceTypes2) {
-			return new ClassInvocation(aClassOf, aO, aDeduceTypes2);
-		}
-
-		public IElementHolder new_ConstructableElementHolder(final OS_Element aE, final IdentIA aIdentIA) {
-			return new ConstructableElementHolder(aE, aIdentIA);
-		}
-
-		public IVariableConnector new_CtorConnector(final IEvaConstructor aGeneratedFunction, final DeduceTypes2 aDeduceTypes2) {
-			return new CtorConnector(aGeneratedFunction, aDeduceTypes2);
-		}
-
-		public DC_ClassNote new_DC_ClassNote(final ClassStatement aE, final Context aCtx,
-											 final DeduceCentral aDeduceCentral) {
-			return new DC_ClassNote(aE, aCtx, aDeduceCentral);
-		}
-
-		public DC_ClassNote.DC_ClassNote_DT2 new_DC_ClassNote_DT2(final IdentTableEntry aIte,
-																  final BaseEvaFunction aGeneratedFunction, final DeduceTypes2 aDeduceTypes2) {
-			return new DC_ClassNote.DC_ClassNote_DT2(aIte, aGeneratedFunction, aDeduceTypes2);
-		}
-
-		public DE3_Active new_DE3_ActivePTE(final DeduceTypes2 aDeduceTypes2, final ProcTableEntry aPte,
-											final ClassInvocation aClassInvocation) {
-			return new DE3_ActivePTE(aDeduceTypes2, aPte, aClassInvocation);
-		}
-
-		public IElementHolder new_DE3_EH_GroundedVariableStatement(final VariableStatement aE,
-																   final DeduceElement3_IdentTableEntry aDeduceElement3IdentTableEntry) {
-			return aDeduceElement3IdentTableEntry.new DE3_EH_GroundedVariableStatement(
-					aE,
-					aDeduceElement3IdentTableEntry
-			);
-		}
-
-		public DeduceElement3_IdentTableEntry.DE3_ITE_Holder new_DE3_ITE_Holder(final OS_Element aEl,
-																				final DeduceElement3_IdentTableEntry aDeduceElement3IdentTableEntry) {
-			return aDeduceElement3IdentTableEntry.new DE3_ITE_Holder(aEl);
-		}
-
-		public DeclAnchor new_DeclAnchor(final OS_Element aDeclAnchor, final DeclAnchor.AnchorType aAnchorType) {
-			return new DeclAnchor(aDeclAnchor, aAnchorType);
-		}
-
-		public DeduceElement new_DeclTarget(final FunctionDef aBest, final OS_Element aDeclAnchor,
-											final DeclAnchor.AnchorType aAnchorType, final DeduceProcCall aDeduceProcCall) throws FCA_Stop {
-			return aDeduceProcCall.new DeclTarget(aBest, aDeclAnchor, aAnchorType);
-		}
-
-		public DeduceCentral new_DeduceCentral(final DeduceTypes2 aDeduceTypes2) {
-			return new DeduceCentral(aDeduceTypes2);
-		}
-
-		public DeduceClient1 new_DeduceClient1(final DeduceTypes2 aDeduceTypes2) {
-			return new DeduceClient1(aDeduceTypes2);
-		}
-
-		public DeduceClient2 new_DeduceClient2(final DeduceTypes2 aDeduceTypes2) {
-			return new DeduceClient2(aDeduceTypes2);
-		}
-
-		public DeduceClient3 new_DeduceClient3(final DeduceTypes2 aDeduceTypes2) {
-			return new DeduceClient3(aDeduceTypes2);
-		}
-
-		public DeduceClient4 new_DeduceClient4(final DeduceTypes2 aDeduceTypes2) {
-			return aDeduceTypes2.new DeduceClient4(aDeduceTypes2);
-		}
-
-		public DeduceElement3_Function new_DeduceElement3_Function(final DeduceTypes2 aDeduceTypes2,
-																   final BaseEvaFunction aGeneratedFunction) {
-			return new DeduceElement3_Function(aDeduceTypes2, aGeneratedFunction);
-		}
-
-		public DeduceElement3_IdentTableEntry new_DeduceElement3_IdentTableEntry(final IdentTableEntry aIte) {
-			return new DeduceElement3_IdentTableEntry(aIte);
-		}
-
-		public DeduceElement3_ProcTableEntry new_DeduceElement3_ProcTableEntry(final ProcTableEntry aPte,
-																			   final DeduceTypes2 aDeduceTypes2, final BaseEvaFunction aGeneratedFunction) {
-			return new DeduceElement3_ProcTableEntry(aPte, aDeduceTypes2, aGeneratedFunction);
-		}
-
-		public DeduceElement3_VariableTableEntry new_DeduceElement3_VariableTableEntry(final VariableTableEntry aVte,
-																					   final DeduceTypes2 aDeduceTypes2, final BaseEvaFunction aGeneratedFunction) {
-			return new DeduceElement3_VariableTableEntry(aVte, aDeduceTypes2, aGeneratedFunction);
-		}
-
-		public DeduceProcCall new_DeduceProcCall(final ProcTableEntry aPte) {
-			return new DeduceProcCall(aPte);
-		}
-
-		public OS_Element new_DeduceTypes2_OS_SpecialVariable(final VariableTableEntry aEntry,
-															  final VariableTableType aVariableTableType, final BaseEvaFunction aGeneratedFunction) {
-			return new OS_SpecialVariable(aEntry, aVariableTableType, aGeneratedFunction);
-		}
-
-		public DeduceCreationContext new_DefaultDeduceCreationContext(final DeduceTypes2 aDeduceTypes2) {
-			return new DefaultDeduceCreationContext(aDeduceTypes2);
-		}
-
-		public GenerateResultSink new_DefaultGenerateResultSink(final IPipelineAccess aPa) {
-			return new DefaultGenerateResultSink(aPa);
-		}
-
-		public @NotNull DeferredMember new_DeferredMember(final DeduceElementWrapper aParent,
-														  final IInvocation aInvocation, final VariableStatementImpl aVariableStatement) {
-			return new DeferredMember(aParent, aInvocation, aVariableStatement);
-		}
-
-		public DeferredMemberFunction new_DeferredMemberFunction(final OS_Element aParent,
-																 final IInvocation aInvocation, final FunctionDef aFunctionDef, final DeduceTypes2 aDeduceTypes2,
-																 final FunctionInvocation aFunctionInvocation) {
-			return new DeferredMemberFunction(aParent, aInvocation, aFunctionDef, aDeduceTypes2, aFunctionInvocation);
-		}
-
-		public DeferredObject<BaseEvaFunction, Void, Void> new_DeferredObject__BaseEvaFunction() {
-			return new DeferredObject<>();
-		}
-
-		public DeferredObject<GenType, Diagnostic, Void> new_DeferredObject__GenType() {
-			return new DeferredObject<>();
-		}
-
-		public Dependencies new_Dependencies(final WorkManager aWorkManager, final DeduceTypes2 aDeduceTypes2) {
-			return aDeduceTypes2.new Dependencies(aWorkManager);
-		}
-
-		public IInvocation new_DerivedClassInvocation(final ClassStatement aDeclAnchor,
-													  final ClassInvocation aDeclaredInvocation, final Supplier<DeduceTypes2> aDeduceTypes2) {
-			return new DerivedClassInvocation(aDeclAnchor, aDeclaredInvocation, aDeduceTypes2);
-		}
-
-		public DG_AliasStatement new_DG_AliasStatement(final AliasStatementImpl aE, final DeduceTypes2 aDt2) {
-			return new DG_AliasStatement(aE, aDt2);
-		}
-
-		public DG_ClassStatement new_DG_ClassStatement(final ClassStatement aClassStatement) {
-			return new DG_ClassStatement(aClassStatement);
-		}
-
-		public DG_FunctionDef new_DG_FunctionDef(final FunctionDef aFunctionDef) {
-			return new DG_FunctionDef(aFunctionDef);
-		}
-
-		public Diagnostic new_Diagnostic_8884(final VariableTableEntry aVte, final BaseEvaFunction aGf) {
-			return new DeduceElement3_VariableTableEntry.Diagnostic_8884(aVte, aGf);
-		}
-
-		public Diagnostic new_Diagnostic_8885(final VariableTableEntry aVte) {
-			return new DeduceElement3_VariableTableEntry.Diagnostic_8885(aVte);
-		}
-
-		public FT_FnCallArgs.DoAssignCall new_DoAssignCall(final DeduceClient4 aClient4,
-														   final BaseEvaFunction aGeneratedFunction, final FT_FnCallArgs aFT_FnCallArgs) {
-			return new FT_FnCallArgs.DoAssignCall(aClient4, aGeneratedFunction);
-		}
-
-		public DR_Item new_DR_Ident(final IdentTableEntry aIdentTableEntry, final BaseEvaFunction aGeneratedFunction, final DeduceTypes2 aDeduceTypes2) {
-			return DR_Ident.create(aIdentTableEntry, aGeneratedFunction/* , aDeduceTypes2 */);
-		}
-
-		public DR_IdentUnderstandings.ElementUnderstanding new_DR_Ident_ElementUnderstanding(final OS_Element aEl) {
-			return new DR_IdentUnderstandings.ElementUnderstanding(aEl);
-		}
-
-		public DR_PossibleTypeCI new_DR_PossibleTypeCI(final ClassInvocation aCi, final FunctionInvocation aFi) {
-			return new DR_PossibleTypeCI(aCi, aFi);
-		}
-
-		public DT_Env new_DT_Env(final ElLog aLOG, final ErrSink aErrSink, final DeduceCentral aCentral) {
-			return new DT_Env(aLOG, aErrSink, aCentral);
-		}
-
-		public DT_External_2 new_DT_External_2(final IdentTableEntry aIdentTableEntry,
-											   final OS_Module aModule,
-											   final ProcTableEntry aPte,
-											   final FT_FCA_IdentIA.FakeDC4 aDc,
-											   final ElLog aLOG,
-											   final Context aCtx,
-											   final BaseEvaFunction aGeneratedFunction,
-											   final int aInstructionIndex,
-											   final IdentIA aIdentIA,
-											   final VariableTableEntry aVte) {
-			return new DT_External_2(aIdentTableEntry, aModule, aPte, aDc, aLOG, aCtx, aGeneratedFunction, aInstructionIndex, aIdentIA, aVte);
-		}
-
-		public DTR_IdentExpression new_DTR_IdentExpression(final DeduceTypeResolve aDeduceTypeResolve,
-														   final IdentExpression aIdentExpression, final BaseTableEntry aBte) {
-			return new DTR_IdentExpression(aDeduceTypeResolve, aIdentExpression, aBte);
-		}
-
-		public DTR_VariableStatement new_DTR_VariableStatement(final DeduceTypeResolve aDeduceTypeResolve,
-															   final VariableStatement aVariableStatement) {
-			return new DTR_VariableStatement(aDeduceTypeResolve, aVariableStatement);
-		}
-
-		public ElLog new_ElLog(final String aFileName, final ElLog_.Verbosity aVerbosity, final String aPhase) {
-			return new ElLog_(aFileName, aVerbosity, aPhase);
-		}
-
-		public EN_Usage new_EN_DeduceUsage(final InstructionArgument aBacklink, final BaseEvaFunction aGf,
-										   final IdentTableEntry aIte) {
-			return new EN_DeduceUsage(aBacklink, aGf, aIte);
-		}
-
-		public EN_Usage new_EN_NameUsage(final EN_Name aName, final DeduceElement3_IdentTableEntry aDe3Ite) {
-			return new EN_NameUsage(aName, aDe3Ite);
-		}
-
-		public EN_Understanding new_ENU_AliasedFrom(final AliasStatement aOrigE) {
-			return new ENU_AliasedFrom(aOrigE);
-		}
-
-		public EN_Understanding new_ENU_ClassName() {
-			return new ENU_ClassName();
-		}
-
-		public EN_Understanding new_ENU_ConstructorCallTarget() {
-			return new ENU_ConstructorCallTarget();
-		}
-
-		public EN_Understanding new_ENU_FunctionCallTarget(final ProcTableEntry aPte) {
-			return new ENU_FunctionCallTarget(aPte);
-		}
-
-		public EN_Understanding new_ENU_FunctionInvocation(final ProcTableEntry aCallablePte) {
-			return new ENU_FunctionInvocation(aCallablePte);
-		}
-
-		public EN_Understanding new_ENU_FunctionName() {
-			return new ENU_FunctionName();
-		}
-
-		public EN_Understanding new_ENU_LangConstVar() {
-			return new ENU_LangConstVar();
-		}
-
-		public EN_Understanding new_ENU_LookupResult(final LookupResultList aLrl) {
-			return new ENU_LookupResult(aLrl);
-		}
-
-		public EN_Understanding new_ENU_ResolveToFunction(final FunctionDef aFd) {
-			return new ENU_ResolveToFunction(aFd);
-		}
-
-		public EN_Understanding new_ENU_TypeTransitiveOver(final ProcTableEntry aPte) {
-			return new ENU_TypeTransitiveOver(aPte);
-		}
-
-		public EN_Understanding new_ENU_VariableName() {
-			return new ENU_VariableName();
-		}
-
-		public FT_FCA_IdentIA.FakeDC4 new_FakeDC4(final DeduceClient4 aDc4, final FT_FCA_IdentIA aFT_FCA_IdentIA) {
-			return aFT_FCA_IdentIA.new FakeDC4(aDc4);
-		}
-
-		public Found_Element_For_ITE new_Found_Element_For_ITE(final BaseEvaFunction aGeneratedFunction,
-															   final Context aCtx, final DT_Env aEnv, final DeduceClient1 aDeduceClient1) {
-			return new Found_Element_For_ITE(aGeneratedFunction, aCtx, aEnv, aDeduceClient1);
-		}
-
-		public FT_FCA_ClassStatement new_FT_FCA_ClassStatement(final ClassStatement aEl) {
-			return new FT_FCA_ClassStatement(aEl);
-		}
-
-		public FT_FCA_IdentIA.FT_FCA_Ctx new_FT_FCA_Ctx(final BaseEvaFunction aGeneratedFunction,
-														final TypeTableEntry aTte, final Context aCtx, final ErrSink aErrSink, final DeduceClient4 aDc) {
-			return new FT_FCA_IdentIA.FT_FCA_Ctx(aGeneratedFunction, aTte, aCtx, aErrSink, aDc);
-		}
-
-		public FT_FCA_FormalArgListItem new_FT_FCA_FormalArgListItem(final FormalArgListItem aFali,
-																	 final BaseEvaFunction aGeneratedFunction) {
-			return new FT_FCA_FormalArgListItem(aFali, aGeneratedFunction);
-		}
-
-		public FT_FCA_FunctionDef new_FT_FCA_FunctionDef(final FunctionDef aEl, final DeduceTypes2 aDeduceTypes2) {
-			return new FT_FCA_FunctionDef(aEl, aDeduceTypes2);
-		}
-
-		public FT_FCA_IdentIA new_FT_FCA_IdentIA(final FT_FnCallArgs aFTFnCallArgs, final IdentIA aIdentIA,
-												 final VariableTableEntry aVte) {
-			return new FT_FCA_IdentIA(aFTFnCallArgs, aIdentIA, aVte);
-		}
-
-		public FT_FCA_IdentIA.Resolve_VTE new_FT_FCA_IdentIA_Resolve_VTE(final VariableTableEntry aVte,
-																		 final Context aCtx, final ProcTableEntry aPte, final Instruction aInstruction, final FnCallArgs aFca) {
-			return new FT_FCA_IdentIA.Resolve_VTE(aVte, aCtx, aPte, aInstruction, aFca);
-		}
-
-		public FT_FCA_IdentIA.FT_FCA_ProcedureCall new_FT_FCA_ProcedureCall(final ProcedureCallExpression aPce,
-																			final Context aCtx, final FT_FCA_IdentIA aFT_FCA_IdentIA) {
-			return aFT_FCA_IdentIA.new FT_FCA_ProcedureCall(aPce, aCtx);
-		}
-
-		public FT_FCA_VariableStatement new_FT_FCA_VariableStatement(final VariableStatementImpl aVs,
-																	 final BaseEvaFunction aGeneratedFunction) {
-			return new FT_FCA_VariableStatement(aVs, aGeneratedFunction);
-		}
-
-		public ITastic new_FT_FnCallArgs(final DeduceTypes2 aDeduceTypes2, final FnCallArgs aO) {
-			return new FT_FnCallArgs(aDeduceTypes2, aO);
-		}
-
-		public FoundElement new_FT_FnCallArgs_DoAssignCall_NullFoundElement(final DeduceClient4 aDc) {
-			return new FT_FnCallArgs.NullFoundElement(aDc);
-		}
-
-		public FunctionDef new_FunctionDefImpl(final NamespaceStatement aModNs, final Context aContext) {
-			return new FunctionDefImpl(aModNs, aContext);
-		}
-
-		public IElementHolder new_GenericElementHolder(final OS_Element aBest) {
-			return new GenericElementHolder(aBest);
-		}
-
-		public IElementHolder new_GenericElementHolderWithDC(final OS_Element aEl, final DeduceClient3 aDc,
-															 final Resolve_Ident_IA aResolve_Ident_IA) {
-			return aResolve_Ident_IA.new GenericElementHolderWithDC(aEl, aDc);
-		}
-
-		public IElementHolder new_GenericElementHolderWithType(final OS_Element aElement, final OS_Type aTypeName,
-															   final DeduceTypes2 aDeduceTypes2) {
-			return new GenericElementHolderWithType(aElement, aTypeName, aDeduceTypes2);
-		}
-
-		public GenericPart new_GenericPart(final ClassStatement aBest, final NormalTypeName aTyn1) {
-			return new GenericPart(aBest, aTyn1);
-		}
-
-		public GenType new_GenTypeImpl() {
-			return new GenTypeImpl();
-		}
-
-		public GenType new_GenTypeImpl(final ClassStatement aKlass) {
-			return new GenTypeImpl(aKlass);
-		}
-
-		public GenType new_GenTypeImpl(final NamespaceStatement aParent) {
-			return new GenTypeImpl(aParent);
-		}
-
-		public GenType new_GenTypeImpl(final OS_Type aAttached, final OS_Type aOSType, final boolean aB,
-									   final TypeName aX, final DeduceTypes2 aDt2, final ErrSink aErrSink, final DeducePhase aPhase) {
-			return new GenTypeImpl(aAttached, aOSType, aB, aX, aDt2, aErrSink, aPhase);
-		}
-
-		public Map<OS_Element, DG_Item> new_HashMap_DGS() {
-			return new HashMap<>();
-		}
-
-		public Implement_construct.ICH new_ICH(final GenType aGenType, final Implement_construct aImplement_construct) {
-			return aImplement_construct.new ICH(aGenType);
-		}
-
-		public @NotNull IdentIA new_IdentIA(int index, @NotNull BaseEvaFunction generatedFunction) {
-			return new IdentIA(index, generatedFunction);
-		}
-
-		public IdentTableEntry new_IdentTableEntry(final int aI, final IdentExpression aIdentExpression,
-												   final Context aContext, final BaseEvaFunction aGeneratedFunction) {
-			return new IdentTableEntry(aI, aIdentExpression, aContext, aGeneratedFunction);
-		}
-
-		public Implement_Calls_ new_Implement_Calls_(final BaseEvaFunction aGeneratedFunction, final Context aFdCtx,
-													 final InstructionArgument aI2, final ProcTableEntry aFn1, final int aPc,
-													 final DeduceTypes2 aDeduceTypes2) {
-			return aDeduceTypes2.new Implement_Calls_(aGeneratedFunction, aFdCtx, aI2, aFn1, aPc);
-		}
-
-		public Implement_construct new_Implement_construct(final DeduceTypes2 aDeduceTypes2,
-														   final BaseEvaFunction aGeneratedFunction, final Instruction aInstruction) {
-			return new Implement_construct(aDeduceTypes2, aGeneratedFunction, aInstruction);
-		}
-
-		public IdentTableEntry.ITE_Resolver_Result new_ITE_Resolver_Result(final OS_Element aE) {
-			return new IdentTableEntry.ITE_Resolver_Result(aE);
-		}
-
-		public List<DT_External> new_LinkedList__DT_External() {
-			return new ArrayList<>();
-		}
-
-		public List<EvaClass> new_LinkedList__EvaClass() {
-			return new ArrayList<>();
-		}
-
-		public DeduceLocalVariable.MemberInvocation new_MemberInvocation(final ClassStatement aB,
-																		 final DeduceLocalVariable.MemberInvocation.Role aRole) {
-			return new DeduceLocalVariable.MemberInvocation(aB, aRole);
-		}
-
-		public NamespaceInvocation new_NamespaceInvocation(final NamespaceStatement aModNs) {
-			return new NamespaceInvocation(aModNs);
-		}
-
-		public NamespaceStatement new_NamespaceStatementImpl(final OS_Module aModule, final Context aContext) {
-			return new NamespaceStatementImpl(aModule, aContext);
-		}
-
-		public IVariableConnector new_NullConnector() {
-			return new NullConnector();
-		}
-
-		public OS_Type new_OS_BuiltinType(final BuiltInTypes aBuiltInType) {
-			return new OS_BuiltinType(aBuiltInType);
-		}
-
-		public OS_Type new_OS_UnknownType(final OS_Element aElement) {
-			return new OS_UnknownType(aElement);
-		}
-
-		public OS_Type new_OS_UnknownType(final StatementWrapperImpl aStatementWrapper) {
-			return new OS_UnknownType(aStatementWrapper);
-		}
-
-		public OS_UserType new_OS_UserType(final TypeName aTypeName) {
-			return new OS_UserType(aTypeName);
-		}
-
-		public BaseTableEntry.StatusListener new_ProcTableListener(final ProcTableEntry aPte,
-																   final BaseEvaFunction aGeneratedFunction, final DeduceClient2 aO) {
-			return new ProcTableListener(aPte, aGeneratedFunction, aO);
-		}
-
-		public <B> PromiseExpectation<B> new_PromiseExpectation(final ExpectationBase aBase, final String aDesc,
-																final DeduceTypes2 aDeduceTypes2) {
-			return new PromiseExpectation<B>(aDeduceTypes2, aBase, aDesc);
-		}
-
-		public PromiseExpectations new_PromiseExpectations(final DeduceTypes2 aDeduceTypes2) {
-			return new PromiseExpectations();
-		}
-
-		public RegularTypeName new_RegularTypeNameImpl(final Context aContext) {
-			return new RegularTypeNameImpl(aContext);
-		}
-
-		public Resolve_each_typename new_Resolve_each_typename(final DeducePhase aPhase,
-															   final DeduceTypes2 aDeduceTypes2, final ErrSink aErrSink) {
-			return aDeduceTypes2.new Resolve_each_typename(aPhase, aDeduceTypes2, aErrSink);
-		}
-
-		public Resolve_Ident_IA new_Resolve_Ident_IA(final DeduceClient3 aDeduceClient3, final Context aContext,
-													 final DeduceElementIdent aDei, final BaseEvaFunction aGeneratedFunction,
-													 final FoundElement aFoundElement, final ErrSink aErrSink) {
-			return new Resolve_Ident_IA(aDeduceClient3, aContext, aDei, aGeneratedFunction, aFoundElement, aErrSink);
-		}
-
-		public Resolve_Ident_IA new_Resolve_Ident_IA(final DeduceClient3 aDeduceClient3, final Context aContext,
-													 final IdentIA aIdentIA, final BaseEvaFunction aGeneratedFunction, final FoundElement aFoundElement,
-													 final ErrSink aErrSink) {
-			return new Resolve_Ident_IA(aDeduceClient3, aContext, aIdentIA, aGeneratedFunction, aFoundElement,
-										aErrSink
-			);
-		}
-
-		public Resolve_Ident_IA2 new_Resolve_Ident_IA2(final DeduceTypes2 aDeduceTypes2, final ErrSink aErrSink,
-													   final DeducePhase aPhase, final BaseEvaFunction aGeneratedFunction, final FoundElement aFoundElement) {
-			return new Resolve_Ident_IA2(aDeduceTypes2, aErrSink, aPhase, aGeneratedFunction, aFoundElement);
-		}
-
-		public Resolve_Variable_Table_Entry new_Resolve_Variable_Table_Entry(final BaseEvaFunction aGeneratedFunction,
-																			 final Context aContext, final DeduceTypes2 aDeduceTypes2) {
-			return new Resolve_Variable_Table_Entry(aGeneratedFunction, aContext, aDeduceTypes2);
-		}
-
-		public Diagnostic new_ResolveError(final IdentExpression aIdent, final LookupResultList aLrl) {
-			return new ResolveError(aIdent, aLrl);
-		}
-
-		public Diagnostic new_ResolveError(final TypeName aX, final LookupResultList aLrl) {
-			return new ResolveError(aX, aLrl);
-		}
-
-		public Resolve_Ident_IA2.RIA_Clear_98 new_RIA_Clear_98(final IdentTableEntry aIdte,
-															   final VariableStatementImpl aVs, final Context aCtx, final Resolve_Ident_IA2 aResolve_Ident_IA2) {
-			return aResolve_Ident_IA2.new RIA_Clear_98(aIdte, aVs, aCtx);
-		}
-
-		public setup_GenType_Action new_SGTA_RegisterClassInvocation(final ClassStatement aClassStatement,
-																	 final DeducePhase aPhase) {
-			return new SGTA_RegisterClassInvocation(aClassStatement, aPhase);
-		}
-
-		public setup_GenType_Action new_SGTA_RegisterNamespaceInvocation(final NamespaceStatement aNamespaceStatement,
-																		 final DeducePhase aPhase) {
-			return new SGTA_RegisterNamespaceInvocation(aNamespaceStatement, aPhase);
-		}
-
-		public setup_GenType_Action new_SGTA_SetClassInvocation() {
-			return new SGTA_SetClassInvocation();
-		}
-
-		public setup_GenType_Action new_SGTA_SetNamespaceInvocation() {
-			return new SGTA_SetNamespaceInvocation();
-		}
-
-		public SGTA_SetResolvedClass new_SGTA_SetResolvedClass(final ClassStatement aKlass) {
-			return new SGTA_SetResolvedClass(aKlass);
-		}
-
-		public setup_GenType_Action new_SGTA_SetResolvedNamespace(final NamespaceStatement aNamespaceStatement) {
-			return new SGTA_SetResolvedNamespace(aNamespaceStatement);
-		}
-
-		public StatementWrapperImpl new_StatementWrapperImpl(final IExpression aLeft, final Context aO,
-															 final OS_Element aO1) {
-			return new StatementWrapperImpl(aLeft, aO, aO1);
-		}
-
-		public BaseTableEntry.StatusListener new_StatusListener__RIA__176(final IdentTableEntry aY,
-																		  final FoundElement aFoundElement, final Resolve_Ident_IA aResolve_Ident_IA) {
-			return aResolve_Ident_IA.new StatusListener__RIA__176(aY, aFoundElement);
-		}
-
-		public ITasticMap new_TasticMap() {
-			return new TasticMap_1();
-		}
-
-		public TypeTableEntry new_TypeTableEntry(final int aI, final TypeTableEntry.Type aType, final OS_Type aTypeName,
-												 final IdentExpression aIdent, final TableEntryIV aO) {
-			return new TypeTableEntry(aI, aType, aTypeName, aIdent, aO);
-		}
-
-		public ITE_Resolver new_Unnamed_ITE_Resolver1(final DeduceTypes2 aDeduceTypes2, final IdentTableEntry aIte,
-													  final BaseEvaFunction aGeneratedFunction, final Context aContext) {
-			return new Unnamed_ITE_Resolver1(aDeduceTypes2, aIte, aGeneratedFunction, aContext);
-		}
-
-		public WorkJob new_WlDeduceFunction(final WorkJob aGen, final List<BaseEvaFunction> aColl,
-											final DeduceTypes2 aDeduceTypes2) {
-			return aDeduceTypes2.new WlDeduceFunction(aGen, aColl);
-		}
-
-		public WlGenerateClass new_WlGenerateClass(final GenerateFunctions aGenerateFunctions,
-												   final ClassInvocation aCi, final DeducePhase.GeneratedClasses aGeneratedClasses,
-												   final ICodeRegistrar aCodeRegistrar) {
-			return new WlGenerateClass(aGenerateFunctions, aCi, aGeneratedClasses, aCodeRegistrar);
-		}
-
-		public WlGenerateCtor new_WlGenerateCtor(final GenerateFunctions aGenerateFunctions,
-												 final FunctionInvocation aFi,
-												 final IdentExpression aIdentExpression,
-												 final ICodeRegistrar aCodeRegistrar) {
-			return new WlGenerateCtor(aGenerateFunctions, aFi, aIdentExpression, aCodeRegistrar);
-		}
-
-		public WlGenerateCtor new_WlGenerateCtor(final OS_Module aModule,
-												 final IdentExpression aNameNode,
-												 final FunctionInvocation aFunctionInvocation,
-												 final DeduceCreationContext aCl) {
-			return new WlGenerateCtor(aModule, aFunctionInvocation.getFunction().getNameNode(), aFunctionInvocation, aCl);
-		}
-
-		public @NotNull WlGenerateDefaultCtor new_WlGenerateDefaultCtor(final GenerateFunctions aGf,
-																		final FunctionInvocation aDependentFunction,
-																		final DeduceCreationContext aDeduceCreationContext,
-																		final ICodeRegistrar aCodeRegistrar) {
-			return new WlGenerateDefaultCtor(aGf, aDependentFunction, aDeduceCreationContext, aCodeRegistrar);
-		}
-
-		public WlGenerateDefaultCtor new_WlGenerateDefaultCtor(final OS_Module aModule,
-															   final FunctionInvocation aFunctionInvocation,
-															   final @NotNull DeduceCreationContext aCl) {
-			return new WlGenerateDefaultCtor(aModule, aFunctionInvocation, aCl);
-		}
-
-		public @Nullable WlGenerateFunction new_WlGenerateFunction(final GenerateFunctions aGf,
-																   final FunctionInvocation aDependentFunction,
-																   final ICodeRegistrar aCodeRegistrar) {
-			return new WlGenerateFunction(aGf, aDependentFunction, aCodeRegistrar);
-		}
-
-		public WlGenerateFunction new_WlGenerateFunction(final OS_Module aModule,
-														 final FunctionInvocation aDependentFunction,
-														 final DeduceCreationContext aCl) {
-			return new WlGenerateFunction(aModule, aDependentFunction, aCl);
-		}
-
-		public WlGenerateNamespace new_WlGenerateNamespace(final GenerateFunctions aGenerateFunctions,
-														   final NamespaceInvocation aCi,
-														   final DeducePhase.GeneratedClasses aGeneratedClasses,
-														   final ICodeRegistrar aCodeRegistrar) {
-			return new WlGenerateNamespace(aGenerateFunctions, aCi, aGeneratedClasses, aCodeRegistrar);
-		}
-
-		public WorkList new_WorkList() {
-			return new WorkList__();
-		}
-
-		public WorkManager new_WorkManager() {
-			return new WorkManager__();
-		}
-
-		public Zero new_Zero(final DeduceTypes2 aDeduceTypes2) {
-			return aDeduceTypes2.new Zero();
-		}
-
-		public abstract static class DerivedClassInvocation2 {
-			public IInvocation asInvocation() {
-				return carrier;
-			}
-
-			protected IInvocation carrier;
-
-			public abstract void into(final Eventual<IInvocation> aInvocationP);
-		}
-
-		@SuppressWarnings("UnnecessaryLocalVariable")
-		public DerivedClassInvocation2 new_DerivedClassInvocation2(final ClassStatement aDeclAnchor,
-																   final ClassInvocation aDeclaredInvocation,
-																   final ReadySupplier_1<DeduceTypes2> dtSupplier) {
-			final DerivedClassInvocation2 result = new DerivedClassInvocation2() {
-				@Override
-				public void into(final Eventual<IInvocation> aInvocationP) {
-					if (this.carrier == null) {
-						this.carrier = new_DerivedClassInvocation(aDeclAnchor, aDeclaredInvocation, dtSupplier);
-					}
-
-					aInvocationP.resolve(this.carrier);
-				}
-			};
-			return result;
-		}
-	}
-
-	static class NullConnector implements IVariableConnector {
-		@Override
-		public void connect(final VariableTableEntry aVte, final String aName) {
-		}
-	}
-
-	public static class OS_SpecialVariable implements OS_Element {
-		private final BaseEvaFunction                      generatedFunction;
-		private final VariableTableType                    type;
-		private final VariableTableEntry                   variableTableEntry;
-		public        DeduceLocalVariable.MemberInvocation memberInvocation;
-
-		public OS_SpecialVariable(final VariableTableEntry aVariableTableEntry, final VariableTableType aType,
-								  final BaseEvaFunction aGeneratedFunction) {
-			variableTableEntry = aVariableTableEntry;
-			type               = aType;
-			generatedFunction  = aGeneratedFunction;
-		}
-
-		@Override
-		public Context getContext() {
-			return generatedFunction.getFD().getContext();
-		}
-
-		@Override
-		public @NotNull OS_Element getParent() {
-			return generatedFunction.getFD();
-		}
-
-		@Override
-		public void serializeTo(final SmallWriter sw) {
-
-		}
-
-		@Override
-		public void visitGen(final ElElementVisitor visit) {
-			throw new IllegalArgumentException("not implemented");
-		}
-
-		@Nullable
-		public IInvocation getInvocation(final @NotNull DeduceTypes2 aDeduceTypes2) {
-			final @Nullable IInvocation aInvocation;
-			final OS_SpecialVariable    specialVariable = this;
-			assert specialVariable.type == VariableTableType.SELF;
-			// first parent is always a function
-			switch (DecideElObjectType.getElObjectType(specialVariable.getParent().getParent())) {
-			case CLASS:
-				final ClassStatement classStatement = (ClassStatement) specialVariable.getParent().getParent();
-				aInvocation = aDeduceTypes2.phase.registerClassInvocation(classStatement, null,
-																		  new ReadySupplier_1<>(aDeduceTypes2)
-																		 ); // TODO generics
-//				ClassInvocationMake.withGenericPart(classStatement, null, null, this);
-				break;
-			case NAMESPACE:
-				throw new NotImplementedException(); // README ha! implemented in
-			default:
-				throw new IllegalArgumentException("Illegal object type for parent");
-			}
-			return aInvocation;
-		}
-	}
-
-	class _DT_Function implements DT_Function {
-
-		private final BaseEvaFunction carrier;
-		private final DeduceTypes2    deduceTypes2;
-
-		public _DT_Function(BaseEvaFunction aGeneratedFunction, final DeduceTypes2 aDeduceTypes2) {
-			carrier      = aGeneratedFunction;
-			deduceTypes2 = aDeduceTypes2;
-		}
-
-		@Override
-		public List<VariableTableEntry> vte_list() {
-			return carrier.vte_list;
-		}
-
-		@Override
-		public List<IdentTableEntry> idte_list() {
-			return carrier.idte_list;
-		}
-
-		@Override
-		public List<ProcTableEntry> prte_list() {
-			return carrier.prte_list;
-		}
-
-		@Override
-		public BaseEvaFunction get() {
-			return carrier;
-		}
-
-		@Override
-		public List<ConstantTableEntry> cte_list() {
-			return carrier.cte_list;
-		}
-
-		@Override
-		public void add_proc_table_listeners() {
-			final @NotNull BaseEvaFunction   generatedFunction = get();
-			final __Add_Proc_Table_Listeners aptl              = deduceTypes2._inj().new___Add_Proc_Table_Listeners();
-
-			for (final @NotNull ProcTableEntry pte : generatedFunction.prte_list) {
-				aptl.add_proc_table_listeners(generatedFunction, pte, deduceTypes2);
-			}
-		}
-
-		@Override
-		public void resolve_ident_table(final Context aContext) {
-			for (@NotNull IdentTableEntry ite : this.idte_list()) {
-				ite.resolveExpectation = promiseExpectation(ite, "Element Resolved");
-				ite.addResolver(_inj().new_Unnamed_ITE_Resolver1(deduceTypes2, ite, this.get(), aContext));
-			}
-
-			for (@NotNull IdentTableEntry ite : this.idte_list()) {
-				ite.resolvers_round();
-			}
-		}
-
-		@Override
-		public void resolve_arguments_table(final Context aContext) {
-			final @NotNull Resolve_Variable_Table_Entry    rvte      = _inj().new_Resolve_Variable_Table_Entry(carrier, aContext, deduceTypes2);
-			final @NotNull DeduceTypes2.IVariableConnector connector = getVariableConnector();
-
-			for (final @NotNull VariableTableEntry vte : vte_list()) {
-				rvte.action(vte, connector);
-			}
-		}
-
-		private @NotNull DeduceTypes2.IVariableConnector getVariableConnector() {
-			final @NotNull DeduceTypes2.IVariableConnector connector;
-			if (carrier instanceof EvaConstructor) {
-				final IEvaConstructor evaConstructor = (IEvaConstructor) carrier;
-				connector = _inj().new_CtorConnector(evaConstructor, deduceTypes2);
-			} else {
-				connector = _inj().new_NullConnector();
-			}
-			return connector;
-		}
-
-	}
-
-	public class DeduceClient4 {
-		private final DeduceTypes2 deduceTypes2;
-
-		public DeduceClient4(final DeduceTypes2 aDeduceTypes2) {
-			deduceTypes2 = aDeduceTypes2;
-		}
-
-		public @Nullable OS_Element _resolveAlias(final @NotNull AliasStatement aAliasStatement) {
-			return DeduceLookupUtils._resolveAlias(aAliasStatement, deduceTypes2);
-		}
-
-		public @Nullable OS_Element _resolveAlias2(final @NotNull AliasStatementImpl aAliasStatement)
-		throws ResolveError {
-			return DeduceLookupUtils._resolveAlias2(aAliasStatement, deduceTypes2);
-		}
-
-		public @NotNull DeferredMemberFunction deferred_member_function(final OS_Element aParent,
-																		final IInvocation aInvocation, final @NotNull FunctionDef aFunctionDef,
-																		final @NotNull FunctionInvocation aFunctionInvocation) {
-			return deduceTypes2.deferred_member_function(aParent, aInvocation, aFunctionDef, aFunctionInvocation);
-		}
-
-		public void forFunction(final @NotNull FunctionInvocation aFunctionInvocation,
-								final @NotNull ForFunction aForFunction) {
-			deduceTypes2.forFunction(aFunctionInvocation, aForFunction);
-		}
-
-		public void found_element_for_ite(final BaseEvaFunction aGeneratedFunction,
-										  final @NotNull IdentTableEntry aEntry, final OS_Element aE, final Context aCtx) {
-			deduceTypes2.found_element_for_ite(aGeneratedFunction, aEntry, aE, aCtx, central());
-		}
-
-		public ClassInvocation genCI(final @NotNull GenType aType, final TypeName aGenericTypeName) {
-			return aType.genCI(aGenericTypeName, deduceTypes2, deduceTypes2.errSink, deduceTypes2.phase);
-		}
-
-		public DeduceTypes2 get() {
-			return deduceTypes2;
-		}
-
-		public ErrSink getErrSink() {
-			return deduceTypes2.errSink;
-		}
-
-		public IInvocation getInvocation(final @NotNull EvaFunction aGeneratedFunction) {
-			return deduceTypes2.getInvocation(aGeneratedFunction);
-		}
-
-		public @NotNull ElLog getLOG() {
-			return LOG;
-		}
-
-		public @NotNull OS_Module getModule() {
-			return module;
-		}
-
-		public @NotNull DeducePhase getPhase() {
-			return deduceTypes2.phase;
-		}
-
-		public @NotNull List<TypeTableEntry> getPotentialTypesVte(final @NotNull EvaFunction aGeneratedFunction,
-																  final @NotNull InstructionArgument aVte_ia) {
-			return deduceTypes2.getPotentialTypesVte(aGeneratedFunction, aVte_ia);
-		}
-
-		public OS_Type gt(final @NotNull GenType aType) {
-			return deduceTypes2.gt(aType);
-		}
-
-		public void implement_calls(final @NotNull BaseEvaFunction aGeneratedFunction, final @NotNull Context aParent,
-									final @NotNull InstructionArgument aArg, final @NotNull ProcTableEntry aPte,
-									final int aInstructionIndex) {
-			if (aGeneratedFunction.deferred_calls.contains(aInstructionIndex)) {
-				deduceTypes2.LOG.err("Call is deferred "/* +gf.getInstruction(pc) */ + " " + aPte);
-				return;
-			}
-			Implement_Calls_ ic = _inj().new_Implement_Calls_(aGeneratedFunction, aParent, aArg, aPte,
-															  aInstructionIndex, deduceTypes2
-															 );
-			ic.action();
-		}
-
-		public @Nullable OS_Element lookup(final @NotNull IdentExpression aElement, final @NotNull Context aContext)
-		throws ResolveError {
-			return DeduceLookupUtils.lookup(aElement, aContext, deduceTypes2);
-		}
-
-		public LookupResultList lookupExpression(final @NotNull IExpression aExpression,
-												 final @NotNull Context aContext) throws ResolveError {
-			return DeduceLookupUtils.lookupExpression(aExpression, aContext, deduceTypes2);
-		}
-
-		public @NotNull FunctionInvocation newFunctionInvocation(final FunctionDef aElement, final ProcTableEntry aPte,
-																 final @NotNull IInvocation aInvocation) {
-			return deduceTypes2.newFunctionInvocation(aElement, aPte, aInvocation, deduceTypes2.phase);
-		}
-
-		public void onFinish(final Runnable aRunnable) {
-			deduceTypes2.onFinish(aRunnable);
-		}
-
-		public <T> @NotNull PromiseExpectation<T> promiseExpectation(final BaseEvaFunction aGeneratedFunction,
-																	 final String aName) {
-			return deduceTypes2.promiseExpectation(aGeneratedFunction, aName);
-		}
-
-		public void register_and_resolve(final @NotNull VariableTableEntry aVte,
-										 final @NotNull ClassStatement aClassStatement) {
-			deduceTypes2.register_and_resolve(aVte, aClassStatement);
-		}
-
-		public @NotNull ClassInvocation registerClassInvocation(final @NotNull ClassInvocation aCi) {
-			return deduceTypes2.phase.registerClassInvocation(aCi);
-		}
-
-		public @Nullable ClassInvocation registerClassInvocation(final @NotNull ClassStatement aClassStatement,
-																 final String constructorName) {
-			return deduceTypes2.phase.registerClassInvocation(aClassStatement, constructorName,
-															  new ReadySupplier_1<>(deduceTypes2)
-															 );
-		}
-
-		public NamespaceInvocation registerNamespaceInvocation(final NamespaceStatement aNamespaceStatement) {
-			return deduceTypes2.phase.registerNamespaceInvocation(aNamespaceStatement);
-		}
-
-		public void reportDiagnostic(final ResolveError aResolveError) {
-			deduceTypes2.errSink.reportDiagnostic(aResolveError);
-		}
-
-		public @NotNull GenType resolve_type(final @NotNull OS_Type aTy, final Context aCtx) throws ResolveError {
-			return deduceTypes2.resolve_type(aTy, aCtx);
-		}
-
-		public void resolveIdentIA_(final @NotNull Context aCtx, final @NotNull IdentIA aIdentIA,
-									final @NotNull BaseEvaFunction aGeneratedFunction, final @NotNull FoundElement aFoundElement) {
-			deduceTypes2.resolveIdentIA_(aCtx, aIdentIA, aGeneratedFunction, aFoundElement);
-		}
-	}
-
-	class Dependencies {
-		final WorkList    wl = _inj().new_WorkList();
-		final WorkManager wm;
-
-		Dependencies(final WorkManager aWm) {
-			wm = aWm;
-		}
-
-		public void subscribeFunctions(final @NotNull Subject<FunctionInvocation> aDependentFunctionSubject) {
-			aDependentFunctionSubject.subscribe(new Observer<FunctionInvocation>() {
-				@Override
-				public void onSubscribe(@NonNull final Disposable d) {
-
-				}
-
-				@Override
-				public void onNext(@NonNull final @NotNull FunctionInvocation aFunctionInvocation) {
-					action_function(aFunctionInvocation);
-				}
-
-				@Override
-				public void onError(@NonNull final Throwable e) {
-
-				}
-
-				@Override
-				public void onComplete() {
-
-				}
-			});
-		}
-
-		public void action_function(@NotNull FunctionInvocation aDependentFunction) {
-			final FunctionDef        function = aDependentFunction.getFunction();
-			WorkJob                  gen;
-			final @NotNull OS_Module mod;
-			if (function == LangGlobals.defaultVirtualCtor) {
-				ClassInvocation ci = aDependentFunction.getClassInvocation();
-				if (ci == null) {
-					NamespaceInvocation ni = aDependentFunction.getNamespaceInvocation();
-					assert ni != null;
-					mod = ni.getNamespace().getContext().module();
-
-					ni.resolvePromise().then(result -> result.dependentFunctions().add(aDependentFunction));
-				} else {
-					mod = ci.getKlass().getContext().module();
-					ci.resolvePromise().then(result -> result.dependentFunctions().add(aDependentFunction));
-				}
-				final @NotNull GenerateFunctions gf = getGenerateFunctions(mod);
-				gen = _inj().new_WlGenerateDefaultCtor(gf, aDependentFunction, creationContext(),
-													   phase.getCodeRegistrar()
-													  );
-			} else {
-				mod = function.getContext().module();
-				final @NotNull GenerateFunctions gf = getGenerateFunctions(mod);
-				gen = _inj().new_WlGenerateFunction(gf, aDependentFunction, phase.getCodeRegistrar());
-			}
-			wl.addJob(gen);
-			List<BaseEvaFunction> coll = new ArrayList<>();
-			wl.addJob(_inj().new_WlDeduceFunction(gen, coll, DeduceTypes2.this));
-			wm.addJobs(wl);
-		}
-
-		public void subscribeTypes(final @NotNull Subject<GenType> aDependentTypesSubject) {
-			aDependentTypesSubject.subscribe(new Observer<GenType>() {
-				@Override
-				public void onSubscribe(@NonNull final Disposable d) {
-				}
-
-				@Override
-				public void onNext(final @NotNull GenType aGenType) {
-					action_type(aGenType);
-				}
-
-				@Override
-				public void onError(final Throwable aThrowable) {
-				}
-
-				@Override
-				public void onComplete() {
-				}
-			});
-		}
-
-		public void action_type(@NotNull GenType genType) {
-			// TODO work this out further, maybe like a Deepin flavor
-			if (genType.getResolvedn() != null) {
-				@NotNull
-				OS_Module mod = genType.getResolvedn().getContext().module();
-				final @NotNull GenerateFunctions gf = phase.generatePhase.getGenerateFunctions(mod);
-				NamespaceInvocation              ni = phase.registerNamespaceInvocation(genType.getResolvedn());
-				@NotNull
-				WlGenerateNamespace gen = _inj().new_WlGenerateNamespace(gf, ni, phase.generatedClasses,
-																		 phase.getCodeRegistrar()
-																		);
-
-				assert genType.getCi() == null || genType.getCi() == ni;
-				genType.setCi(ni);
-
-				wl.addJob(gen);
-
-				ni.resolvePromise().then(result -> {
-					genType.setNode(result);
-					result.dependentTypes().add(genType);
-				});
-			} else if (genType.getResolved() != null) {
-				if (genType.getFunctionInvocation() != null) {
-					action_function(genType.getFunctionInvocation());
-					return;
-				}
-
-				final ClassStatement             c   = genType.getResolved().getClassOf();
-				final @NotNull OS_Module         mod = c.getContext().module();
-				final @NotNull GenerateFunctions gf  = phase.generatePhase.getGenerateFunctions(mod);
-				@Nullable
-				ClassInvocation ci;
-				if (genType.getCi() == null) {
-					ci = _inj().new_ClassInvocation(c, null, new ReadySupplier_1<>(DeduceTypes2.this));
-					ci = phase.registerClassInvocation(ci);
-
-					genType.setCi(ci);
-				} else {
-					assert genType.getCi() instanceof ClassInvocation;
-					ci = (ClassInvocation) genType.getCi();
-				}
-
-				final Eventual<ClassDefinition> pcd = phase.generateClass2(gf, ci, wm);
-
-				pcd.then(result -> {
-					final EvaClass genclass = (EvaClass) result.getNode();
-
-					genType.setNode(genclass);
-					genclass.dependentTypes().add(genType);
-				});
-			}
-			//
-			wm.addJobs(wl);
-		}
 	}
 
 	class df_helper_Constructors implements df_helper<IEvaConstructor> {
@@ -2779,465 +1412,6 @@ public class DeduceTypes2 implements GDeduceTypes2 {
 		}
 	}
 
-	private class do_assign_normal_ident_deferred__DT_ResolveObserver implements DT_ResolveObserver {
-		private final @NotNull IdentTableEntry identTableEntry;
-		private final @NotNull BaseEvaFunction generatedFunction;
-
-		public do_assign_normal_ident_deferred__DT_ResolveObserver(final @NotNull IdentTableEntry aIdentTableEntry,
-																   final @NotNull BaseEvaFunction aGeneratedFunction) {
-			identTableEntry   = aIdentTableEntry;
-			generatedFunction = aGeneratedFunction;
-		}
-
-		@Override
-		public void onElement(@Nullable OS_Element best) {
-			if (best != null) {
-				identTableEntry.setStatus(BaseTableEntry.Status.KNOWN, _inj().new_GenericElementHolder(best));
-				// TODO check for elements which may contain type information
-				if (best instanceof final @NotNull VariableStatementImpl vs) {
-					do_assign_normal_ident_deferred_VariableStatement(generatedFunction, identTableEntry, vs);
-				} else if (best instanceof final @NotNull FormalArgListItem fali) {
-					do_assign_normal_ident_deferred_FALI(generatedFunction, identTableEntry, fali);
-				} else
-					throw new NotImplementedException();
-			} else {
-				identTableEntry.setStatus(BaseTableEntry.Status.UNKNOWN, null);
-				LOG.err("242 Bad lookup" + identTableEntry.getIdent().getText());
-			}
-		}
-
-		public void do_assign_normal_ident_deferred_VariableStatement(final @NotNull BaseEvaFunction generatedFunction,
-																	  final @NotNull IdentTableEntry aIdentTableEntry, final @NotNull VariableStatementImpl vs) {
-			final DeduceElementWrapper parent = new DeduceElementWrapper(vs.getParent().getParent());
-			final DeferredMember       dm     = deferred_member(parent, new X_S(generatedFunction).get(), vs, aIdentTableEntry);
-
-			dm.typePromise().done(result -> {
-				assert result.getResolved() != null;
-				aIdentTableEntry.type.setAttached(result.getResolved());
-			});
-
-			final GenType genType = _inj().new_GenTypeImpl();
-			genType.setCi(dm.getInvocation());
-
-			if (genType.getCi() instanceof NamespaceInvocation) {
-				genType.setResolvedn(((NamespaceInvocation) genType.getCi()).getNamespace());
-			} else if (genType.getCi() instanceof ClassInvocation) {
-				genType.setResolved(((ClassInvocation) genType.getCi()).getKlass().getOS_Type());
-			} else {
-				throw new IllegalStateException();
-			}
-			generatedFunction.addDependentType(genType);
-		}
-
-		private void do_assign_normal_ident_deferred_FALI(final @NotNull BaseEvaFunction generatedFunction,
-														  final @NotNull IdentTableEntry aIdentTableEntry, final @NotNull FormalArgListItem fali) {
-			final GenType            genType            = _inj().new_GenTypeImpl();
-			final FunctionInvocation functionInvocation = generatedFunction.fi;
-			final String             fali_name          = fali.name();
-
-			IInvocation invocation = null;
-			if (functionInvocation.getClassInvocation() != null) {
-				invocation = functionInvocation.getClassInvocation();
-				genType.setResolved(((ClassInvocation) invocation).getKlass().getOS_Type());
-			} else if (functionInvocation.getNamespaceInvocation() != null) {
-				invocation = functionInvocation.getNamespaceInvocation();
-				genType.setResolvedn(((NamespaceInvocation) invocation).getNamespace());
-			}
-			assert invocation != null;
-			genType.setCi(Objects.requireNonNull(invocation));
-
-			final @Nullable InstructionArgument vte_ia = generatedFunction.vte_lookup(fali_name);
-			assert vte_ia != null;
-			((IntegerIA) vte_ia).getEntry().typeResolvePromise().then(new DoneCallback<GenType>() {
-				@Override
-				public void onDone(final @NotNull GenType result) {
-					assert result.getResolved() != null;
-					aIdentTableEntry.type.setAttached(result);
-				}
-			});
-			generatedFunction.addDependentType(genType);
-			DebugPrint.addDependentType(generatedFunction, genType);
-		}
-
-		class X_S implements Supplier<IInvocation> {
-			private final BaseEvaFunction generatedFunction1;
-
-			public X_S(final BaseEvaFunction aGeneratedFunction) {
-				generatedFunction1 = aGeneratedFunction;
-			}
-
-			@Override
-			@NotNull
-			public IInvocation get() {
-				final IInvocation invocation;
-
-				if (generatedFunction1.fi.getClassInvocation() != null) {
-					invocation = generatedFunction1.fi.getClassInvocation();
-				} else {
-					invocation = generatedFunction1.fi.getNamespaceInvocation();
-				}
-
-				return invocation;
-			}
-		}
-	}
-
-	class Implement_Calls_ {
-		private final @NotNull Context             context;
-		private final @NotNull BaseEvaFunction     gf;
-		private final @NotNull InstructionArgument i2;
-		private final          int                 pc;
-		private final @NotNull ProcTableEntry      pte;
-
-		public Implement_Calls_(final @NotNull BaseEvaFunction aGf, final @NotNull Context aContext,
-								final @NotNull InstructionArgument aI2, final @NotNull ProcTableEntry aPte, final int aPc) {
-			gf      = aGf;
-			context = aContext;
-			i2      = aI2;
-			pte     = aPte;
-			pc      = aPc;
-		}
-
-		void action() {
-			final IExpression pn1 = pte.__debug_expression;
-			if (!(pn1 instanceof IdentExpression)) {
-				throw new IllegalStateException("pn1 is not IdentExpression");
-			}
-
-			final String pn    = ((IdentExpression) pn1).getText();
-			boolean      found = lookup_name_calls(context, pn, pte);
-			if (found)
-				return;
-
-			final @Nullable String pn2 = SpecialFunctions.reverse_name(pn);
-			if (pn2 != null) {
-//				LOG.info("7002 "+pn2);
-				found = lookup_name_calls(context, pn2, pte);
-				if (found)
-					return;
-			}
-
-			if (i2 instanceof IntegerIA) {
-				found = action_i2_IntegerIA(pn, pn2);
-			} else {
-				found = action_dunder(pn);
-			}
-
-			if (!found) {
-				pte.setStatus(BaseTableEntry.Status.UNKNOWN, null);
-			}
-		}
-
-		private boolean action_i2_IntegerIA(@NotNull String pn, @Nullable String pn2) {
-			boolean                           found;
-			final @NotNull VariableTableEntry vte     = gf.getVarTableEntry(to_int(i2));
-			final Context                     ctx     = gf.getContextFromPC(pc); // might be inside a loop or something
-			final String                      vteName = vte.getName();
-			if (vteName != null) {
-				found = action_i2_IntegerIA_vteName_is_null(pn, pn2, ctx, vteName);
-			} else {
-				found = action_i2_IntegerIA_vteName_is_not_null(pn, pn2, vte);
-			}
-			return found;
-		}
-
-		private boolean action_dunder(String pn) {
-			assert Pattern.matches("__[a-z]+__", pn);
-//			LOG.info(String.format("i2 is not IntegerIA (%s)",i2.getClass().getName()));
-			//
-			// try to get dunder method from class
-			//
-			IExpression exp = pte.getArgs().get(0).__debug_expression;
-			if (exp instanceof IdentExpression) {
-				return action_dunder_doIt(pn, (IdentExpression) exp);
-			}
-			return false;
-		}
-
-		private boolean action_i2_IntegerIA_vteName_is_null(@NotNull String pn, @Nullable String pn2,
-															@NotNull Context ctx, @NotNull String vteName) {
-			boolean found = false;
-			if (SpecialVariables.contains(vteName)) {
-				LOG.err("Skipping special variable " + vteName + " " + pn);
-			} else {
-				final LookupResultList lrl2 = ctx.lookup(vteName);
-//				LOG.info("7003 "+vteName+" "+ctx);
-				final @Nullable OS_Element best2 = lrl2.chooseBest(null);
-				if (best2 != null) {
-					found = lookup_name_calls(best2.getContext(), pn, pte);
-					if (found)
-						return true;
-
-					if (pn2 != null) {
-						found = lookup_name_calls(best2.getContext(), pn2, pte);
-						if (found)
-							return true;
-					}
-
-					errSink.reportError("Special Function not found " + pn);
-				} else {
-					throw new NotImplementedException(); // Cant find vte, should never happen
-				}
-			}
-			return found;
-		}
-
-		private boolean action_i2_IntegerIA_vteName_is_not_null(@NotNull String pn, @Nullable String pn2,
-																@NotNull VariableTableEntry vte) {
-			final @NotNull List<TypeTableEntry> tt = getPotentialTypesVte(vte);
-			if (tt.size() != 1) {
-				return false;
-			}
-			final OS_Type x = tt.get(0).getAttached();
-			assert x != null;
-			switch (x.getType()) {
-			case USER_CLASS -> {
-				pot_types_size_is_1_USER_CLASS(pn, pn2, x);
-				return true;
-			}
-			case BUILT_IN -> {
-				final Context ctx2 = context;// x.getTypeName().getContext();
-				try {
-					@NotNull
-					GenType ty2 = resolve_type(x, ctx2);
-					pot_types_size_is_1_USER_CLASS(pn, pn2, ty2.getResolved());
-					return true;
-				} catch (ResolveError resolveError) {
-					resolveError.printStackTrace();
-					errSink.reportDiagnostic(resolveError);
-					return false;
-				}
-			}
-			default -> {
-				assert false;
-				return false;
-			}
-			}
-		}
-
-		private boolean action_dunder_doIt(String pn, IdentExpression exp) {
-			final @NotNull IdentExpression identExpression = exp;
-			@Nullable
-			InstructionArgument vte_ia = gf.vte_lookup(identExpression.getText());
-			if (vte_ia != null) {
-				VTE_TypePromises.dunder(pn, (IntegerIA) vte_ia, pte, DeduceTypes2.this);
-				return true;
-			}
-			return false;
-		}
-
-		private void pot_types_size_is_1_USER_CLASS(@NotNull String pn, @Nullable String pn2, @NotNull OS_Type x) {
-			boolean       found;
-			final Context ctx1 = x.getClassOf().getContext();
-
-			found = lookup_name_calls(ctx1, pn, pte);
-			if (found)
-				return;
-
-			if (pn2 != null) {
-				found = lookup_name_calls(ctx1, pn2, pte);
-			}
-
-			if (!found) {
-				// throw new NotImplementedException(); // TODO
-				errSink.reportError("Special Function not found " + pn);
-			}
-		}
-	}
-
-	class Resolve_each_typename {
-
-		private final DeduceTypes2 dt2;
-		private final ErrSink      errSink;
-		private final DeducePhase  phase;
-
-		public Resolve_each_typename(final DeducePhase aPhase, final DeduceTypes2 aDeduceTypes2,
-									 final ErrSink aErrSink) {
-			phase   = aPhase;
-			dt2     = aDeduceTypes2;
-			errSink = aErrSink;
-		}
-
-		public void action(@NotNull final TypeTableEntry typeTableEntry) {
-			@Nullable final OS_Type attached = typeTableEntry.getAttached();
-			if (attached == null)
-				return;
-			if (attached.getType() == OS_Type.Type.USER) {
-				action_USER(typeTableEntry, attached);
-			} else if (attached.getType() == OS_Type.Type.USER_CLASS) {
-				action_USER_CLASS(typeTableEntry, attached);
-			}
-		}
-
-		public void action_USER(@NotNull final TypeTableEntry typeTableEntry, @Nullable final OS_Type aAttached) {
-			final TypeName tn = aAttached.getTypeName();
-			if (tn == null)
-				return; // hack specifically for Result
-			switch (tn.kindOfType()) {
-			case FUNCTION:
-			case GENERIC:
-			case TYPE_OF:
-				return;
-			}
-			try {
-				typeTableEntry.setAttached(dt2.resolve_type(aAttached, aAttached.getTypeName().getContext()));
-				switch (typeTableEntry.getAttached().getType()) {
-				case USER_CLASS:
-					action_USER_CLASS(typeTableEntry, typeTableEntry.getAttached());
-					break;
-				case GENERIC_TYPENAME:
-					LOG.err(String.format("801 Generic Typearg %s for %s", tn, "genericFunction.getFD().getParent()"));
-					break;
-				default:
-					LOG.err("245 typeTableEntry attached wrong type " + typeTableEntry);
-					break;
-				}
-			} catch (final ResolveError aResolveError) {
-				LOG.err("288 Failed to resolve type " + aAttached);
-				errSink.reportDiagnostic(aResolveError);
-			}
-		}
-
-		public void action_USER_CLASS(@NotNull final TypeTableEntry typeTableEntry, @NotNull final OS_Type aAttached) {
-			final ClassStatement c = aAttached.getClassOf();
-			assert c != null;
-			phase.onClass(c, typeTableEntry::resolve);
-		}
-	}
-
-	class WlDeduceFunction implements WorkJob {
-		private final List<BaseEvaFunction> coll;
-		private final WorkJob               workJob;
-		private       boolean               _isDone;
-
-		public WlDeduceFunction(final WorkJob aWorkJob, List<BaseEvaFunction> aColl) {
-			workJob = aWorkJob;
-			coll    = aColl;
-		}
-
-		@Override
-		public boolean isDone() {
-			return _isDone;
-		}
-
-		@Override
-		public void run(final WorkManager aWorkManager) {
-			// README coll seems out of place here
-
-			// TODO assumes result is in the same file as this (DeduceTypes2)
-
-			if (workJob instanceof WlGenerateFunction) {
-				final EvaFunction generatedFunction1 = ((WlGenerateFunction) workJob).getResult();
-				if (!coll.contains(generatedFunction1)) {
-					coll.add(generatedFunction1);
-					if (!generatedFunction1.deducedAlready) {
-						GCompilationEnclosure ce = _phase().ca().getCompilation().getCompilationEnclosure();
-						GModuleThing          mt = ce.addModuleThing(generatedFunction1.module());
-
-						deduce_generated_function(generatedFunction1, (ModuleThing) mt);
-					}
-					generatedFunction1.deducedAlready = true;
-				}
-			} else if (workJob instanceof final WlGenerateDefaultCtor generateDefaultCtor) {
-				// TODO 10/17 PromiseExpectationBuilder, annoy
-				generateDefaultCtor.getGenerated().then(result -> {
-					final EvaConstructor evaConstructor = (EvaConstructor) result;
-					if (!coll.contains(evaConstructor)) {
-						coll.add(evaConstructor);
-						if (!evaConstructor.deducedAlready) { // TODO 10/17 queue_deduce
-							deduce_generated_constructor(evaConstructor);
-						}
-						evaConstructor.deducedAlready = true;
-					}
-				});
-			} else if (workJob instanceof WlGenerateCtor) {
-				final EvaConstructor evaConstructor = ((WlGenerateCtor) workJob).getResult();
-				if (!coll.contains(evaConstructor)) {
-					coll.add(evaConstructor);
-					if (!evaConstructor.deducedAlready) {
-						deduce_generated_constructor(evaConstructor);
-					}
-					evaConstructor.deducedAlready = true;
-				}
-			} else
-				throw new NotImplementedException();
-
-			assert coll.size() == 1;
-
-			_isDone = true;
-		}
-	}
-
-	public class Zero {
-		private final Map<Object, IDeduceElement3> l = new HashMap<>();
-
-		// TODO search living classes?
-		public @NotNull List<EvaClass> findClassesFor(ClassStatement classStatement) {
-			List<EvaClass> c = _inj().new_LinkedList__EvaClass();
-
-			for (Map.Entry<Object, IDeduceElement3> entry : l.entrySet()) {
-				if (entry.getKey() instanceof EvaFunction evaFunction) {
-					if (evaFunction.getFD().getParent() == classStatement) {
-						var cls = (EvaClass) entry.getValue().generatedFunction().getGenClass();
-
-						assert cls.getKlass() == classStatement;
-
-						c.add(cls);
-					}
-				}
-			}
-
-			return c;
-		}
-
-		public DeduceElement3_Function get(final DeduceTypes2 aDeduceTypes2, final BaseEvaFunction aGeneratedFunction) {
-			if (l.containsKey(aGeneratedFunction)) {
-				return (DeduceElement3_Function) l.get(aGeneratedFunction);
-			}
-
-			final DeduceElement3_Function de3 = _inj().new_DeduceElement3_Function(aDeduceTypes2, aGeneratedFunction);
-			l.put(aGeneratedFunction, de3);
-			return de3;
-		}
-
-		public DeduceElement3_ProcTableEntry get(final ProcTableEntry pte, final BaseEvaFunction aGeneratedFunction,
-												 final DeduceTypes2 aDeduceTypes2) {
-			if (l.containsKey(pte)) {
-				return (DeduceElement3_ProcTableEntry) l.get(pte);
-			}
-
-			final DeduceElement3_ProcTableEntry de3 = _inj().new_DeduceElement3_ProcTableEntry(pte, aDeduceTypes2,
-																							   aGeneratedFunction
-																							  );
-			l.put(pte, de3);
-			return de3;
-		}
-
-		public DeduceElement3_VariableTableEntry get(final VariableTableEntry vte,
-													 final BaseEvaFunction aGeneratedFunction) {
-			if (l.containsKey(vte)) {
-				return (DeduceElement3_VariableTableEntry) l.get(vte);
-			}
-
-			final DeduceElement3_VariableTableEntry de3 = _inj().new_DeduceElement3_VariableTableEntry(vte,
-																									   DeduceTypes2.this, aGeneratedFunction
-																									  );
-			l.put(vte, de3);
-			return de3;
-		}
-
-		public DeduceElement3_IdentTableEntry getIdent(final IdentTableEntry ite,
-													   final BaseEvaFunction aGeneratedFunction, final DeduceTypes2 aDeduceTypes2) {
-			if (l.containsKey(ite)) {
-				return (DeduceElement3_IdentTableEntry) l.get(ite);
-			}
-
-			final DeduceElement3_IdentTableEntry de3 = _inj().new_DeduceElement3_IdentTableEntry(ite);
-			de3.setDeduceTypes(aDeduceTypes2, aGeneratedFunction);
-			l.put(ite, de3);
-			return de3;
-		}
-	}
 }
 
 //

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceTypes2Injector.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceTypes2Injector.java
@@ -1,0 +1,708 @@
+package tripleo.elijah.stages.deduce;
+
+import java.util.*;
+import java.util.function.*;
+
+import org.jdeferred2.impl.*;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.*;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.comp.i.extra.*;
+import tripleo.elijah.diagnostic.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.lang.impl.*;
+import tripleo.elijah.lang.nextgen.names.i.*;
+import tripleo.elijah.lang.nextgen.names.impl.*;
+import tripleo.elijah.lang.types.*;
+import tripleo.elijah.lang2.*;
+import tripleo.elijah.nextgen.reactive.*;
+import tripleo.elijah.stages.deduce.declarations.*;
+import tripleo.elijah.stages.deduce.nextgen.*;
+import tripleo.elijah.stages.deduce.post_bytecode.*;
+import tripleo.elijah.stages.deduce.tastic.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.gen_generic.*;
+import tripleo.elijah.stages.gen_generic.pipeline_impl.*;
+import tripleo.elijah.stages.instructions.*;
+import tripleo.elijah.stages.logging.*;
+import tripleo.elijah.work.*;
+
+// TODO 10/14 mix of injector and factory ;)
+public class DeduceTypes2Injector {
+	public __Add_Proc_Table_Listeners new___Add_Proc_Table_Listeners() {
+		return new __Add_Proc_Table_Listeners();
+	}
+
+	public BaseTableEntry.StatusListener new__StatusListener__BTE_203(final DeduceTypeResolve aDeduceTypeResolve) {
+		return aDeduceTypeResolve.new _StatusListener__BTE_203();
+	}
+
+	public BaseTableEntry.StatusListener new__StatusListener__BTE_86(final DeduceTypeResolve aDeduceTypeResolve) {
+		return aDeduceTypeResolve.new _StatusListener__BTE_86();
+	}
+
+	public List<Reactivable> new_ArrayList__Ables() {
+		return new ArrayList<>();
+	}
+
+	public List<DE3_Active> new_ArrayList__DE3_Active() {
+		return new ArrayList<>();
+	}
+
+	public List<FunctionInvocation> new_ArrayList__FunctionInvocation() {
+		return new ArrayList<>();
+	}
+
+	public List<IDeduceResolvable> new_ArrayList__IDeduceResolvable() {
+		return new ArrayList<>();
+	}
+
+	public List<Runnable> new_ArrayList__Runnable() {
+		return new ArrayList<>();
+	}
+
+	public List<TypeTableEntry> new_ArrayList__TypeTableEntry(final Collection<TypeTableEntry> aTypeTableEntries) {
+		return new ArrayList<>(aTypeTableEntries);
+	}
+
+	public CantDecideType new_CantDecideType(final VariableTableEntry aVte,
+			final Collection<TypeTableEntry> aTypeTableEntries) {
+		return new CantDecideType(aVte, aTypeTableEntries);
+	}
+
+	public ClassInvocation.CI_GenericPart new_CI_GenericPart(final List<TypeName> aGenericPart,
+			final ClassInvocation aClassInvocation) {
+		return aClassInvocation.new CI_GenericPart(aGenericPart);
+	}
+
+	public ClassInvocation new_ClassInvocation(final ClassStatement aClassOf, final String aO,
+			final @NotNull Supplier<DeduceTypes2> aDeduceTypes2) {
+		return new ClassInvocation(aClassOf, aO, aDeduceTypes2);
+	}
+
+	public IElementHolder new_ConstructableElementHolder(final OS_Element aE, final IdentIA aIdentIA) {
+		return new ConstructableElementHolder(aE, aIdentIA);
+	}
+
+	public IVariableConnector new_CtorConnector(final IEvaConstructor aGeneratedFunction,
+			final DeduceTypes2 aDeduceTypes2) {
+		return new CtorConnector(aGeneratedFunction, aDeduceTypes2);
+	}
+
+	public DC_ClassNote new_DC_ClassNote(final ClassStatement aE, final Context aCtx,
+			final DeduceCentral aDeduceCentral) {
+		return new DC_ClassNote(aE, aCtx, aDeduceCentral);
+	}
+
+	public DC_ClassNote.DC_ClassNote_DT2 new_DC_ClassNote_DT2(final IdentTableEntry aIte,
+			final BaseEvaFunction aGeneratedFunction, final DeduceTypes2 aDeduceTypes2) {
+		return new DC_ClassNote.DC_ClassNote_DT2(aIte, aGeneratedFunction, aDeduceTypes2);
+	}
+
+	public DE3_Active new_DE3_ActivePTE(final DeduceTypes2 aDeduceTypes2, final ProcTableEntry aPte,
+			final ClassInvocation aClassInvocation) {
+		return new DE3_ActivePTE(aDeduceTypes2, aPte, aClassInvocation);
+	}
+
+	public IElementHolder new_DE3_EH_GroundedVariableStatement(final VariableStatement aE,
+			final DeduceElement3_IdentTableEntry aDeduceElement3IdentTableEntry) {
+		return aDeduceElement3IdentTableEntry.new DE3_EH_GroundedVariableStatement(
+				aE,
+				aDeduceElement3IdentTableEntry);
+	}
+
+	public DeduceElement3_IdentTableEntry.DE3_ITE_Holder new_DE3_ITE_Holder(final OS_Element aEl,
+			final DeduceElement3_IdentTableEntry aDeduceElement3IdentTableEntry) {
+		return aDeduceElement3IdentTableEntry.new DE3_ITE_Holder(aEl);
+	}
+
+	public DeclAnchor new_DeclAnchor(final OS_Element aDeclAnchor, final DeclAnchor.AnchorType aAnchorType) {
+		return new DeclAnchor(aDeclAnchor, aAnchorType);
+	}
+
+	public DeduceElement new_DeclTarget(final FunctionDef aBest, final OS_Element aDeclAnchor,
+			final DeclAnchor.AnchorType aAnchorType, final DeduceProcCall aDeduceProcCall) throws FCA_Stop {
+		return aDeduceProcCall.new DeclTarget(aBest, aDeclAnchor, aAnchorType);
+	}
+
+	public DeduceCentral new_DeduceCentral(final DeduceTypes2 aDeduceTypes2) {
+		return new DeduceCentral(aDeduceTypes2);
+	}
+
+	public DeduceClient1 new_DeduceClient1(final DeduceTypes2 aDeduceTypes2) {
+		return new DeduceClient1(aDeduceTypes2);
+	}
+
+	public DeduceClient2 new_DeduceClient2(final DeduceTypes2 aDeduceTypes2) {
+		return new DeduceClient2(aDeduceTypes2);
+	}
+
+	public DeduceClient3 new_DeduceClient3(final DeduceTypes2 aDeduceTypes2) {
+		return new DeduceClient3(aDeduceTypes2);
+	}
+
+	public DeduceClient4 new_DeduceClient4(final DeduceTypes2 aDeduceTypes2) {
+		return new DeduceClient4(aDeduceTypes2, aDeduceTypes2);
+	}
+
+	public DeduceElement3_Function new_DeduceElement3_Function(final DeduceTypes2 aDeduceTypes2,
+			final BaseEvaFunction aGeneratedFunction) {
+		return new DeduceElement3_Function(aDeduceTypes2, aGeneratedFunction);
+	}
+
+	public DeduceElement3_IdentTableEntry new_DeduceElement3_IdentTableEntry(final IdentTableEntry aIte) {
+		return new DeduceElement3_IdentTableEntry(aIte);
+	}
+
+	public DeduceElement3_ProcTableEntry new_DeduceElement3_ProcTableEntry(final ProcTableEntry aPte,
+			final DeduceTypes2 aDeduceTypes2, final BaseEvaFunction aGeneratedFunction) {
+		return new DeduceElement3_ProcTableEntry(aPte, aDeduceTypes2, aGeneratedFunction);
+	}
+
+	public DeduceElement3_VariableTableEntry new_DeduceElement3_VariableTableEntry(final VariableTableEntry aVte,
+			final DeduceTypes2 aDeduceTypes2, final BaseEvaFunction aGeneratedFunction) {
+		return new DeduceElement3_VariableTableEntry(aVte, aDeduceTypes2, aGeneratedFunction);
+	}
+
+	public DeduceProcCall new_DeduceProcCall(final ProcTableEntry aPte) {
+		return new DeduceProcCall(aPte);
+	}
+
+	public OS_Element new_DeduceTypes2_OS_SpecialVariable(final VariableTableEntry aEntry,
+			final VariableTableType aVariableTableType, final BaseEvaFunction aGeneratedFunction) {
+		return new OS_SpecialVariable(aEntry, aVariableTableType, aGeneratedFunction);
+	}
+
+	public DeduceCreationContext new_DefaultDeduceCreationContext(final DeduceTypes2 aDeduceTypes2) {
+		return new DefaultDeduceCreationContext(aDeduceTypes2);
+	}
+
+	public GenerateResultSink new_DefaultGenerateResultSink(final IPipelineAccess aPa) {
+		return new DefaultGenerateResultSink(aPa);
+	}
+
+	public @NotNull DeferredMember new_DeferredMember(final DeduceElementWrapper aParent,
+			final IInvocation aInvocation, final VariableStatementImpl aVariableStatement) {
+		return new DeferredMember(aParent, aInvocation, aVariableStatement);
+	}
+
+	public DeferredMemberFunction new_DeferredMemberFunction(final OS_Element aParent,
+			final IInvocation aInvocation, final FunctionDef aFunctionDef, final DeduceTypes2 aDeduceTypes2,
+			final FunctionInvocation aFunctionInvocation) {
+		return new DeferredMemberFunction(aParent, aInvocation, aFunctionDef, aDeduceTypes2, aFunctionInvocation);
+	}
+
+	public DeferredObject<BaseEvaFunction, Void, Void> new_DeferredObject__BaseEvaFunction() {
+		return new DeferredObject<>();
+	}
+
+	public DeferredObject<GenType, Diagnostic, Void> new_DeferredObject__GenType() {
+		return new DeferredObject<>();
+	}
+
+	public Dependencies new_Dependencies(final WorkManager aWorkManager, final DeduceTypes2 aDeduceTypes2) {
+		return new Dependencies(aDeduceTypes2, aWorkManager);
+	}
+
+	public DG_AliasStatement new_DG_AliasStatement(final AliasStatementImpl aE, final DeduceTypes2 aDt2) {
+		return new DG_AliasStatement(aE, aDt2);
+	}
+
+	public DG_ClassStatement new_DG_ClassStatement(final ClassStatement aClassStatement) {
+		return new DG_ClassStatement(aClassStatement);
+	}
+
+	public DG_FunctionDef new_DG_FunctionDef(final FunctionDef aFunctionDef) {
+		return new DG_FunctionDef(aFunctionDef);
+	}
+
+	public Diagnostic new_Diagnostic_8884(final VariableTableEntry aVte, final BaseEvaFunction aGf) {
+		return new DeduceElement3_VariableTableEntry.Diagnostic_8884(aVte, aGf);
+	}
+
+	public Diagnostic new_Diagnostic_8885(final VariableTableEntry aVte) {
+		return new DeduceElement3_VariableTableEntry.Diagnostic_8885(aVte);
+	}
+
+	public FT_FnCallArgs.DoAssignCall new_DoAssignCall(final DeduceClient4 aClient4,
+			final BaseEvaFunction aGeneratedFunction, final FT_FnCallArgs aFT_FnCallArgs) {
+		return new FT_FnCallArgs.DoAssignCall(aClient4, aGeneratedFunction);
+	}
+
+	public DR_Item new_DR_Ident(final IdentTableEntry aIdentTableEntry, final BaseEvaFunction aGeneratedFunction,
+			final DeduceTypes2 aDeduceTypes2) {
+		return DR_Ident.create(aIdentTableEntry, aGeneratedFunction/* , aDeduceTypes2 */);
+	}
+
+	public DR_IdentUnderstandings.ElementUnderstanding new_DR_Ident_ElementUnderstanding(final OS_Element aEl) {
+		return new DR_IdentUnderstandings.ElementUnderstanding(aEl);
+	}
+
+	public DR_PossibleTypeCI new_DR_PossibleTypeCI(final ClassInvocation aCi, final FunctionInvocation aFi) {
+		return new DR_PossibleTypeCI(aCi, aFi);
+	}
+
+	public DT_Env new_DT_Env(final ElLog aLOG, final ErrSink aErrSink, final DeduceCentral aCentral) {
+		return new DT_Env(aLOG, aErrSink, aCentral);
+	}
+
+	public DT_External_2 new_DT_External_2(final IdentTableEntry aIdentTableEntry,
+			final OS_Module aModule,
+			final ProcTableEntry aPte,
+			final FT_FCA_IdentIA.FakeDC4 aDc,
+			final ElLog aLOG,
+			final Context aCtx,
+			final BaseEvaFunction aGeneratedFunction,
+			final int aInstructionIndex,
+			final IdentIA aIdentIA,
+			final VariableTableEntry aVte) {
+		return new DT_External_2(aIdentTableEntry, aModule, aPte, aDc, aLOG, aCtx, aGeneratedFunction,
+				aInstructionIndex, aIdentIA, aVte);
+	}
+
+	public DTR_IdentExpression new_DTR_IdentExpression(final DeduceTypeResolve aDeduceTypeResolve,
+			final IdentExpression aIdentExpression, final BaseTableEntry aBte) {
+		return new DTR_IdentExpression(aDeduceTypeResolve, aIdentExpression, aBte);
+	}
+
+	public DTR_VariableStatement new_DTR_VariableStatement(final DeduceTypeResolve aDeduceTypeResolve,
+			final VariableStatement aVariableStatement) {
+		return new DTR_VariableStatement(aDeduceTypeResolve, aVariableStatement);
+	}
+
+	public ElLog new_ElLog(final String aFileName, final ElLog_.Verbosity aVerbosity, final String aPhase) {
+		return new ElLog_(aFileName, aVerbosity, aPhase);
+	}
+
+	public EN_Usage new_EN_DeduceUsage(final InstructionArgument aBacklink, final BaseEvaFunction aGf,
+			final IdentTableEntry aIte) {
+		return new EN_DeduceUsage(aBacklink, aGf, aIte);
+	}
+
+	public EN_Usage new_EN_NameUsage(final EN_Name aName, final DeduceElement3_IdentTableEntry aDe3Ite) {
+		return new EN_NameUsage(aName, aDe3Ite);
+	}
+
+	public EN_Understanding new_ENU_AliasedFrom(final AliasStatement aOrigE) {
+		return new ENU_AliasedFrom(aOrigE);
+	}
+
+	public EN_Understanding new_ENU_ClassName() {
+		return new ENU_ClassName();
+	}
+
+	public EN_Understanding new_ENU_ConstructorCallTarget() {
+		return new ENU_ConstructorCallTarget();
+	}
+
+	public EN_Understanding new_ENU_FunctionCallTarget(final ProcTableEntry aPte) {
+		return new ENU_FunctionCallTarget(aPte);
+	}
+
+	public EN_Understanding new_ENU_FunctionInvocation(final ProcTableEntry aCallablePte) {
+		return new ENU_FunctionInvocation(aCallablePte);
+	}
+
+	public EN_Understanding new_ENU_FunctionName() {
+		return new ENU_FunctionName();
+	}
+
+	public EN_Understanding new_ENU_LangConstVar() {
+		return new ENU_LangConstVar();
+	}
+
+	public EN_Understanding new_ENU_LookupResult(final LookupResultList aLrl) {
+		return new ENU_LookupResult(aLrl);
+	}
+
+	public EN_Understanding new_ENU_ResolveToFunction(final FunctionDef aFd) {
+		return new ENU_ResolveToFunction(aFd);
+	}
+
+	public EN_Understanding new_ENU_TypeTransitiveOver(final ProcTableEntry aPte) {
+		return new ENU_TypeTransitiveOver(aPte);
+	}
+
+	public EN_Understanding new_ENU_VariableName() {
+		return new ENU_VariableName();
+	}
+
+	public FT_FCA_IdentIA.FakeDC4 new_FakeDC4(final DeduceClient4 aDc4, final FT_FCA_IdentIA aFT_FCA_IdentIA) {
+		return aFT_FCA_IdentIA.new FakeDC4(aDc4);
+	}
+
+	public Found_Element_For_ITE new_Found_Element_For_ITE(final BaseEvaFunction aGeneratedFunction,
+			final Context aCtx, final DT_Env aEnv, final DeduceClient1 aDeduceClient1) {
+		return new Found_Element_For_ITE(aGeneratedFunction, aCtx, aEnv, aDeduceClient1);
+	}
+
+	public FT_FCA_ClassStatement new_FT_FCA_ClassStatement(final ClassStatement aEl) {
+		return new FT_FCA_ClassStatement(aEl);
+	}
+
+	public FT_FCA_IdentIA.FT_FCA_Ctx new_FT_FCA_Ctx(final BaseEvaFunction aGeneratedFunction,
+			final TypeTableEntry aTte, final Context aCtx, final ErrSink aErrSink, final DeduceClient4 aDc) {
+		return new FT_FCA_IdentIA.FT_FCA_Ctx(aGeneratedFunction, aTte, aCtx, aErrSink, aDc);
+	}
+
+	public FT_FCA_FormalArgListItem new_FT_FCA_FormalArgListItem(final FormalArgListItem aFali,
+			final BaseEvaFunction aGeneratedFunction) {
+		return new FT_FCA_FormalArgListItem(aFali, aGeneratedFunction);
+	}
+
+	public FT_FCA_FunctionDef new_FT_FCA_FunctionDef(final FunctionDef aEl, final DeduceTypes2 aDeduceTypes2) {
+		return new FT_FCA_FunctionDef(aEl, aDeduceTypes2);
+	}
+
+	public FT_FCA_IdentIA new_FT_FCA_IdentIA(final FT_FnCallArgs aFTFnCallArgs, final IdentIA aIdentIA,
+			final VariableTableEntry aVte) {
+		return new FT_FCA_IdentIA(aFTFnCallArgs, aIdentIA, aVte);
+	}
+
+	public FT_FCA_IdentIA.Resolve_VTE new_FT_FCA_IdentIA_Resolve_VTE(final VariableTableEntry aVte,
+			final Context aCtx, final ProcTableEntry aPte, final Instruction aInstruction, final FnCallArgs aFca) {
+		return new FT_FCA_IdentIA.Resolve_VTE(aVte, aCtx, aPte, aInstruction, aFca);
+	}
+
+	public FT_FCA_IdentIA.FT_FCA_ProcedureCall new_FT_FCA_ProcedureCall(final ProcedureCallExpression aPce,
+			final Context aCtx, final FT_FCA_IdentIA aFT_FCA_IdentIA) {
+		return aFT_FCA_IdentIA.new FT_FCA_ProcedureCall(aPce, aCtx);
+	}
+
+	public FT_FCA_VariableStatement new_FT_FCA_VariableStatement(final VariableStatementImpl aVs,
+			final BaseEvaFunction aGeneratedFunction) {
+		return new FT_FCA_VariableStatement(aVs, aGeneratedFunction);
+	}
+
+	public ITastic new_FT_FnCallArgs(final DeduceTypes2 aDeduceTypes2, final FnCallArgs aO) {
+		return new FT_FnCallArgs(aDeduceTypes2, aO);
+	}
+
+	public FoundElement new_FT_FnCallArgs_DoAssignCall_NullFoundElement(final DeduceClient4 aDc) {
+		return new FT_FnCallArgs.NullFoundElement(aDc);
+	}
+
+	public FunctionDef new_FunctionDefImpl(final NamespaceStatement aModNs, final Context aContext) {
+		return new FunctionDefImpl(aModNs, aContext);
+	}
+
+	public IElementHolder new_GenericElementHolder(final OS_Element aBest) {
+		return new GenericElementHolder(aBest);
+	}
+
+	public IElementHolder new_GenericElementHolderWithDC(final OS_Element aEl, final DeduceClient3 aDc,
+			final Resolve_Ident_IA aResolve_Ident_IA) {
+		return aResolve_Ident_IA.new GenericElementHolderWithDC(aEl, aDc);
+	}
+
+	public IElementHolder new_GenericElementHolderWithType(final OS_Element aElement, final OS_Type aTypeName,
+			final DeduceTypes2 aDeduceTypes2) {
+		return new GenericElementHolderWithType(aElement, aTypeName, aDeduceTypes2);
+	}
+
+	public GenericPart new_GenericPart(final ClassStatement aBest, final NormalTypeName aTyn1) {
+		return new GenericPart(aBest, aTyn1);
+	}
+
+	public GenType new_GenTypeImpl() {
+		return new GenTypeImpl();
+	}
+
+	public GenType new_GenTypeImpl(final ClassStatement aKlass) {
+		return new GenTypeImpl(aKlass);
+	}
+
+	public GenType new_GenTypeImpl(final NamespaceStatement aParent) {
+		return new GenTypeImpl(aParent);
+	}
+
+	public GenType new_GenTypeImpl(final OS_Type aAttached, final OS_Type aOSType, final boolean aB,
+			final TypeName aX, final DeduceTypes2 aDt2, final ErrSink aErrSink, final DeducePhase aPhase) {
+		return new GenTypeImpl(aAttached, aOSType, aB, aX, aDt2, aErrSink, aPhase);
+	}
+
+	public Map<OS_Element, DG_Item> new_HashMap_DGS() {
+		return new HashMap<>();
+	}
+
+	public Implement_construct.ICH new_ICH(final GenType aGenType, final Implement_construct aImplement_construct) {
+		return aImplement_construct.new ICH(aGenType);
+	}
+
+	public @NotNull IdentIA new_IdentIA(int index, @NotNull BaseEvaFunction generatedFunction) {
+		return new IdentIA(index, generatedFunction);
+	}
+
+	public IdentTableEntry new_IdentTableEntry(final int aI, final IdentExpression aIdentExpression,
+			final Context aContext, final BaseEvaFunction aGeneratedFunction) {
+		return new IdentTableEntry(aI, aIdentExpression, aContext, aGeneratedFunction);
+	}
+
+	public Implement_Calls_ new_Implement_Calls_(final BaseEvaFunction aGeneratedFunction, final Context aFdCtx,
+			final InstructionArgument aI2, final ProcTableEntry aFn1, final int aPc,
+			final DeduceTypes2 aDeduceTypes2) {
+		return new Implement_Calls_(aDeduceTypes2, aGeneratedFunction, aFdCtx, aI2, aFn1, aPc);
+	}
+
+	public Implement_construct new_Implement_construct(final DeduceTypes2 aDeduceTypes2,
+			final BaseEvaFunction aGeneratedFunction, final Instruction aInstruction) {
+		return new Implement_construct(aDeduceTypes2, aGeneratedFunction, aInstruction);
+	}
+
+	public IdentTableEntry.ITE_Resolver_Result new_ITE_Resolver_Result(final OS_Element aE) {
+		return new IdentTableEntry.ITE_Resolver_Result(aE);
+	}
+
+	public List<DT_External> new_LinkedList__DT_External() {
+		return new ArrayList<>();
+	}
+
+	public List<EvaClass> new_LinkedList__EvaClass() {
+		return new ArrayList<>();
+	}
+
+	public DeduceLocalVariable.MemberInvocation new_MemberInvocation(final ClassStatement aB,
+			final DeduceLocalVariable.MemberInvocation.Role aRole) {
+		return new DeduceLocalVariable.MemberInvocation(aB, aRole);
+	}
+
+	public NamespaceInvocation new_NamespaceInvocation(final NamespaceStatement aModNs) {
+		return new NamespaceInvocation(aModNs);
+	}
+
+	public NamespaceStatement new_NamespaceStatementImpl(final OS_Module aModule, final Context aContext) {
+		return new NamespaceStatementImpl(aModule, aContext);
+	}
+
+	public IVariableConnector new_NullConnector() {
+		return new NullConnector();
+	}
+
+	public OS_Type new_OS_BuiltinType(final BuiltInTypes aBuiltInType) {
+		return new OS_BuiltinType(aBuiltInType);
+	}
+
+	public OS_Type new_OS_UnknownType(final OS_Element aElement) {
+		return new OS_UnknownType(aElement);
+	}
+
+	public OS_Type new_OS_UnknownType(final StatementWrapperImpl aStatementWrapper) {
+		return new OS_UnknownType(aStatementWrapper);
+	}
+
+	public OS_UserType new_OS_UserType(final TypeName aTypeName) {
+		return new OS_UserType(aTypeName);
+	}
+
+	public BaseTableEntry.StatusListener new_ProcTableListener(final ProcTableEntry aPte,
+			final BaseEvaFunction aGeneratedFunction, final DeduceClient2 aO) {
+		return new ProcTableListener(aPte, aGeneratedFunction, aO);
+	}
+
+	public <B> PromiseExpectation<B> new_PromiseExpectation(final ExpectationBase aBase, final String aDesc,
+			final DeduceTypes2 aDeduceTypes2) {
+		return new PromiseExpectation<B>(aDeduceTypes2, aBase, aDesc);
+	}
+
+	public PromiseExpectations new_PromiseExpectations(final DeduceTypes2 aDeduceTypes2) {
+		return new PromiseExpectations();
+	}
+
+	public RegularTypeName new_RegularTypeNameImpl(final Context aContext) {
+		return new RegularTypeNameImpl(aContext);
+	}
+
+	public Resolve_each_typename new_Resolve_each_typename(final DeducePhase aPhase,
+			final DeduceTypes2 aDeduceTypes2, final ErrSink aErrSink) {
+		return new Resolve_each_typename(aDeduceTypes2, aPhase, aDeduceTypes2, aErrSink);
+	}
+
+	public Resolve_Ident_IA new_Resolve_Ident_IA(final DeduceClient3 aDeduceClient3, final Context aContext,
+			final Resolve_Ident_IA.DeduceElementIdent aDei, final BaseEvaFunction aGeneratedFunction,
+			final FoundElement aFoundElement, final ErrSink aErrSink) {
+		return new Resolve_Ident_IA(aDeduceClient3, aContext, aDei, aGeneratedFunction, aFoundElement, aErrSink);
+	}
+
+	public Resolve_Ident_IA new_Resolve_Ident_IA(final DeduceClient3 aDeduceClient3, final Context aContext,
+			final IdentIA aIdentIA, final BaseEvaFunction aGeneratedFunction, final FoundElement aFoundElement,
+			final ErrSink aErrSink) {
+		return new Resolve_Ident_IA(aDeduceClient3, aContext, aIdentIA, aGeneratedFunction, aFoundElement,
+				aErrSink);
+	}
+
+	public Resolve_Ident_IA2 new_Resolve_Ident_IA2(final DeduceTypes2 aDeduceTypes2, final ErrSink aErrSink,
+			final DeducePhase aPhase, final BaseEvaFunction aGeneratedFunction, final FoundElement aFoundElement) {
+		return new Resolve_Ident_IA2(aDeduceTypes2, aErrSink, aPhase, aGeneratedFunction, aFoundElement);
+	}
+
+	public Resolve_Variable_Table_Entry new_Resolve_Variable_Table_Entry(final BaseEvaFunction aGeneratedFunction,
+			final Context aContext, final DeduceTypes2 aDeduceTypes2) {
+		return new Resolve_Variable_Table_Entry(aGeneratedFunction, aContext, aDeduceTypes2);
+	}
+
+	public Diagnostic new_ResolveError(final IdentExpression aIdent, final LookupResultList aLrl) {
+		return new ResolveError(aIdent, aLrl);
+	}
+
+	public Diagnostic new_ResolveError(final TypeName aX, final LookupResultList aLrl) {
+		return new ResolveError(aX, aLrl);
+	}
+
+	public Resolve_Ident_IA2.RIA_Clear_98 new_RIA_Clear_98(final IdentTableEntry aIdte,
+			final VariableStatementImpl aVs, final Context aCtx, final Resolve_Ident_IA2 aResolve_Ident_IA2) {
+		return aResolve_Ident_IA2.new RIA_Clear_98(aIdte, aVs, aCtx);
+	}
+
+	public setup_GenType_Action new_SGTA_RegisterClassInvocation(final ClassStatement aClassStatement,
+			final DeducePhase aPhase) {
+		return new SGTA_RegisterClassInvocation(aClassStatement, aPhase);
+	}
+
+	public setup_GenType_Action new_SGTA_RegisterNamespaceInvocation(final NamespaceStatement aNamespaceStatement,
+			final DeducePhase aPhase) {
+		return new SGTA_RegisterNamespaceInvocation(aNamespaceStatement, aPhase);
+	}
+
+	public setup_GenType_Action new_SGTA_SetClassInvocation() {
+		return new SGTA_SetClassInvocation();
+	}
+
+	public setup_GenType_Action new_SGTA_SetNamespaceInvocation() {
+		return new SGTA_SetNamespaceInvocation();
+	}
+
+	public SGTA_SetResolvedClass new_SGTA_SetResolvedClass(final ClassStatement aKlass) {
+		return new SGTA_SetResolvedClass(aKlass);
+	}
+
+	public setup_GenType_Action new_SGTA_SetResolvedNamespace(final NamespaceStatement aNamespaceStatement) {
+		return new SGTA_SetResolvedNamespace(aNamespaceStatement);
+	}
+
+	public StatementWrapperImpl new_StatementWrapperImpl(final IExpression aLeft, final Context aO,
+			final OS_Element aO1) {
+		return new StatementWrapperImpl(aLeft, aO, aO1);
+	}
+
+	public BaseTableEntry.StatusListener new_StatusListener__RIA__176(final IdentTableEntry aY,
+			final FoundElement aFoundElement, final Resolve_Ident_IA aResolve_Ident_IA) {
+		return aResolve_Ident_IA.new StatusListener__RIA__176(aY, aFoundElement);
+	}
+
+	public ITasticMap new_TasticMap() {
+		return new TasticMap_1();
+	}
+
+	public TypeTableEntry new_TypeTableEntry(final int aI, final TypeTableEntry.Type aType, final OS_Type aTypeName,
+			final IdentExpression aIdent, final TableEntryIV aO) {
+		return new TypeTableEntry(aI, aType, aTypeName, aIdent, aO);
+	}
+
+	public ITE_Resolver new_Unnamed_ITE_Resolver1(final DeduceTypes2 aDeduceTypes2, final IdentTableEntry aIte,
+			final BaseEvaFunction aGeneratedFunction, final Context aContext) {
+		return new Unnamed_ITE_Resolver1(aDeduceTypes2, aIte, aGeneratedFunction, aContext);
+	}
+
+	public WorkJob new_WlDeduceFunction(final WorkJob aGen, final List<BaseEvaFunction> aColl,
+			final DeduceTypes2 aDeduceTypes2) {
+		return new WlDeduceFunction(aDeduceTypes2, aGen, aColl);
+	}
+
+	public WlGenerateClass new_WlGenerateClass(final GenerateFunctions aGenerateFunctions,
+			final ClassInvocation aCi, final DeducePhase.GeneratedClasses aGeneratedClasses,
+			final ICodeRegistrar aCodeRegistrar) {
+		return new WlGenerateClass(aGenerateFunctions, aCi, aGeneratedClasses, aCodeRegistrar);
+	}
+
+	public WlGenerateCtor new_WlGenerateCtor(final GenerateFunctions aGenerateFunctions,
+			final FunctionInvocation aFi,
+			final IdentExpression aIdentExpression,
+			final ICodeRegistrar aCodeRegistrar) {
+		return new WlGenerateCtor(aGenerateFunctions, aFi, aIdentExpression, aCodeRegistrar);
+	}
+
+	public WlGenerateCtor new_WlGenerateCtor(final OS_Module aModule,
+			final IdentExpression aNameNode,
+			final FunctionInvocation aFunctionInvocation,
+			final DeduceCreationContext aCl) {
+		return new WlGenerateCtor(aModule, aFunctionInvocation.getFunction().getNameNode(), aFunctionInvocation,
+				aCl);
+	}
+
+	public @NotNull WlGenerateDefaultCtor new_WlGenerateDefaultCtor(final GenerateFunctions aGf,
+			final FunctionInvocation aDependentFunction,
+			final DeduceCreationContext aDeduceCreationContext,
+			final ICodeRegistrar aCodeRegistrar) {
+		return new WlGenerateDefaultCtor(aGf, aDependentFunction, aDeduceCreationContext, aCodeRegistrar);
+	}
+
+	public WlGenerateDefaultCtor new_WlGenerateDefaultCtor(final OS_Module aModule,
+			final FunctionInvocation aFunctionInvocation,
+			final @NotNull DeduceCreationContext aCl) {
+		return new WlGenerateDefaultCtor(aModule, aFunctionInvocation, aCl);
+	}
+
+	public @Nullable WlGenerateFunction new_WlGenerateFunction(final GenerateFunctions aGf,
+			final FunctionInvocation aDependentFunction,
+			final ICodeRegistrar aCodeRegistrar) {
+		return new WlGenerateFunction(aGf, aDependentFunction, aCodeRegistrar);
+	}
+
+	public WlGenerateFunction new_WlGenerateFunction(final OS_Module aModule,
+			final FunctionInvocation aDependentFunction,
+			final DeduceCreationContext aCl) {
+		return new WlGenerateFunction(aModule, aDependentFunction, aCl);
+	}
+
+	public WlGenerateNamespace new_WlGenerateNamespace(final GenerateFunctions aGenerateFunctions,
+			final NamespaceInvocation aCi,
+			final DeducePhase.GeneratedClasses aGeneratedClasses,
+			final ICodeRegistrar aCodeRegistrar) {
+		return new WlGenerateNamespace(aGenerateFunctions, aCi, aGeneratedClasses, aCodeRegistrar);
+	}
+
+	public WorkList new_WorkList() {
+		return new WorkList__();
+	}
+
+	public WorkManager new_WorkManager() {
+		return new WorkManager__();
+	}
+
+	public Zero new_Zero(final DeduceTypes2 aDeduceTypes2) {
+		return new Zero(aDeduceTypes2);
+	}
+
+	@SuppressWarnings("UnnecessaryLocalVariable")
+	public DerivedClassInvocation2 new_DerivedClassInvocation2(final ClassStatement aDeclAnchor,
+			final ClassInvocation aDeclaredInvocation,
+			final ReadySupplier_1<DeduceTypes2> dtSupplier) {
+		final DerivedClassInvocation2 result = new DerivedClassInvocation2() {
+			@Override
+			public void into(final Eventual<IInvocation> aInvocationP) {
+				if (this.carrier == null) {
+					this.carrier = new_DerivedClassInvocation(aDeclAnchor, aDeclaredInvocation, dtSupplier);
+				}
+
+				aInvocationP.resolve(this.carrier);
+			}
+		};
+		return result;
+	}
+
+	public IInvocation new_DerivedClassInvocation(final ClassStatement aDeclAnchor,
+			final ClassInvocation aDeclaredInvocation, final Supplier<DeduceTypes2> aDeduceTypes2) {
+		return new DerivedClassInvocation(aDeclAnchor, aDeclaredInvocation, aDeduceTypes2);
+	}
+
+	public abstract static class DerivedClassInvocation2 {
+		protected IInvocation carrier;
+
+		public IInvocation asInvocation() {
+			return carrier;
+		}
+
+		public abstract void into(final Eventual<IInvocation> aInvocationP);
+	}
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceTypes2Injector.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/DeduceTypes2Injector.java
@@ -143,7 +143,7 @@ public class DeduceTypes2Injector {
 	}
 
 	public DeduceClient4 new_DeduceClient4(final DeduceTypes2 aDeduceTypes2) {
-		return new DeduceClient4(aDeduceTypes2, aDeduceTypes2);
+		return new DeduceClient4(aDeduceTypes2);
 	}
 
 	public DeduceElement3_Function new_DeduceElement3_Function(final DeduceTypes2 aDeduceTypes2,
@@ -515,7 +515,7 @@ public class DeduceTypes2Injector {
 
 	public Resolve_each_typename new_Resolve_each_typename(final DeducePhase aPhase,
 			final DeduceTypes2 aDeduceTypes2, final ErrSink aErrSink) {
-		return new Resolve_each_typename(aDeduceTypes2, aPhase, aDeduceTypes2, aErrSink);
+		return new Resolve_each_typename(aDeduceTypes2, aPhase, aErrSink);
 	}
 
 	public Resolve_Ident_IA new_Resolve_Ident_IA(final DeduceClient3 aDeduceClient3, final Context aContext,

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Dependencies.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Dependencies.java
@@ -18,12 +18,13 @@ import tripleo.elijah.work.*;
 
 class Dependencies {
 	private final DeduceTypes2 deduceTypes2;
-	final WorkList wl = deduceTypes2._inj().new_WorkList();
+	final WorkList wl;
 	final WorkManager wm;
 
 	Dependencies(final DeduceTypes2 aDeduceTypes2, final WorkManager aWm) {
 		deduceTypes2 = aDeduceTypes2;
 		wm = aWm;
+		wl = deduceTypes2._inj().new_WorkList();
 	}
 
 	public void subscribeFunctions(final @NotNull Subject<FunctionInvocation> aDependentFunctionSubject) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Dependencies.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Dependencies.java
@@ -1,0 +1,159 @@
+package tripleo.elijah.stages.deduce;
+
+import java.util.*;
+
+import org.jetbrains.annotations.*;
+import org.jetbrains.annotations.Nullable;
+
+import io.reactivex.rxjava3.annotations.*;
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.disposables.*;
+import io.reactivex.rxjava3.subjects.*;
+import tripleo.elijah.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.lang.impl.*;
+import tripleo.elijah.nextgen.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.work.*;
+
+class Dependencies {
+	private final DeduceTypes2 deduceTypes2;
+	final WorkList wl = deduceTypes2._inj().new_WorkList();
+	final WorkManager wm;
+
+	Dependencies(final DeduceTypes2 aDeduceTypes2, final WorkManager aWm) {
+		deduceTypes2 = aDeduceTypes2;
+		wm = aWm;
+	}
+
+	public void subscribeFunctions(final @NotNull Subject<FunctionInvocation> aDependentFunctionSubject) {
+		aDependentFunctionSubject.subscribe(new Observer<FunctionInvocation>() {
+			@Override
+			public void onSubscribe(@NonNull final Disposable d) {
+
+			}
+
+			@Override
+			public void onNext(@NonNull final @NotNull FunctionInvocation aFunctionInvocation) {
+				action_function(aFunctionInvocation);
+			}
+
+			@Override
+			public void onError(@NonNull final Throwable e) {
+
+			}
+
+			@Override
+			public void onComplete() {
+
+			}
+		});
+	}
+
+	public void action_function(@NotNull FunctionInvocation aDependentFunction) {
+		final FunctionDef function = aDependentFunction.getFunction();
+		WorkJob gen;
+		final @NotNull OS_Module mod;
+		if (function == LangGlobals.defaultVirtualCtor) {
+			ClassInvocation ci = aDependentFunction.getClassInvocation();
+			if (ci == null) {
+				NamespaceInvocation ni = aDependentFunction.getNamespaceInvocation();
+				assert ni != null;
+				mod = ni.getNamespace().getContext().module();
+
+				ni.resolvePromise().then(result -> result.dependentFunctions().add(aDependentFunction));
+			} else {
+				mod = ci.getKlass().getContext().module();
+				ci.resolvePromise().then(result -> result.dependentFunctions().add(aDependentFunction));
+			}
+			final @NotNull GenerateFunctions gf = deduceTypes2.getGenerateFunctions(mod);
+			gen = deduceTypes2._inj().new_WlGenerateDefaultCtor(gf, aDependentFunction, deduceTypes2.creationContext(),
+					deduceTypes2.phase.getCodeRegistrar());
+		} else {
+			mod = function.getContext().module();
+			final @NotNull GenerateFunctions gf = deduceTypes2.getGenerateFunctions(mod);
+			gen = deduceTypes2._inj().new_WlGenerateFunction(gf, aDependentFunction,
+					deduceTypes2.phase.getCodeRegistrar());
+		}
+		wl.addJob(gen);
+		List<BaseEvaFunction> coll = new ArrayList<>();
+		wl.addJob(deduceTypes2._inj().new_WlDeduceFunction(gen, coll, deduceTypes2));
+		wm.addJobs(wl);
+	}
+
+	public void subscribeTypes(final @NotNull Subject<GenType> aDependentTypesSubject) {
+		aDependentTypesSubject.subscribe(new Observer<GenType>() {
+			@Override
+			public void onSubscribe(@NonNull final Disposable d) {
+			}
+
+			@Override
+			public void onNext(final @NotNull GenType aGenType) {
+				action_type(aGenType);
+			}
+
+			@Override
+			public void onError(final Throwable aThrowable) {
+			}
+
+			@Override
+			public void onComplete() {
+			}
+		});
+	}
+
+	public void action_type(@NotNull GenType genType) {
+		// TODO work this out further, maybe like a Deepin flavor
+		if (genType.getResolvedn() != null) {
+			@NotNull
+			OS_Module mod = genType.getResolvedn().getContext().module();
+			final @NotNull GenerateFunctions gf = deduceTypes2.phase.generatePhase.getGenerateFunctions(mod);
+			NamespaceInvocation ni = deduceTypes2.phase.registerNamespaceInvocation(genType.getResolvedn());
+			@NotNull
+			WlGenerateNamespace gen = deduceTypes2._inj().new_WlGenerateNamespace(gf, ni,
+					deduceTypes2.phase.generatedClasses,
+					deduceTypes2.phase.getCodeRegistrar());
+
+			assert genType.getCi() == null || genType.getCi() == ni;
+			genType.setCi(ni);
+
+			wl.addJob(gen);
+
+			ni.resolvePromise().then(result -> {
+				genType.setNode(result);
+				result.dependentTypes().add(genType);
+			});
+		} else if (genType.getResolved() != null) {
+			if (genType.getFunctionInvocation() != null) {
+				action_function(genType.getFunctionInvocation());
+				return;
+			}
+
+			final ClassStatement c = genType.getResolved().getClassOf();
+			final @NotNull OS_Module mod = c.getContext().module();
+			final @NotNull GenerateFunctions gf = deduceTypes2.phase.generatePhase.getGenerateFunctions(mod);
+			@Nullable
+			ClassInvocation ci;
+			if (genType.getCi() == null) {
+				ci = deduceTypes2._inj().new_ClassInvocation(c, null, new ReadySupplier_1<>(deduceTypes2));
+				ci = deduceTypes2.phase.registerClassInvocation(ci);
+
+				genType.setCi(ci);
+			} else {
+				assert genType.getCi() instanceof ClassInvocation;
+				ci = (ClassInvocation) genType.getCi();
+			}
+
+			final Eventual<ClassDefinition> pcd = deduceTypes2.phase.generateClass2(gf, ci, wm);
+
+			pcd.then(result -> {
+				final EvaClass genclass = (EvaClass) result.getNode();
+
+				genType.setNode(genclass);
+				genclass.dependentTypes().add(genType);
+			});
+		}
+		//
+		wm.addJobs(wl);
+	}
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/ExpectationBase.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/ExpectationBase.java
@@ -1,0 +1,5 @@
+package tripleo.elijah.stages.deduce;
+
+public interface ExpectationBase {
+	String expectationString();
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Found_Element_For_ITE.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Found_Element_For_ITE.java
@@ -11,7 +11,8 @@ package tripleo.elijah.stages.deduce;
 
 import org.jdeferred2.*;
 import org.jetbrains.annotations.*;
-import tripleo.elijah.comp.i.ErrSink;
+
+import tripleo.elijah.comp.i.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.stages.deduce.declarations.*;
@@ -25,14 +26,14 @@ class Found_Element_For_ITE {
 
 	private final DeduceCentral central;
 	private final Context ctx;
-	private final DeduceTypes2.DeduceClient1 dc;
-	private final ErrSink                    errSink;
+	private final DeduceClient1 dc;
+	private final ErrSink errSink;
 	private final BaseEvaFunction            generatedFunction;
 	private final ElLog LOG;
 	private final DeduceTypes2 deduceTypes2;
 
 	public Found_Element_For_ITE(BaseEvaFunction aGeneratedFunction, Context aCtx, final @NotNull DT_Env aEnv,
-			DeduceTypes2.DeduceClient1 aDeduceClient1) {
+			DeduceClient1 aDeduceClient1) {
 		generatedFunction = aGeneratedFunction;
 		ctx = aCtx;
 		dc = aDeduceClient1;
@@ -44,7 +45,7 @@ class Found_Element_For_ITE {
 		deduceTypes2 = dc._deduceTypes2();
 	}
 
-	private DeduceTypes2.DeduceTypes2Injector _inj() {
+	private DeduceTypes2Injector _inj() {
 		return deduceTypes2._inj();
 	}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/FunctionInvocation.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/FunctionInvocation.java
@@ -135,7 +135,7 @@ public class FunctionInvocation implements IInvocation {
 
 	private Eventual<BaseEvaFunction> xxx___forDefaultVirtualCtor(final @NotNull DeduceCreationContext cl,
 			final @NotNull DeduceTypes2Injector injector,
-																  final @NotNull OS_Module module) {
+			final @NotNull OS_Module module) {
 		final @NotNull WlGenerateDefaultCtor wlgdc = injector.new_WlGenerateDefaultCtor(module, this, cl);
 		wlgdc.run(null);
 		return wlgdc.getGenerated();
@@ -143,9 +143,9 @@ public class FunctionInvocation implements IInvocation {
 
 	@NotNull
 	private BaseEvaFunction xxxForConstructorDef(final @NotNull DeduceCreationContext cl,
-												 final @NotNull ConstructorDef cd,
+			final @NotNull ConstructorDef cd,
 			final @NotNull DeduceTypes2Injector injector,
-												 final @NotNull OS_Module module) {
+			final @NotNull OS_Module module) {
 		final @NotNull WlGenerateCtor wlgf = injector.new_WlGenerateCtor(module, cd.getNameNode(), this, cl);
 		wlgf.run(null);
 
@@ -156,7 +156,7 @@ public class FunctionInvocation implements IInvocation {
 	@NotNull
 	private BaseEvaFunction xxx__forFunction(final @NotNull DeduceCreationContext cl,
 			final @NotNull DeduceTypes2Injector injector,
-											 final @NotNull OS_Module module) {
+			final @NotNull OS_Module module) {
 
 		final GeneratePhase generatePhase = cl.getGeneratePhase();
 		final DeducePhase   deducePhase   = cl.getDeducePhase();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/FunctionInvocation.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/FunctionInvocation.java
@@ -8,23 +8,20 @@
  */
 package tripleo.elijah.stages.deduce;
 
-import lombok.Getter;
-import tripleo.elijah.Eventual;
-import tripleo.elijah.EventualRegister;
-import tripleo.elijah.UnintendedUseException;
+import static tripleo.elijah.util.Helpers.*;
+
+import java.util.*;
+
+import org.jetbrains.annotations.*;
+
+import lombok.*;
+import tripleo.elijah.*;
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.LangGlobals;
-import tripleo.elijah.stages.deduce.nextgen.DeduceCreationContext;
-import tripleo.elijah.stages.deduce.post_bytecode.__LFOE_Q;
+import tripleo.elijah.lang.impl.*;
+import tripleo.elijah.stages.deduce.nextgen.*;
+import tripleo.elijah.stages.deduce.post_bytecode.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.work.*;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.List;
-
-import static tripleo.elijah.util.Helpers.List_of;
 
 /**
  * Created 1/21/21 9:04 PM
@@ -117,7 +114,7 @@ public class FunctionInvocation implements IInvocation {
 
 		// TODO 10/15 is this q?; 10/17 yes, now find a way to use it
 		final __LFOE_Q q = new __LFOE_Q(null, new WorkList__(), deduceTypes2);
-		final DeduceTypes2.DeduceTypes2Injector injector = deduceTypes2._inj();
+		final DeduceTypes2Injector injector = deduceTypes2._inj();
 
 		if (fd == LangGlobals.defaultVirtualCtor) {
 			xxx___forDefaultVirtualCtor(cl, injector, module).then(eef::resolve);
@@ -137,7 +134,7 @@ public class FunctionInvocation implements IInvocation {
 	}
 
 	private Eventual<BaseEvaFunction> xxx___forDefaultVirtualCtor(final @NotNull DeduceCreationContext cl,
-																  final DeduceTypes2.@NotNull DeduceTypes2Injector injector,
+			final @NotNull DeduceTypes2Injector injector,
 																  final @NotNull OS_Module module) {
 		final @NotNull WlGenerateDefaultCtor wlgdc = injector.new_WlGenerateDefaultCtor(module, this, cl);
 		wlgdc.run(null);
@@ -147,7 +144,7 @@ public class FunctionInvocation implements IInvocation {
 	@NotNull
 	private BaseEvaFunction xxxForConstructorDef(final @NotNull DeduceCreationContext cl,
 												 final @NotNull ConstructorDef cd,
-												 final DeduceTypes2.@NotNull DeduceTypes2Injector injector,
+			final @NotNull DeduceTypes2Injector injector,
 												 final @NotNull OS_Module module) {
 		final @NotNull WlGenerateCtor wlgf = injector.new_WlGenerateCtor(module, cd.getNameNode(), this, cl);
 		wlgf.run(null);
@@ -158,7 +155,7 @@ public class FunctionInvocation implements IInvocation {
 
 	@NotNull
 	private BaseEvaFunction xxx__forFunction(final @NotNull DeduceCreationContext cl,
-											 final DeduceTypes2.@NotNull DeduceTypes2Injector injector,
+			final @NotNull DeduceTypes2Injector injector,
 											 final @NotNull OS_Module module) {
 
 		final GeneratePhase generatePhase = cl.getGeneratePhase();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/IElementProcessor.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/IElementProcessor.java
@@ -1,0 +1,9 @@
+package tripleo.elijah.stages.deduce;
+
+import tripleo.elijah.lang.i.*;
+
+public interface IElementProcessor {
+	void elementIsNull();
+
+	void hasElement(OS_Element el);
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/IVariableConnector.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/IVariableConnector.java
@@ -1,0 +1,7 @@
+package tripleo.elijah.stages.deduce;
+
+import tripleo.elijah.stages.gen_fn.*;
+
+interface IVariableConnector {
+	void connect(VariableTableEntry aVte, String aName);
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Implement_Calls_.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Implement_Calls_.java
@@ -5,6 +5,7 @@ import java.util.regex.*;
 
 import org.jetbrains.annotations.*;
 
+import tripleo.elijah.comp.i.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang2.*;
 import tripleo.elijah.stages.gen_fn.*;
@@ -106,7 +107,7 @@ class Implement_Calls_ {
 						return true;
 				}
 
-				deduceTypes2.errSink.reportError("Special Function not found " + pn);
+				getErrSink().reportError("Special Function not found " + pn);
 			} else {
 				throw new NotImplementedException(); // Cant find vte, should never happen
 			}
@@ -136,7 +137,7 @@ class Implement_Calls_ {
 					return true;
 				} catch (ResolveError resolveError) {
 					resolveError.printStackTrace();
-					deduceTypes2.errSink.reportDiagnostic(resolveError);
+					getErrSink().reportDiagnostic(resolveError);
 					return false;
 				}
 			}
@@ -172,7 +173,11 @@ class Implement_Calls_ {
 
 		if (!found) {
 			// throw new NotImplementedException(); // TODO
-			deduceTypes2.errSink.reportError("Special Function not found " + pn);
+			getErrSink().reportError("Special Function not found " + pn);
 		}
+	}
+
+	private ErrSink getErrSink() {
+		return deduceTypes2._errSink();
 	}
 }

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Implement_Calls_.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Implement_Calls_.java
@@ -1,0 +1,178 @@
+package tripleo.elijah.stages.deduce;
+
+import java.util.*;
+import java.util.regex.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.lang2.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.instructions.*;
+import tripleo.elijah.util.*;
+
+class Implement_Calls_ {
+	private final DeduceTypes2 deduceTypes2;
+	private final @NotNull Context context;
+	private final @NotNull BaseEvaFunction gf;
+	private final @NotNull InstructionArgument i2;
+	private final int pc;
+	private final @NotNull ProcTableEntry pte;
+
+	public Implement_Calls_(final DeduceTypes2 aDeduceTypes2, final @NotNull BaseEvaFunction aGf,
+			final @NotNull Context aContext,
+			final @NotNull InstructionArgument aI2, final @NotNull ProcTableEntry aPte, final int aPc) {
+		deduceTypes2 = aDeduceTypes2;
+		gf = aGf;
+		context = aContext;
+		i2 = aI2;
+		pte = aPte;
+		pc = aPc;
+	}
+
+	void action() {
+		final IExpression pn1 = pte.__debug_expression;
+		if (!(pn1 instanceof IdentExpression)) {
+			throw new IllegalStateException("pn1 is not IdentExpression");
+		}
+
+		final String pn = ((IdentExpression) pn1).getText();
+		boolean found = deduceTypes2.lookup_name_calls(context, pn, pte);
+		if (found)
+			return;
+
+		final @Nullable String pn2 = SpecialFunctions.reverse_name(pn);
+		if (pn2 != null) {
+			// LOG.info("7002 "+pn2);
+			found = deduceTypes2.lookup_name_calls(context, pn2, pte);
+			if (found)
+				return;
+		}
+
+		if (i2 instanceof IntegerIA) {
+			found = action_i2_IntegerIA(pn, pn2);
+		} else {
+			found = action_dunder(pn);
+		}
+
+		if (!found) {
+			pte.setStatus(BaseTableEntry.Status.UNKNOWN, null);
+		}
+	}
+
+	private boolean action_i2_IntegerIA(@NotNull String pn, @Nullable String pn2) {
+		boolean found;
+		final @NotNull VariableTableEntry vte = gf.getVarTableEntry(DeduceTypes2.to_int(i2));
+		final Context ctx = gf.getContextFromPC(pc); // might be inside a loop or something
+		final String vteName = vte.getName();
+		if (vteName != null) {
+			found = action_i2_IntegerIA_vteName_is_null(pn, pn2, ctx, vteName);
+		} else {
+			found = action_i2_IntegerIA_vteName_is_not_null(pn, pn2, vte);
+		}
+		return found;
+	}
+
+	private boolean action_dunder(String pn) {
+		assert Pattern.matches("__[a-z]+__", pn);
+		// LOG.info(String.format("i2 is not IntegerIA (%s)",i2.getClass().getName()));
+		//
+		// try to get dunder method from class
+		//
+		IExpression exp = pte.getArgs().get(0).__debug_expression;
+		if (exp instanceof IdentExpression) {
+			return action_dunder_doIt(pn, (IdentExpression) exp);
+		}
+		return false;
+	}
+
+	private boolean action_i2_IntegerIA_vteName_is_null(@NotNull String pn, @Nullable String pn2,
+			@NotNull Context ctx, @NotNull String vteName) {
+		boolean found = false;
+		if (SpecialVariables.contains(vteName)) {
+			deduceTypes2.LOG.err("Skipping special variable " + vteName + " " + pn);
+		} else {
+			final LookupResultList lrl2 = ctx.lookup(vteName);
+			// LOG.info("7003 "+vteName+" "+ctx);
+			final @Nullable OS_Element best2 = lrl2.chooseBest(null);
+			if (best2 != null) {
+				found = deduceTypes2.lookup_name_calls(best2.getContext(), pn, pte);
+				if (found)
+					return true;
+
+				if (pn2 != null) {
+					found = deduceTypes2.lookup_name_calls(best2.getContext(), pn2, pte);
+					if (found)
+						return true;
+				}
+
+				deduceTypes2.errSink.reportError("Special Function not found " + pn);
+			} else {
+				throw new NotImplementedException(); // Cant find vte, should never happen
+			}
+		}
+		return found;
+	}
+
+	private boolean action_i2_IntegerIA_vteName_is_not_null(@NotNull String pn, @Nullable String pn2,
+			@NotNull VariableTableEntry vte) {
+		final @NotNull List<TypeTableEntry> tt = deduceTypes2.getPotentialTypesVte(vte);
+		if (tt.size() != 1) {
+			return false;
+		}
+		final OS_Type x = tt.get(0).getAttached();
+		assert x != null;
+		switch (x.getType()) {
+			case USER_CLASS -> {
+				pot_types_size_is_1_USER_CLASS(pn, pn2, x);
+				return true;
+			}
+			case BUILT_IN -> {
+				final Context ctx2 = context;// x.getTypeName().getContext();
+				try {
+					@NotNull
+					GenType ty2 = deduceTypes2.resolve_type(x, ctx2);
+					pot_types_size_is_1_USER_CLASS(pn, pn2, ty2.getResolved());
+					return true;
+				} catch (ResolveError resolveError) {
+					resolveError.printStackTrace();
+					deduceTypes2.errSink.reportDiagnostic(resolveError);
+					return false;
+				}
+			}
+			default -> {
+				assert false;
+				return false;
+			}
+		}
+	}
+
+	private boolean action_dunder_doIt(String pn, IdentExpression exp) {
+		final @NotNull IdentExpression identExpression = exp;
+		@Nullable
+		InstructionArgument vte_ia = gf.vte_lookup(identExpression.getText());
+		if (vte_ia != null) {
+			VTE_TypePromises.dunder(pn, (IntegerIA) vte_ia, pte, deduceTypes2);
+			return true;
+		}
+		return false;
+	}
+
+	private void pot_types_size_is_1_USER_CLASS(@NotNull String pn, @Nullable String pn2, @NotNull OS_Type x) {
+		boolean found;
+		final Context ctx1 = x.getClassOf().getContext();
+
+		found = deduceTypes2.lookup_name_calls(ctx1, pn, pte);
+		if (found)
+			return;
+
+		if (pn2 != null) {
+			found = deduceTypes2.lookup_name_calls(ctx1, pn2, pte);
+		}
+
+		if (!found) {
+			// throw new NotImplementedException(); // TODO
+			deduceTypes2.errSink.reportError("Special Function not found " + pn);
+		}
+	}
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Implement_construct.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Implement_construct.java
@@ -1,7 +1,12 @@
 package tripleo.elijah.stages.deduce;
 
-import com.google.common.base.*;
+import java.util.*;
+import java.util.Objects;
+
 import org.jetbrains.annotations.*;
+
+import com.google.common.base.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.lang.types.*;
@@ -11,9 +16,6 @@ import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.util.*;
 import tripleo.elijah.work.*;
-
-import java.util.Objects;
-import java.util.*;
 
 public class Implement_construct {
 	public class ICH {
@@ -133,7 +135,7 @@ public class Implement_construct {
 		}
 	}
 
-	private DeduceTypes2.DeduceTypes2Injector _inj() {
+	private DeduceTypes2Injector _inj() {
 		return deduceTypes2._inj();
 	}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/NullConnector.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/NullConnector.java
@@ -1,0 +1,9 @@
+package tripleo.elijah.stages.deduce;
+
+import tripleo.elijah.stages.gen_fn.*;
+
+class NullConnector implements IVariableConnector {
+	@Override
+	public void connect(final VariableTableEntry aVte, final String aName) {
+	}
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/OS_SpecialVariable.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/OS_SpecialVariable.java
@@ -1,0 +1,65 @@
+package tripleo.elijah.stages.deduce;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.lang2.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.instructions.*;
+import tripleo.elijah.util.*;
+
+public class OS_SpecialVariable implements OS_Element {
+	private final BaseEvaFunction generatedFunction;
+	private final VariableTableType type;
+	private final VariableTableEntry variableTableEntry;
+	public DeduceLocalVariable.MemberInvocation memberInvocation;
+
+	public OS_SpecialVariable(final VariableTableEntry aVariableTableEntry, final VariableTableType aType,
+			final BaseEvaFunction aGeneratedFunction) {
+		variableTableEntry = aVariableTableEntry;
+		type = aType;
+		generatedFunction = aGeneratedFunction;
+	}
+
+	@Override
+	public Context getContext() {
+		return generatedFunction.getFD().getContext();
+	}
+
+	@Override
+	public @NotNull OS_Element getParent() {
+		return generatedFunction.getFD();
+	}
+
+	@Override
+	public void serializeTo(final SmallWriter sw) {
+
+	}
+
+	@Override
+	public void visitGen(final ElElementVisitor visit) {
+		throw new IllegalArgumentException("not implemented");
+	}
+
+	@Nullable
+	public IInvocation getInvocation(final @NotNull DeduceTypes2 aDeduceTypes2) {
+		final @Nullable IInvocation aInvocation;
+		final OS_SpecialVariable specialVariable = this;
+		assert specialVariable.type == VariableTableType.SELF;
+		// first parent is always a function
+		switch (DecideElObjectType.getElObjectType(specialVariable.getParent().getParent())) {
+			case CLASS:
+				final ClassStatement classStatement = (ClassStatement) specialVariable.getParent().getParent();
+				aInvocation = aDeduceTypes2.phase.registerClassInvocation(classStatement, null,
+						new ReadySupplier_1<>(aDeduceTypes2)); // TODO generics
+				// ClassInvocationMake.withGenericPart(classStatement, null, null, this);
+				break;
+			case NAMESPACE:
+				throw new NotImplementedException(); // README ha! implemented in
+			default:
+				throw new IllegalArgumentException("Illegal object type for parent");
+		}
+		return aInvocation;
+	}
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/ProcTableListener.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/ProcTableListener.java
@@ -8,7 +8,10 @@
  */
 package tripleo.elijah.stages.deduce;
 
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.stages.deduce.nextgen.*;
@@ -16,8 +19,6 @@ import tripleo.elijah.stages.deduce.post_bytecode.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.stages.logging.*;
-
-import java.util.*;
 
 /**
  * Created 9/10/21 3:42 AM
@@ -145,7 +146,7 @@ public class ProcTableListener implements BaseTableEntry.StatusListener {
 		dcs.attachClass(result); // T168-089
 	}
 
-	private final DeduceTypes2.@NotNull DeduceClient2 dc;
+	private final @NotNull DeduceClient2 dc;
 	private final BaseEvaFunction generatedFunction;
 
 	private final @NotNull ElLog LOG;
@@ -153,7 +154,7 @@ public class ProcTableListener implements BaseTableEntry.StatusListener {
 	private final ProcTableEntry pte;
 
 	public ProcTableListener(ProcTableEntry pte, BaseEvaFunction generatedFunction,
-			DeduceTypes2.@NotNull DeduceClient2 dc) {
+			@NotNull DeduceClient2 dc) {
 		this.pte = pte;
 		this.generatedFunction = generatedFunction;
 		this.dc = dc;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/ProcessElement.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/ProcessElement.java
@@ -1,0 +1,16 @@
+package tripleo.elijah.stages.deduce;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.lang.i.*;
+
+public enum ProcessElement {
+	;
+
+	public static void processElement(@Nullable OS_Element el, @NotNull IElementProcessor ep) {
+		if (el == null)
+			ep.elementIsNull();
+		else
+			ep.hasElement(el);
+	}
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/PromiseExpectation.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/PromiseExpectation.java
@@ -3,14 +3,14 @@ package tripleo.elijah.stages.deduce;
 public class PromiseExpectation<B> {
 
 	private final DeduceTypes2 deduceTypes2;
-	private final DeduceTypes2.ExpectationBase base;
+	private final ExpectationBase base;
 	private final String desc;
 	private boolean _printed;
 	private long counter;
 	private B result;
 	private boolean satisfied;
 
-	public PromiseExpectation(final DeduceTypes2 aDeduceTypes2, DeduceTypes2.ExpectationBase aBase, String aDesc) {
+	public PromiseExpectation(final DeduceTypes2 aDeduceTypes2, ExpectationBase aBase, String aDesc) {
 		deduceTypes2 = aDeduceTypes2;
 		base = aBase;
 		desc = aDesc;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/RegisterClassInvocation_env.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/RegisterClassInvocation_env.java
@@ -1,14 +1,14 @@
 package tripleo.elijah.stages.deduce;
 
-import org.jetbrains.annotations.NotNull;
+import java.util.*;
+import java.util.function.*;
 
-import java.util.Objects;
-import java.util.function.Supplier;
+import org.jetbrains.annotations.*;
 
 public final class RegisterClassInvocation_env {
-	private final @NotNull ClassInvocation        classInvocation;
+	private final @NotNull ClassInvocation classInvocation;
 	private final @NotNull Supplier<DeduceTypes2> deduceTypes2Supplier;
-	private final @NotNull Supplier<DeducePhase>  deducePhaseSupplier;
+	private final @NotNull Supplier<DeducePhase> deducePhaseSupplier;
 
 	public RegisterClassInvocation_env(
 			@NotNull ClassInvocation classInvocation,

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Resolve_Ident_IA.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Resolve_Ident_IA.java
@@ -8,9 +8,13 @@
  */
 package tripleo.elijah.stages.deduce;
 
+import java.text.*;
+import java.util.*;
+
 import org.jdeferred2.*;
 import org.jdeferred2.impl.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.lang.i.*;
@@ -22,9 +26,6 @@ import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.stages.logging.*;
 import tripleo.elijah.util.*;
 import tripleo.elijah.work.*;
-
-import java.text.*;
-import java.util.*;
 
 /**
  * Created 7/8/21 2:31 AM
@@ -156,15 +157,15 @@ public class Resolve_Ident_IA {
 	}
 
 	class GenericElementHolderWithDC implements IElementHolder {
-		private final DeduceTypes2.DeduceClient3 deduceClient3;
+		private final DeduceClient3 deduceClient3;
 		private final OS_Element element;
 
-		public GenericElementHolderWithDC(final OS_Element aElement, final DeduceTypes2.DeduceClient3 aDeduceClient3) {
+		public GenericElementHolderWithDC(final OS_Element aElement, final DeduceClient3 aDeduceClient3) {
 			element = aElement;
 			deduceClient3 = aDeduceClient3;
 		}
 
-		public DeduceTypes2.DeduceClient3 getDC() {
+		public DeduceClient3 getDC() {
 			return deduceClient3;
 		}
 
@@ -211,8 +212,8 @@ public class Resolve_Ident_IA {
 
 	private final @NotNull Context context;
 	private final          DeduceElementIdent         dei;
-	private final @NotNull ErrSink                    errSink;
-	private final @NotNull DeduceTypes2.DeduceClient3 dc;
+	private final @NotNull ErrSink errSink;
+	private final @NotNull DeduceClient3 dc;
 	private final @NotNull FoundElement foundElement;
 	private final BaseEvaFunction generatedFunction;
 	private final @NotNull IdentIA identIA;
@@ -227,7 +228,7 @@ public class Resolve_Ident_IA {
 	@Nullable
 	OS_Element el;
 
-	public Resolve_Ident_IA(final DeduceTypes2.@NotNull DeduceClient3 aDeduceClient3, final @NotNull Context aContext,
+	public Resolve_Ident_IA(final @NotNull DeduceClient3 aDeduceClient3, final @NotNull Context aContext,
 			final DeduceElementIdent aDei, final BaseEvaFunction aGeneratedFunction,
 			final @NotNull FoundElement aFoundElement, final @NotNull ErrSink aErrSink) {
 		dc = aDeduceClient3;
@@ -245,7 +246,7 @@ public class Resolve_Ident_IA {
 	}
 
 	@Contract(pure = true)
-	public Resolve_Ident_IA(final @NotNull DeduceTypes2.DeduceClient3 aDeduceClient3, final @NotNull Context aContext,
+	public Resolve_Ident_IA(final @NotNull DeduceClient3 aDeduceClient3, final @NotNull Context aContext,
 			final @NotNull IdentIA aIdentIA, final @NotNull BaseEvaFunction aGeneratedFunction,
 			final @NotNull FoundElement aFoundElement, final @NotNull ErrSink aErrSink) {
 		dc = aDeduceClient3;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Resolve_Ident_IA2.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Resolve_Ident_IA2.java
@@ -8,10 +8,13 @@
  */
 package tripleo.elijah.stages.deduce;
 
+import java.util.*;
+
 import org.jdeferred2.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
-import tripleo.elijah.comp.i.ErrSink;
+import tripleo.elijah.comp.i.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.lang.types.*;
@@ -19,8 +22,6 @@ import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.stages.logging.*;
 import tripleo.elijah.util.*;
-
-import java.util.*;
 
 /**
  * Created 7/21/21 7:33 PM
@@ -134,7 +135,7 @@ class Resolve_Ident_IA2 {
 		LOG = deduceTypes2.LOG;
 	}
 
-	private DeduceTypes2.DeduceTypes2Injector _inj() {
+	private DeduceTypes2Injector _inj() {
 		return deduceTypes2._inj();
 	}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Resolve_Ident_IA2.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Resolve_Ident_IA2.java
@@ -583,7 +583,8 @@ class Resolve_Ident_IA2 {
 					}
 				} else if (ia2 instanceof ProcIA) {
 					LOG.err("1373 ProcIA");
-//						@NotNull ProcTableEntry pte = ((ProcIA) ia2).getEntry(); // README ectx seems to be set up already
+					// @NotNull ProcTableEntry pte = ((ProcIA) ia2).getEntry(); // README ectx seems
+					// to be set up already
 					return;
 				} else
 					throw new NotImplementedException();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Resolve_Variable_Table_Entry.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Resolve_Variable_Table_Entry.java
@@ -8,8 +8,11 @@
  */
 package tripleo.elijah.stages.deduce;
 
+import java.util.*;
+
 import org.jdeferred2.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.contexts.*;
 import tripleo.elijah.diagnostic.*;
@@ -22,8 +25,6 @@ import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.logging.*;
 import tripleo.elijah.util.*;
 import tripleo.elijah.work.*;
-
-import java.util.*;
 
 /**
  * Created 9/5/21 2:54 AM
@@ -49,7 +50,7 @@ class Resolve_Variable_Table_Entry {
 		phase = deduceTypes2._phase();
 	}
 
-	public void action(final @NotNull VariableTableEntry vte, final @NotNull DeduceTypes2.IVariableConnector aConnector) {
+	public void action(final @NotNull VariableTableEntry vte, final @NotNull IVariableConnector aConnector) {
 		switch (vte.getVtt()) {
 		case ARG:
 			action_ARG(vte);
@@ -177,7 +178,7 @@ class Resolve_Variable_Table_Entry {
 
 			@NotNull
 			PromiseExpectation<GenType> pe = deduceTypes2
-					.promiseExpectation(/* pot.genType.node */new DeduceTypes2.ExpectationBase() {
+					.promiseExpectation(/* pot.genType.node */new ExpectationBase() {
 						@Override
 						public @NotNull String expectationString() {
 							return "FuncType..."; // TODO

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Resolve_each_typename.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Resolve_each_typename.java
@@ -14,7 +14,6 @@ class Resolve_each_typename {
 	private final DeducePhase phase;
 
 	public Resolve_each_typename(final DeduceTypes2 aDeduceTypes2, final DeducePhase aPhase,
-			final DeduceTypes2 aDeduceTypes2,
 			final ErrSink aErrSink) {
 		deduceTypes2 = aDeduceTypes2;
 		phase = aPhase;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Resolve_each_typename.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Resolve_each_typename.java
@@ -1,0 +1,72 @@
+package tripleo.elijah.stages.deduce;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.stages.gen_fn.*;
+
+class Resolve_each_typename {
+
+	private final DeduceTypes2 deduceTypes2;
+	private final DeduceTypes2 dt2;
+	private final ErrSink errSink;
+	private final DeducePhase phase;
+
+	public Resolve_each_typename(final DeduceTypes2 aDeduceTypes2, final DeducePhase aPhase,
+			final DeduceTypes2 aDeduceTypes2,
+			final ErrSink aErrSink) {
+		deduceTypes2 = aDeduceTypes2;
+		phase = aPhase;
+		dt2 = aDeduceTypes2;
+		errSink = aErrSink;
+	}
+
+	public void action(@NotNull final TypeTableEntry typeTableEntry) {
+		@Nullable
+		final OS_Type attached = typeTableEntry.getAttached();
+		if (attached == null)
+			return;
+		if (attached.getType() == OS_Type.Type.USER) {
+			action_USER(typeTableEntry, attached);
+		} else if (attached.getType() == OS_Type.Type.USER_CLASS) {
+			action_USER_CLASS(typeTableEntry, attached);
+		}
+	}
+
+	public void action_USER(@NotNull final TypeTableEntry typeTableEntry, @Nullable final OS_Type aAttached) {
+		final TypeName tn = aAttached.getTypeName();
+		if (tn == null)
+			return; // hack specifically for Result
+		switch (tn.kindOfType()) {
+			case FUNCTION:
+			case GENERIC:
+			case TYPE_OF:
+				return;
+		}
+		try {
+			typeTableEntry.setAttached(dt2.resolve_type(aAttached, aAttached.getTypeName().getContext()));
+			switch (typeTableEntry.getAttached().getType()) {
+				case USER_CLASS:
+					action_USER_CLASS(typeTableEntry, typeTableEntry.getAttached());
+					break;
+				case GENERIC_TYPENAME:
+					deduceTypes2.LOG.err(String.format("801 Generic Typearg %s for %s", tn,
+							"genericFunction.getFD().getParent()"));
+					break;
+				default:
+					deduceTypes2.LOG.err("245 typeTableEntry attached wrong type " + typeTableEntry);
+					break;
+			}
+		} catch (final ResolveError aResolveError) {
+			deduceTypes2.LOG.err("288 Failed to resolve type " + aAttached);
+			errSink.reportDiagnostic(aResolveError);
+		}
+	}
+
+	public void action_USER_CLASS(@NotNull final TypeTableEntry typeTableEntry, @NotNull final OS_Type aAttached) {
+		final ClassStatement c = aAttached.getClassOf();
+		assert c != null;
+		phase.onClass(c, typeTableEntry::resolve);
+	}
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Unnamed_ITE_Resolver1.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Unnamed_ITE_Resolver1.java
@@ -259,8 +259,10 @@ class Unnamed_ITE_Resolver1 implements ITE_Resolver {
 						fi.generateDeferred().then(new DoneCallback<BaseEvaFunction>() {
 							@Override
 							public void onDone(BaseEvaFunction result) {
-								@NotNull IEvaConstructor constructorDef = (IEvaConstructor) result;
-								@NotNull FunctionDef     ele            = constructorDef.getFD();
+								@NotNull
+								IEvaConstructor constructorDef = (IEvaConstructor) result;
+								@NotNull
+								FunctionDef ele = constructorDef.getFD();
 
 								try {
 									LookupResultList lrl = DeduceLookupUtils.lookupExpression(ite.getIdent(),
@@ -361,7 +363,7 @@ class Unnamed_ITE_Resolver1 implements ITE_Resolver {
 
 									if (ite.getCallablePTE() != null) {
 										final @Nullable ProcTableEntry pte        = ite.getCallablePTE();
-										final @NotNull IInvocation     invocation = result.getCi();
+										final @NotNull IInvocation invocation = result.getCi();
 										final @NotNull FunctionInvocation fi = dt2.newFunctionInvocation(
 												(BaseFunctionDef) ele2, pte, invocation, dt2.phase);
 
@@ -435,7 +437,7 @@ class Unnamed_ITE_Resolver1 implements ITE_Resolver {
 				ite.setStatus(BaseTableEntry.Status.KNOWN, dt2._inj().new_GenericElementHolder(best));
 //									ite.setResolvedElement(best);
 
-				final @NotNull ClassStatement klass = (ClassStatement) ele;
+final @NotNull ClassStatement klass = (ClassStatement) ele;
 
 				dt2.register_and_resolve(vte, klass);
 			} catch (ResolveError resolveError) {
@@ -455,7 +457,7 @@ class Unnamed_ITE_Resolver1 implements ITE_Resolver {
 				assert best != null;
 				ite.setResolvedElement(best);
 
-				final @NotNull GenType          genType  = dt2._inj().new_GenTypeImpl(klass);
+				final @NotNull GenType genType = dt2._inj().new_GenTypeImpl(klass);
 				final TypeName                  typeName = vte.getTypeTableEntry().genType.getNonGenericTypeName();
 				final @Nullable ClassInvocation ci       = genType.genCI(typeName, dt2, dt2._errSink(), dt2.phase);
 //							resolve_vte_for_class(vte, klass);
@@ -471,7 +473,7 @@ class Unnamed_ITE_Resolver1 implements ITE_Resolver {
 		}
 
 		private @Nullable GenType getTY2(final @NotNull VariableStatementImpl aVariableStatement,
-										 @NotNull TypeName aTypeName, @NotNull OS_Type aTy) throws ResolveError {
+				@NotNull TypeName aTypeName, @NotNull OS_Type aTy) throws ResolveError {
 			if (aTy.getType() != OS_Type.Type.USER) {
 				assert false;
 				@NotNull
@@ -524,7 +526,7 @@ class Unnamed_ITE_Resolver1 implements ITE_Resolver {
 //			ite.onType(phase, _inj().new_OnType() {
 //
 //				@Override
-//				public void typeDeduced(@NotNull OS_Type aType) {
+// public void typeDeduced(@NotNull OS_Type aType) {
 //					// TODO Auto-generated method stub
 //					pe.satisfy(aType);
 //				}
@@ -549,7 +551,8 @@ class Unnamed_ITE_Resolver1 implements ITE_Resolver {
 //							try {
 //								OS_Type ty3 = resolve_type(attached1, attached1.getTypeName().getContext());
 //								// no expression or TableEntryIV below
-//								@NotNull TypeTableEntry tte4 = generatedFunction.newTypeTableEntry(TypeTableEntry.Type.TRANSIENT, null);
+// @NotNull TypeTableEntry tte4 =
+// generatedFunction.newTypeTableEntry(TypeTableEntry.Type.TRANSIENT, null);
 //								// README trying to keep genType up to date
 //								tte4.setAttached(attached1);
 //								tte4.setAttached(ty3);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Unnamed_ITE_Resolver1.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Unnamed_ITE_Resolver1.java
@@ -1,25 +1,17 @@
 package tripleo.elijah.stages.deduce;
 
-import org.jdeferred2.DoneCallback;
+import java.util.*;
+
+import org.jdeferred2.*;
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.BaseFunctionDef;
-import tripleo.elijah.lang.impl.VariableStatementImpl;
+import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.lang.types.*;
 import tripleo.elijah.stages.gen_fn.*;
-import tripleo.elijah.stages.gen_fn.IdentTableEntry.ITE_Resolver_Result;
-import tripleo.elijah.stages.instructions.IdentIA;
-import tripleo.elijah.stages.instructions.InstructionArgument;
-import tripleo.elijah.stages.instructions.IntegerIA;
-import tripleo.elijah.stages.instructions.ProcIA;
-import tripleo.elijah.util.Mode;
-import tripleo.elijah.util.NotImplementedException;
-import tripleo.elijah.util.Operation;
-
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.List;
+import tripleo.elijah.stages.gen_fn.IdentTableEntry.*;
+import tripleo.elijah.stages.instructions.*;
+import tripleo.elijah.util.*;
 
 class Unnamed_ITE_Resolver1 implements ITE_Resolver {
 	private final DeduceTypes2    dt2;
@@ -140,7 +132,7 @@ class Unnamed_ITE_Resolver1 implements ITE_Resolver {
 		}
 	}
 
-	private DeduceTypes2.DeduceTypes2Injector _inj() {
+	private DeduceTypes2Injector _inj() {
 		return dt2._inj();
 	}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/WlDeduceFunction.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/WlDeduceFunction.java
@@ -1,0 +1,74 @@
+package tripleo.elijah.stages.deduce;
+
+import java.util.*;
+
+import tripleo.elijah.g.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.inter.*;
+import tripleo.elijah.util.*;
+import tripleo.elijah.work.*;
+
+class WlDeduceFunction implements WorkJob {
+	private final DeduceTypes2 deduceTypes2;
+	private final List<BaseEvaFunction> coll;
+	private final WorkJob workJob;
+	private boolean _isDone;
+
+	public WlDeduceFunction(final DeduceTypes2 aDeduceTypes2, final WorkJob aWorkJob, List<BaseEvaFunction> aColl) {
+		deduceTypes2 = aDeduceTypes2;
+		workJob = aWorkJob;
+		coll = aColl;
+	}
+
+	@Override
+	public boolean isDone() {
+		return _isDone;
+	}
+
+	@Override
+	public void run(final WorkManager aWorkManager) {
+		// README coll seems out of place here
+
+		// TODO assumes result is in the same file as this (DeduceTypes2)
+
+		if (workJob instanceof WlGenerateFunction) {
+			final EvaFunction generatedFunction1 = ((WlGenerateFunction) workJob).getResult();
+			if (!coll.contains(generatedFunction1)) {
+				coll.add(generatedFunction1);
+				if (!generatedFunction1.deducedAlready) {
+					GCompilationEnclosure ce = deduceTypes2._phase().ca().getCompilation().getCompilationEnclosure();
+					GModuleThing mt = ce.addModuleThing(generatedFunction1.module());
+
+					deduceTypes2.deduce_generated_function(generatedFunction1, (ModuleThing) mt);
+				}
+				generatedFunction1.deducedAlready = true;
+			}
+		} else if (workJob instanceof final WlGenerateDefaultCtor generateDefaultCtor) {
+			// TODO 10/17 PromiseExpectationBuilder, annoy
+			generateDefaultCtor.getGenerated().then(result -> {
+				final EvaConstructor evaConstructor = (EvaConstructor) result;
+				if (!coll.contains(evaConstructor)) {
+					coll.add(evaConstructor);
+					if (!evaConstructor.deducedAlready) { // TODO 10/17 queue_deduce
+						deduceTypes2.deduce_generated_constructor(evaConstructor);
+					}
+					evaConstructor.deducedAlready = true;
+				}
+			});
+		} else if (workJob instanceof WlGenerateCtor) {
+			final EvaConstructor evaConstructor = ((WlGenerateCtor) workJob).getResult();
+			if (!coll.contains(evaConstructor)) {
+				coll.add(evaConstructor);
+				if (!evaConstructor.deducedAlready) {
+					deduceTypes2.deduce_generated_constructor(evaConstructor);
+				}
+				evaConstructor.deducedAlready = true;
+			}
+		} else
+			throw new NotImplementedException();
+
+		assert coll.size() == 1;
+
+		_isDone = true;
+	}
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Zero.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/Zero.java
@@ -1,0 +1,85 @@
+package tripleo.elijah.stages.deduce;
+
+import java.util.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.stages.deduce.post_bytecode.*;
+import tripleo.elijah.stages.gen_fn.*;
+
+public class Zero {
+	private final DeduceTypes2 deduceTypes2;
+	private final Map<Object, IDeduceElement3> l = new HashMap<>();
+
+	public Zero(final DeduceTypes2 aDeduceTypes2) {
+		deduceTypes2 = aDeduceTypes2;
+	}
+
+	// TODO search living classes?
+	public @NotNull List<EvaClass> findClassesFor(ClassStatement classStatement) {
+		List<EvaClass> c = deduceTypes2._inj().new_LinkedList__EvaClass();
+
+		for (Map.Entry<Object, IDeduceElement3> entry : l.entrySet()) {
+			if (entry.getKey() instanceof EvaFunction evaFunction) {
+				if (evaFunction.getFD().getParent() == classStatement) {
+					var cls = (EvaClass) entry.getValue().generatedFunction().getGenClass();
+
+					assert cls.getKlass() == classStatement;
+
+					c.add(cls);
+				}
+			}
+		}
+
+		return c;
+	}
+
+	public DeduceElement3_Function get(final DeduceTypes2 aDeduceTypes2, final BaseEvaFunction aGeneratedFunction) {
+		if (l.containsKey(aGeneratedFunction)) {
+			return (DeduceElement3_Function) l.get(aGeneratedFunction);
+		}
+
+		final DeduceElement3_Function de3 = deduceTypes2._inj().new_DeduceElement3_Function(aDeduceTypes2,
+				aGeneratedFunction);
+		l.put(aGeneratedFunction, de3);
+		return de3;
+	}
+
+	public DeduceElement3_ProcTableEntry get(final ProcTableEntry pte, final BaseEvaFunction aGeneratedFunction,
+			final DeduceTypes2 aDeduceTypes2) {
+		if (l.containsKey(pte)) {
+			return (DeduceElement3_ProcTableEntry) l.get(pte);
+		}
+
+		final DeduceElement3_ProcTableEntry de3 = deduceTypes2._inj().new_DeduceElement3_ProcTableEntry(pte,
+				aDeduceTypes2,
+				aGeneratedFunction);
+		l.put(pte, de3);
+		return de3;
+	}
+
+	public DeduceElement3_VariableTableEntry get(final VariableTableEntry vte,
+			final BaseEvaFunction aGeneratedFunction) {
+		if (l.containsKey(vte)) {
+			return (DeduceElement3_VariableTableEntry) l.get(vte);
+		}
+
+		final DeduceElement3_VariableTableEntry de3 = deduceTypes2._inj().new_DeduceElement3_VariableTableEntry(vte,
+				deduceTypes2, aGeneratedFunction);
+		l.put(vte, de3);
+		return de3;
+	}
+
+	public DeduceElement3_IdentTableEntry getIdent(final IdentTableEntry ite,
+			final BaseEvaFunction aGeneratedFunction, final DeduceTypes2 aDeduceTypes2) {
+		if (l.containsKey(ite)) {
+			return (DeduceElement3_IdentTableEntry) l.get(ite);
+		}
+
+		final DeduceElement3_IdentTableEntry de3 = deduceTypes2._inj().new_DeduceElement3_IdentTableEntry(ite);
+		de3.setDeduceTypes(aDeduceTypes2, aGeneratedFunction);
+		l.put(ite, de3);
+		return de3;
+	}
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/_DT_Function.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/_DT_Function.java
@@ -1,0 +1,94 @@
+package tripleo.elijah.stages.deduce;
+
+import java.util.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.stages.gen_fn.*;
+
+class _DT_Function implements DT_Function {
+
+	private final DeduceTypes2 deduceTypes2;
+	private final BaseEvaFunction carrier;
+	private final DeduceTypes2 deduceTypes2;
+
+	public _DT_Function(final DeduceTypes2 aDeduceTypes2, BaseEvaFunction aGeneratedFunction,
+			final DeduceTypes2 aDeduceTypes2) {
+		deduceTypes2 = aDeduceTypes2;
+		carrier = aGeneratedFunction;
+		deduceTypes2 = aDeduceTypes2;
+	}
+
+	@Override
+	public List<VariableTableEntry> vte_list() {
+		return carrier.vte_list;
+	}
+
+	@Override
+	public List<IdentTableEntry> idte_list() {
+		return carrier.idte_list;
+	}
+
+	@Override
+	public List<ProcTableEntry> prte_list() {
+		return carrier.prte_list;
+	}
+
+	@Override
+	public BaseEvaFunction get() {
+		return carrier;
+	}
+
+	@Override
+	public List<ConstantTableEntry> cte_list() {
+		return carrier.cte_list;
+	}
+
+	@Override
+	public void add_proc_table_listeners() {
+		final @NotNull BaseEvaFunction generatedFunction = get();
+		final __Add_Proc_Table_Listeners aptl = deduceTypes2._inj().new___Add_Proc_Table_Listeners();
+
+		for (final @NotNull ProcTableEntry pte : generatedFunction.prte_list) {
+			aptl.add_proc_table_listeners(generatedFunction, pte, deduceTypes2);
+		}
+	}
+
+	@Override
+	public void resolve_ident_table(final Context aContext) {
+		for (@NotNull
+		IdentTableEntry ite : this.idte_list()) {
+			ite.resolveExpectation = deduceTypes2.promiseExpectation(ite, "Element Resolved");
+			ite.addResolver(deduceTypes2._inj().new_Unnamed_ITE_Resolver1(deduceTypes2, ite, this.get(), aContext));
+		}
+
+		for (@NotNull
+		IdentTableEntry ite : this.idte_list()) {
+			ite.resolvers_round();
+		}
+	}
+
+	@Override
+	public void resolve_arguments_table(final Context aContext) {
+		final @NotNull Resolve_Variable_Table_Entry rvte = deduceTypes2._inj().new_Resolve_Variable_Table_Entry(carrier,
+				aContext, deduceTypes2);
+		final @NotNull IVariableConnector connector = getVariableConnector();
+
+		for (final @NotNull VariableTableEntry vte : vte_list()) {
+			rvte.action(vte, connector);
+		}
+	}
+
+	private @NotNull IVariableConnector getVariableConnector() {
+		final @NotNull IVariableConnector connector;
+		if (carrier instanceof EvaConstructor) {
+			final IEvaConstructor evaConstructor = (IEvaConstructor) carrier;
+			connector = deduceTypes2._inj().new_CtorConnector(evaConstructor, deduceTypes2);
+		} else {
+			connector = deduceTypes2._inj().new_NullConnector();
+		}
+		return connector;
+	}
+
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/_DT_Function.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/_DT_Function.java
@@ -11,11 +11,8 @@ class _DT_Function implements DT_Function {
 
 	private final DeduceTypes2 deduceTypes2;
 	private final BaseEvaFunction carrier;
-	private final DeduceTypes2 deduceTypes2;
 
-	public _DT_Function(final DeduceTypes2 aDeduceTypes2, BaseEvaFunction aGeneratedFunction,
-			final DeduceTypes2 aDeduceTypes2) {
-		deduceTypes2 = aDeduceTypes2;
+	public _DT_Function(final DeduceTypes2 aDeduceTypes2, BaseEvaFunction aGeneratedFunction) {
 		carrier = aGeneratedFunction;
 		deduceTypes2 = aDeduceTypes2;
 	}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/__Add_Proc_Table_Listeners.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/__Add_Proc_Table_Listeners.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.stages.deduce;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.instructions.*;
@@ -105,7 +106,8 @@ public class __Add_Proc_Table_Listeners {
 		InstructionArgument en = pte.expression_num;
 		if (en != null) {
 			if (en instanceof final @NotNull IdentIA identIA) {
-				@NotNull IdentTableEntry idte = identIA.getEntry();
+				@NotNull
+				IdentTableEntry idte = identIA.getEntry();
 				idte.addStatusListener(new SL(generatedFunction, idte, pte, identIA, aDeduceTypes2));
 			} else if (en instanceof IntegerIA) {
 				// TODO this code does nothing so commented out

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/declarations/DeferredMemberFunction.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/declarations/DeferredMemberFunction.java
@@ -17,9 +17,7 @@ import org.jetbrains.annotations.Nullable;
 import tripleo.elijah.diagnostic.Diagnostic;
 import tripleo.elijah.lang.i.FunctionDef;
 import tripleo.elijah.lang.i.OS_Element;
-import tripleo.elijah.stages.deduce.DeduceTypes2;
-import tripleo.elijah.stages.deduce.FunctionInvocation;
-import tripleo.elijah.stages.deduce.IInvocation;
+import tripleo.elijah.stages.deduce.*;
 import tripleo.elijah.stages.gen_fn.BaseEvaFunction;
 import tripleo.elijah.stages.gen_fn.EvaConstructor;
 import tripleo.elijah.stages.gen_fn.EvaFunction;
@@ -38,9 +36,9 @@ public class DeferredMemberFunction {
 	/**
 	 * A {@link tripleo.elijah.stages.deduce.ClassInvocation} or
 	 * {@link tripleo.elijah.stages.deduce.NamespaceInvocation}. useless if parent
-	 * is a {@link tripleo.elijah.stages.deduce.DeduceTypes2.OS_SpecialVariable} and
+	 * is a {@link OS_SpecialVariable} and
 	 * its
-	 * {@link tripleo.elijah.stages.deduce.DeduceTypes2.OS_SpecialVariable#memberInvocation}
+	 * {@link OS_SpecialVariable#memberInvocation}
 	 * role value is
 	 * {@link tripleo.elijah.stages.deduce.DeduceTypes2.MemberInvocation.Role#INHERITED}
 	 */
@@ -76,7 +74,7 @@ public class DeferredMemberFunction {
 		});
 	}
 
-	private DeduceTypes2.DeduceTypes2Injector _inj() {
+	private DeduceTypes2Injector _inj() {
 		return deduceTypes2._inj();
 	}
 
@@ -98,7 +96,7 @@ public class DeferredMemberFunction {
 
 	public @Nullable IInvocation getInvocation() {
 		if (invocation == null) {
-			if (parent instanceof final DeduceTypes2.@NotNull OS_SpecialVariable specialVariable) {
+			if (parent instanceof @NotNull OS_SpecialVariable specialVariable) {
 				invocation = specialVariable.getInvocation(deduceTypes2);
 			}
 		}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/do_assign_normal_ident_deferred__DT_ResolveObserver.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/do_assign_normal_ident_deferred__DT_ResolveObserver.java
@@ -1,0 +1,122 @@
+package tripleo.elijah.stages.deduce;
+
+import java.util.*;
+import java.util.function.*;
+
+import org.jdeferred2.*;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.lang.impl.*;
+import tripleo.elijah.stages.deduce.declarations.*;
+import tripleo.elijah.stages.deduce.nextgen.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.instructions.*;
+import tripleo.elijah.util.*;
+
+class do_assign_normal_ident_deferred__DT_ResolveObserver implements DT_ResolveObserver {
+	private final DeduceTypes2 deduceTypes2;
+	private final @NotNull IdentTableEntry identTableEntry;
+	private final @NotNull BaseEvaFunction generatedFunction;
+
+	public do_assign_normal_ident_deferred__DT_ResolveObserver(final DeduceTypes2 aDeduceTypes2,
+			final @NotNull IdentTableEntry aIdentTableEntry,
+			final @NotNull BaseEvaFunction aGeneratedFunction) {
+		deduceTypes2 = aDeduceTypes2;
+		identTableEntry = aIdentTableEntry;
+		generatedFunction = aGeneratedFunction;
+	}
+
+	@Override
+	public void onElement(@Nullable OS_Element best) {
+		if (best != null) {
+			identTableEntry.setStatus(BaseTableEntry.Status.KNOWN, deduceTypes2._inj().new_GenericElementHolder(best));
+			// TODO check for elements which may contain type information
+			if (best instanceof final @NotNull VariableStatementImpl vs) {
+				do_assign_normal_ident_deferred_VariableStatement(generatedFunction, identTableEntry, vs);
+			} else if (best instanceof final @NotNull FormalArgListItem fali) {
+				do_assign_normal_ident_deferred_FALI(generatedFunction, identTableEntry, fali);
+			} else
+				throw new NotImplementedException();
+		} else {
+			identTableEntry.setStatus(BaseTableEntry.Status.UNKNOWN, null);
+			deduceTypes2.LOG.err("242 Bad lookup" + identTableEntry.getIdent().getText());
+		}
+	}
+
+	public void do_assign_normal_ident_deferred_VariableStatement(final @NotNull BaseEvaFunction generatedFunction,
+			final @NotNull IdentTableEntry aIdentTableEntry, final @NotNull VariableStatementImpl vs) {
+		final DeduceElementWrapper parent = new DeduceElementWrapper(vs.getParent().getParent());
+		final DeferredMember dm = deduceTypes2.deferred_member(parent, new X_S(generatedFunction).get(), vs,
+				aIdentTableEntry);
+
+		dm.typePromise().done(result -> {
+			assert result.getResolved() != null;
+			aIdentTableEntry.type.setAttached(result.getResolved());
+		});
+
+		final GenType genType = deduceTypes2._inj().new_GenTypeImpl();
+		genType.setCi(dm.getInvocation());
+
+		if (genType.getCi() instanceof NamespaceInvocation) {
+			genType.setResolvedn(((NamespaceInvocation) genType.getCi()).getNamespace());
+		} else if (genType.getCi() instanceof ClassInvocation) {
+			genType.setResolved(((ClassInvocation) genType.getCi()).getKlass().getOS_Type());
+		} else {
+			throw new IllegalStateException();
+		}
+		generatedFunction.addDependentType(genType);
+	}
+
+	private void do_assign_normal_ident_deferred_FALI(final @NotNull BaseEvaFunction generatedFunction,
+			final @NotNull IdentTableEntry aIdentTableEntry, final @NotNull FormalArgListItem fali) {
+		final GenType genType = deduceTypes2._inj().new_GenTypeImpl();
+		final FunctionInvocation functionInvocation = generatedFunction.fi;
+		final String fali_name = fali.name();
+
+		IInvocation invocation = null;
+		if (functionInvocation.getClassInvocation() != null) {
+			invocation = functionInvocation.getClassInvocation();
+			genType.setResolved(((ClassInvocation) invocation).getKlass().getOS_Type());
+		} else if (functionInvocation.getNamespaceInvocation() != null) {
+			invocation = functionInvocation.getNamespaceInvocation();
+			genType.setResolvedn(((NamespaceInvocation) invocation).getNamespace());
+		}
+		assert invocation != null;
+		genType.setCi(Objects.requireNonNull(invocation));
+
+		final @Nullable InstructionArgument vte_ia = generatedFunction.vte_lookup(fali_name);
+		assert vte_ia != null;
+		((IntegerIA) vte_ia).getEntry().typeResolvePromise().then(new DoneCallback<GenType>() {
+			@Override
+			public void onDone(final @NotNull GenType result) {
+				assert result.getResolved() != null;
+				aIdentTableEntry.type.setAttached(result);
+			}
+		});
+		generatedFunction.addDependentType(genType);
+		DebugPrint.addDependentType(generatedFunction, genType);
+	}
+
+	class X_S implements Supplier<IInvocation> {
+		private final BaseEvaFunction generatedFunction1;
+
+		public X_S(final BaseEvaFunction aGeneratedFunction) {
+			generatedFunction1 = aGeneratedFunction;
+		}
+
+		@Override
+		@NotNull
+		public IInvocation get() {
+			final IInvocation invocation;
+
+			if (generatedFunction1.fi.getClassInvocation() != null) {
+				invocation = generatedFunction1.fi.getClassInvocation();
+			} else {
+				invocation = generatedFunction1.fi.getNamespaceInvocation();
+			}
+
+			return invocation;
+		}
+	}
+}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/nextgen/DR_Ident.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/nextgen/DR_Ident.java
@@ -1,16 +1,16 @@
 package tripleo.elijah.stages.deduce.nextgen;
 
+import java.util.*;
+
 import org.jdeferred2.*;
 import org.jdeferred2.impl.*;
 import org.jetbrains.annotations.*;
 
-import tripleo.elijah.DebugFlags;
+import tripleo.elijah.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.stages.deduce.post_bytecode.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.instructions.*;
-
-import java.util.*;
 
 public abstract class DR_Ident implements DR_Item {
 	public interface Understanding {
@@ -43,7 +43,8 @@ public abstract class DR_Ident implements DR_Item {
 		};
 	}
 
-	public static @NotNull DR_Ident create(@NotNull IdentTableEntry aIdentTableEntry, BaseEvaFunction aGeneratedFunction) {
+	public static @NotNull DR_Ident create(@NotNull IdentTableEntry aIdentTableEntry,
+			BaseEvaFunction aGeneratedFunction) {
 		return new DR_Ident(aIdentTableEntry, aGeneratedFunction) {
 			@Override
 			public _S _s() {
@@ -67,7 +68,8 @@ public abstract class DR_Ident implements DR_Item {
 		};
 	}
 
-	public static @NotNull DR_Ident create(final VariableTableEntry aVariableTableEntry, final BaseEvaFunction aGeneratedFunction) {
+	public static @NotNull DR_Ident create(final VariableTableEntry aVariableTableEntry,
+			final BaseEvaFunction aGeneratedFunction) {
 		return new DR_Ident(aVariableTableEntry, aGeneratedFunction) {
 			@Override
 			public _S _s() {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/nextgen/DeduceCreationContext.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/nextgen/DeduceCreationContext.java
@@ -1,17 +1,20 @@
 package tripleo.elijah.stages.deduce.nextgen;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.stages.deduce.*;
 import tripleo.elijah.stages.gen_fn.*;
 
 public interface DeduceCreationContext {
 
-	@NotNull DeducePhase getDeducePhase();
+	@NotNull
+	DeducePhase getDeducePhase();
 
 	DeduceTypes2 getDeduceTypes2();
 
-	@NotNull GeneratePhase getGeneratePhase();
+	@NotNull
+	GeneratePhase getGeneratePhase();
 
 	Eventual<BaseEvaFunction> makeGenerated_fi__Eventual(FunctionInvocation aFunctionInvocation);
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/pipeline_impl/DeducePipelineImpl.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/pipeline_impl/DeducePipelineImpl.java
@@ -1,14 +1,15 @@
 package tripleo.elijah.stages.deduce.pipeline_impl;
 
-import org.jetbrains.annotations.*;
-import tripleo.elijah.comp.*;
-import tripleo.elijah_elevated.comp.backbone.CompilationEnclosure;
-import tripleo.elijah.comp.i.extra.IPipelineAccess;
-
 import java.util.*;
 
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.comp.*;
+import tripleo.elijah.comp.i.extra.*;
+import tripleo.elijah_elevated.comp.backbone.*;
+
 public class DeducePipelineImpl {
-	private final @NotNull IPipelineAccess             pa;
+	private final @NotNull IPipelineAccess pa;
 	@SuppressWarnings("TypeMayBeWeakened")
 	private final          List<PipelineLogicRunnable> plrs = new ArrayList<>();
 	private final DeducePipelineImplInjector __inj = new DeducePipelineImplInjector();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceElement3_ConstantTableEntry.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceElement3_ConstantTableEntry.java
@@ -4,7 +4,6 @@ import org.jetbrains.annotations.*;
 import tripleo.elijah.diagnostic.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.stages.deduce.*;
-import tripleo.elijah.stages.deduce.DeduceTypes2.*;
 import tripleo.elijah.stages.deduce.post_bytecode.DED.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.instructions.*;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceElement3_Function.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceElement3_Function.java
@@ -8,7 +8,7 @@ import tripleo.elijah.lang.i.OS_Element;
 import tripleo.elijah.lang.types.OS_BuiltinType;
 import tripleo.elijah.lang2.BuiltInTypes;
 import tripleo.elijah.stages.deduce.DeduceTypes2;
-import tripleo.elijah.stages.deduce.DeduceTypes2.DeduceTypes2Injector;
+import tripleo.elijah.stages.deduce.DeduceTypes2Injector;
 import tripleo.elijah.stages.deduce.FoundElement;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.instructions.IdentIA;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceElement3_IdentTableEntry.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceElement3_IdentTableEntry.java
@@ -1,7 +1,10 @@
 package tripleo.elijah.stages.deduce.post_bytecode;
 
+import java.util.*;
+
 import org.jdeferred2.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.comp.*;
 import tripleo.elijah.comp.Finally.*;
 import tripleo.elijah.contexts.*;
@@ -15,8 +18,6 @@ import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.stateful.*;
 import tripleo.elijah.util.*;
-
-import java.util.*;
 
 public class DeduceElement3_IdentTableEntry extends DefaultStateful implements IDeduceElement3 {
 
@@ -460,7 +461,9 @@ public class DeduceElement3_IdentTableEntry extends DefaultStateful implements I
 		return el;
 	}
 
-	private static OS_Element __sneak_el_null__bl1_not_null__resolve_part(final @NotNull IdentExpression ident, final OS_Element[] elx, OS_Element el, final @NotNull VariableTableEntry vte_bl1, final DeduceTypeResolve tr) {
+	private static OS_Element __sneak_el_null__bl1_not_null__resolve_part(final @NotNull IdentExpression ident,
+			final OS_Element[] elx, OS_Element el, final @NotNull VariableTableEntry vte_bl1,
+			final DeduceTypeResolve tr) {
 		if (vte_bl1.typeDeferred_isResolved()) {
 			vte_bl1.typePromise().then(type1 -> {
 				if (tr.typeResolution().isPending()) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceElement3_ProcTableEntry.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceElement3_ProcTableEntry.java
@@ -1,6 +1,10 @@
 package tripleo.elijah.stages.deduce.post_bytecode;
 
+import java.util.*;
+import java.util.function.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.diagnostic.*;
@@ -15,9 +19,6 @@ import tripleo.elijah.util.*;
 import tripleo.elijah.work.*;
 import tripleo.elijah_fluffy.adt.*;
 import tripleo.elijah_prolific.v.*;
-
-import java.util.*;
-import java.util.function.*;
 
 public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 
@@ -36,11 +37,11 @@ public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 	}
 
 	public void _action_002_no_resolved_element(final InstructionArgument _backlink,
-												final @NotNull ProcTableEntry backlink,
+			final @NotNull ProcTableEntry backlink,
 			final @NotNull DeduceClient3 dc,
-												final @NotNull IdentTableEntry ite,
-												final @NotNull ErrSink errSink,
-												final @NotNull DeducePhase phase) {
+			final @NotNull IdentTableEntry ite,
+			final @NotNull ErrSink errSink,
+			final @NotNull DeducePhase phase) {
 		final OS_Element resolvedElement = backlink.getResolvedElement();
 
 		if (resolvedElement == null)
@@ -64,7 +65,7 @@ public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 	}
 
 	private void action_002_1(@NotNull final ProcTableEntry pte, @NotNull final IdentTableEntry ite,
-							  final boolean setClassInvocation, final @NotNull DeducePhase phase,
+			final boolean setClassInvocation, final @NotNull DeducePhase phase,
 			final @NotNull DeduceClient3 dc) {
 		final OS_Element resolvedElement = ite.getResolvedElement();
 
@@ -75,7 +76,8 @@ public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 		var dt2 = dc._deduceTypes2();
 
 		if (pte.getFunctionInvocation() == null) {
-			@NotNull final FunctionInvocation fi;
+			@NotNull
+			final FunctionInvocation fi;
 
 			if (resolvedElement instanceof ClassStatement) {
 				// assuming no constructor name or generic parameters based on function syntax
@@ -245,17 +247,17 @@ public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 	}
 
 	public static final class LFOE_Action_Results {
-		private final @NotNull DeduceTypes2                 aDeduceTypes2;
-		private final @NotNull WorkList                     wl;
-		private final @NotNull Consumer<WorkList>           addJobs;
-		private final @NotNull List<? extends Object>       actualResults;
+		private final @NotNull DeduceTypes2 aDeduceTypes2;
+		private final @NotNull WorkList wl;
+		private final @NotNull Consumer<WorkList> addJobs;
+		private final @NotNull List<? extends Object> actualResults;
 		private final @NotNull Eventual<FunctionInvocation> createdFunctionInvocation;
 
 		public LFOE_Action_Results(@NotNull DeduceTypes2 aDeduceTypes2, // input/not really needed
-								   @NotNull WorkList wl,                // input/not really needed
-								   @NotNull Consumer<WorkList> addJobs, // input/not really needed
-								   @NotNull List<? extends Object> actualResults,
-								   @NotNull Eventual<FunctionInvocation> createdFunctionInvocation
+				@NotNull WorkList wl, // input/not really needed
+				@NotNull Consumer<WorkList> addJobs, // input/not really needed
+				@NotNull List<? extends Object> actualResults,
+				@NotNull Eventual<FunctionInvocation> createdFunctionInvocation
 								  ) {
 			this.aDeduceTypes2             = aDeduceTypes2;
 			this.wl                        = wl;
@@ -313,9 +315,9 @@ public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 	}
 
 	public void lfoe_action(final @NotNull DeduceTypes2 aDeduceTypes2,
-							final @NotNull WorkList wl,
-							final @NotNull Adder<WorkList> addJobs,
-							final @NotNull Consumer<LFOE_Action_Results> resultconsumer) {
+			final @NotNull WorkList wl,
+			final @NotNull Adder<WorkList> addJobs,
+			final @NotNull Consumer<LFOE_Action_Results> resultconsumer) {
 		//assert aDeduceTypes2 == deduceTypes2;
 		if (aDeduceTypes2 != deduceTypes2) {
 			tripleo.elijah.util.SimplePrintLoggerToRemoveSoon.println_err_4("503262 deduceTypes divergence");
@@ -351,7 +353,7 @@ public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 		private final          WorkList           workList;
 		private final          DeducePhase        deducePhase;
 		private final          Consumer<WorkList> addJobs;
-		private final @NotNull __LFOE_Q           q;
+		private final @NotNull __LFOE_Q q;
 
 		public _1(
 				FunctionInvocation functionInvocation,
@@ -427,9 +429,9 @@ public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 		private final @NotNull FunctionInvocation functionInvocation;
 		private final          ClassInvocation    classInvocation;
 		private final          ClassStatement     parentClass;
-		private final @NotNull DeducePhase        deducePhase;
+		private final @NotNull DeducePhase deducePhase;
 		private final          Consumer<WorkList> addJobs;
-		private final @NotNull _LFOE_Q            q;
+		private final @NotNull _LFOE_Q q;
 
 		public _0(
 				@NotNull FunctionInvocation functionInvocation,
@@ -502,7 +504,8 @@ public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 	}
 
 	void __lfoe_action__proceed(_0 o0) {
-		@NotNull FunctionInvocation fi = o0.functionInvocation();
+		@NotNull
+		FunctionInvocation fi = o0.functionInvocation();
 		ClassInvocation ci = o0.classInvocation();
 		ClassStatement aParent = o0.parentClass();
 		final Consumer<WorkList> addJobs = o0.addJobs();
@@ -511,7 +514,8 @@ public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 
 		ci = phase.registerClassInvocation(ci);
 
-		@NotNull ClassStatement kl = ci.getKlass(); // TODO Don't you see aParent??
+		@NotNull
+		ClassStatement kl = ci.getKlass(); // TODO Don't you see aParent??
 		assert kl != null;
 
 		final FunctionDef fd2   = fi.getFunction();
@@ -565,12 +569,12 @@ public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 	}
 
 	void __lfoe_action__proceed(_1 o1) {
-		final @NotNull FunctionInvocation fi      = o1.functionInvocation();
+		final @NotNull FunctionInvocation fi = o1.functionInvocation();
 		final @NotNull NamespaceStatement aParent = o1.parentNamespace();
-		final @NotNull WorkList           wl      = o1.workList();
-		final @NotNull DeducePhase        phase   = o1.deducePhase();
+		final @NotNull WorkList wl = o1.workList();
+		final @NotNull DeducePhase phase = o1.deducePhase();
 		final @NotNull Consumer<WorkList> addJobs = o1.addJobs();
-		final @NotNull _LFOE_Q            q       = o1.q();
+		final @NotNull _LFOE_Q q = o1.q();
 
 		// ci = phase.registerClassInvocation(ci);
 
@@ -587,8 +591,9 @@ public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 	}
 
 	// TODO class Action<FunctionInvocation>
-	private static @NotNull Eventual<FunctionInvocation> __lfoe_action__getFunctionInvocation(final @NotNull ProcTableEntry pte,
-																							  final @NotNull DeduceTypes2 aDeduceTypes2) {
+	private static @NotNull Eventual<FunctionInvocation> __lfoe_action__getFunctionInvocation(
+			final @NotNull ProcTableEntry pte,
+			final @NotNull DeduceTypes2 aDeduceTypes2) {
 		final Eventual<FunctionInvocation> efi = new Eventual<>();
 
 		// Action<FunctionInvocation> action = new ...
@@ -599,8 +604,8 @@ public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 		if (pte.__debug_expression != null && pte.expression_num != null) {
 			if (pte.__debug_expression instanceof final @NotNull ProcedureCallExpression exp) {
 				if (exp.getLeft() instanceof final @NotNull IdentExpression expLeft) {
-					final @NotNull String           left = expLeft.getText();
-					final @NotNull LookupResultList lrl  = expLeft.getContext().lookup(left);
+					final @NotNull String left = expLeft.getText();
+					final @NotNull LookupResultList lrl = expLeft.getContext().lookup(left);
 					final @Nullable OS_Element      e    = lrl.chooseBest(null);
 					if (e != null) {
 						if (e instanceof ClassStatement classStatement) {
@@ -638,7 +643,8 @@ public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 		final DeduceElement3_ProcTableEntry de3_pte = pte.getDeduceElement3(aDeduceTypes2, pte.__gf); // !! pte.__gf
 		//de3_pte.();
 
-		@NotNull FunctionInvocation fi2 = aDeduceTypes2._phase().newFunctionInvocation(LangGlobals.defaultVirtualCtor, pte,
+		@NotNull
+		FunctionInvocation fi2 = aDeduceTypes2._phase().newFunctionInvocation(LangGlobals.defaultVirtualCtor, pte,
 																					   invocation);
 
 		final _LFOE_Q q = new __LFOE_Q(aDeduceTypes2.wm, new WorkList__(), aDeduceTypes2);
@@ -657,8 +663,9 @@ public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 
 		return efi;
 	}
+
 	public boolean sneakResolve_IDTE(@NotNull OS_Element el,
-									 @NotNull DeduceElement3_IdentTableEntry aDeduceElement3IdentTableEntry) {
+			@NotNull DeduceElement3_IdentTableEntry aDeduceElement3IdentTableEntry) {
 		boolean b = false;
 
 		final IExpression left = principal.__debug_expression.getLeft();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceElement3_ProcTableEntry.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceElement3_ProcTableEntry.java
@@ -37,7 +37,7 @@ public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 
 	public void _action_002_no_resolved_element(final InstructionArgument _backlink,
 												final @NotNull ProcTableEntry backlink,
-												final DeduceTypes2.@NotNull DeduceClient3 dc,
+			final @NotNull DeduceClient3 dc,
 												final @NotNull IdentTableEntry ite,
 												final @NotNull ErrSink errSink,
 												final @NotNull DeducePhase phase) {
@@ -59,13 +59,13 @@ public class DeduceElement3_ProcTableEntry implements IDeduceElement3 {
 		action_002_1(principal, ite, false, phase, dc);
 	}
 
-	DeduceTypes2.DeduceTypes2Injector _inj() {
+	DeduceTypes2Injector _inj() {
 		return Objects.requireNonNull(deduceTypes2())._inj();
 	}
 
 	private void action_002_1(@NotNull final ProcTableEntry pte, @NotNull final IdentTableEntry ite,
 							  final boolean setClassInvocation, final @NotNull DeducePhase phase,
-							  final DeduceTypes2.@NotNull DeduceClient3 dc) {
+			final @NotNull DeduceClient3 dc) {
 		final OS_Element resolvedElement = ite.getResolvedElement();
 
 		assert resolvedElement != null;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceElement3_VarTableEntry.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceElement3_VarTableEntry.java
@@ -45,8 +45,8 @@ public class DeduceElement3_VarTableEntry implements IDeduceElement3 {
 	}
 
 	private void __one_potential(final @NotNull DeducePhase aDeducePhase,
-								 final @NotNull VarTableEntry varTableEntry, final @NotNull List<TypeTableEntry> potentialTypes,
-								 final TypeName typeName, final @NotNull ClassInvocation ci) throws STOP {
+			final @NotNull VarTableEntry varTableEntry, final @NotNull List<TypeTableEntry> potentialTypes,
+			final TypeName typeName, final @NotNull ClassInvocation ci) throws STOP {
 		boolean sc = false;
 
 		TypeTableEntry potentialType = potentialTypes.get(0);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceElement3_VariableTableEntry.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceElement3_VariableTableEntry.java
@@ -120,8 +120,8 @@ public class DeduceElement3_VariableTableEntry extends DefaultStateful implement
 
 		static class ExitConvertUserTypes implements State {
 			private static void apply_normal(final @NotNull VariableTableEntry vte, final @NotNull DeduceTypes2 dt2,
-											 final @NotNull ErrSink errSink, final DeducePhase phase, final @NotNull ElLog LOG,
-											 final @NotNull OS_Type attached, final @NotNull TypeName x, final @NotNull String tn) {
+					final @NotNull ErrSink errSink, final DeducePhase phase, final @NotNull ElLog LOG,
+					final @NotNull OS_Type attached, final @NotNull TypeName x, final @NotNull String tn) {
 				final LookupResultList lrl = x.getContext().lookup(tn);
 				@Nullable
 				OS_Element best = lrl.chooseBest(null);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceElement3_VariableTableEntry.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceElement3_VariableTableEntry.java
@@ -8,10 +8,17 @@
  */
 package tripleo.elijah.stages.deduce.post_bytecode;
 
+import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
+
+import java.io.*;
+import java.util.*;
+import java.util.stream.*;
+
 import org.apache.commons.lang3.tuple.*;
 import org.jdeferred2.*;
 import org.jdeferred2.impl.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.diagnostic.*;
@@ -25,12 +32,6 @@ import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.stages.logging.*;
 import tripleo.elijah.stateful.*;
 import tripleo.elijah.util.*;
-
-import java.io.*;
-import java.util.*;
-import java.util.stream.*;
-
-import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
 
 public class DeduceElement3_VariableTableEntry extends DefaultStateful implements IDeduceElement3 {
 
@@ -595,7 +596,7 @@ public class DeduceElement3_VariableTableEntry extends DefaultStateful implement
 	}
 
 	public void _action_002_no_resolved_element(final @NotNull ErrSink errSink, final @NotNull ProcTableEntry pte,
-			final @NotNull IdentTableEntry ite, final DeduceTypes2.@NotNull DeduceClient3 dc,
+			final @NotNull IdentTableEntry ite, final @NotNull DeduceClient3 dc,
 			final @NotNull DeducePhase phase) {
 		final DeferredObject<Context, Void, Void> d = new DeferredObject<Context, Void, Void>();
 		d.then(context -> {
@@ -631,7 +632,7 @@ public class DeduceElement3_VariableTableEntry extends DefaultStateful implement
 	}
 
 	private void action_002_1(@NotNull final ProcTableEntry pte, @NotNull final IdentTableEntry ite,
-			final boolean setClassInvocation, final DeduceTypes2.@NotNull DeduceClient3 dc,
+			final boolean setClassInvocation, final @NotNull DeduceClient3 dc,
 			final @NotNull DeducePhase phase) {
 		final OS_Element resolvedElement = ite.getResolvedElement();
 
@@ -641,7 +642,7 @@ public class DeduceElement3_VariableTableEntry extends DefaultStateful implement
 	}
 
 	private void action_002_1_001(final @NotNull ProcTableEntry pte, final boolean setClassInvocation,
-			final DeduceTypes2.@NotNull DeduceClient3 dc, final @NotNull DeducePhase phase,
+			final @NotNull DeduceClient3 dc, final @NotNull DeducePhase phase,
 			final @NotNull OS_Element resolvedElement) {
 		if (pte.getFunctionInvocation() != null)
 			return;
@@ -663,7 +664,7 @@ public class DeduceElement3_VariableTableEntry extends DefaultStateful implement
 	}
 
 	private @Nullable Pair<ClassInvocation, FunctionInvocation> action_002_1_002_1(final @NotNull ProcTableEntry pte,
-			final DeduceTypes2.@NotNull DeduceClient3 dc, final @NotNull DeducePhase phase,
+			final @NotNull DeduceClient3 dc, final @NotNull DeducePhase phase,
 			final @NotNull OS_Element resolvedElement) {
 		final Pair<ClassInvocation, FunctionInvocation> p;
 		final FunctionInvocation fi;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceType3.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/DeduceType3.java
@@ -30,11 +30,13 @@ class DeduceType3 implements DED {
 		diagnostic = aDiagnostic1;
 	}
 
-//	public static IDeduceElement3 dispatch(final @NotNull IdentTableEntry aIdentTableEntry) {
+	// public static IDeduceElement3 dispatch(final @NotNull IdentTableEntry
+	// aIdentTableEntry) {
 //		return aIdentTableEntry.getDeduceElement3(null/*aDeduceTypes2*/, null/*aGeneratedFunction*/);
 //	}
 
-//	public static IDeduceElement3 dispatch(final @NotNull ConstantTableEntry aConstantTableEntry) {
+// public static IDeduceElement3 dispatch(final @NotNull ConstantTableEntry
+// aConstantTableEntry) {
 //		return aConstantTableEntry.getDeduceElement3();
 //	}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/ExitGetType.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/ExitGetType.java
@@ -84,7 +84,7 @@ public class ExitGetType implements State {
 					switch (ite.type.getAttached().getType()) {
 					case USER -> {
 						try {
-							final @NotNull GenType xx = dt2.resolve_type(ite.type.getAttached(), aFunctionContext);
+								final @NotNull GenType xx = dt2.resolve_type(ite.type.getAttached(), aFunctionContext);
 							ite.type.setAttached(xx);
 						} catch (final ResolveError resolveError) {
 							dt2._LOG().info("192 Can't attach type to " + path);
@@ -99,15 +99,15 @@ public class ExitGetType implements State {
 						// TODO All this for nothing
 						// the ite points to a function, not a function call,
 						// so there is no point in resolving it
-						if (ite.type.tableEntry instanceof final @NotNull ProcTableEntry pte) {
+							if (ite.type.tableEntry instanceof final @NotNull ProcTableEntry pte) {
 
-						} else if (ite.type.tableEntry instanceof final @NotNull IdentTableEntry identTableEntry) {
+							} else if (ite.type.tableEntry instanceof final @NotNull IdentTableEntry identTableEntry) {
 							if (identTableEntry.getCallablePTE() != null) {
 								@Nullable
 								final ProcTableEntry cpte = identTableEntry.getCallablePTE();
 								cpte.typePromise().then(new DoneCallback<GenType>() {
 									@Override
-									public void onDone(@NotNull final GenType result) {
+										public void onDone(@NotNull final GenType result) {
 										SimplePrintLoggerToRemoveSoon
 												.println2("1483 " + result.getResolved() + " " + result.getNode());
 									}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/PostBC_Processor.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/PostBC_Processor.java
@@ -1,8 +1,11 @@
 package tripleo.elijah.stages.deduce.post_bytecode;
 
+import java.util.function.*;
+
 import org.jdeferred2.*;
 import org.jdeferred2.impl.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.diagnostic.*;
 import tripleo.elijah.lang.i.*;
@@ -10,12 +13,10 @@ import tripleo.elijah.stages.deduce.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.util.*;
 
-import java.util.function.*;
-
 public interface PostBC_Processor {
 	abstract class __PostBC_Processor__VTE implements PostBC_Processor {
 		private static @NotNull DeduceType3 doNoTypeAttached__single_potential(final VariableTableEntry vte,
-				final DeduceTypes2.@NotNull DeduceClient1 deduceTypes2) {
+				final @NotNull DeduceClient1 deduceTypes2) {
 			final OS_Type attached = deduceTypes2.getPotentialTypesVte(vte).get(0).getAttached();
 			final DeduceType3 r = new DeduceType3(attached, null);
 
@@ -51,13 +52,13 @@ public interface PostBC_Processor {
 
 		protected abstract Context ctx();
 
-		protected abstract DeduceTypes2.DeduceClient1 deduceTypes2();
+		protected abstract DeduceClient1 deduceTypes2();
 
 		@Override
 		public @Nullable DeduceType3 doNoTypeAttached(final @NotNull ErrSink errSink1) {
 			@NotNull
 			final DeduceType3 r;
-			final DeduceTypes2.DeduceClient1 deduceTypes2 = deduceTypes2();
+			final DeduceClient1 deduceTypes2 = deduceTypes2();
 			final VariableTableEntry vte = vte();
 			final Supplier<CantDecideType> cdt = () -> deduceTypes2._inj().new_CantDecideType(vte,
 					vte.potentialTypes());
@@ -125,7 +126,7 @@ public interface PostBC_Processor {
 		private Promise<DeduceType3, Diagnostic, Void> postBC_getTypeFor_VTE(final @NotNull VariableTableEntry vte,
 				final Context fd_ctx, final ErrSink errSink) {
 			final DeduceType3 r;
-			final DeduceTypes2.DeduceClient1 deduceClient1 = deduceTypes2();
+			final DeduceClient1 deduceClient1 = deduceTypes2();
 			final OS_Type vte_type_attached = vte.getTypeTableEntry().getAttached();
 
 			final DeferredObject<DeduceType3, Diagnostic, Void> rr = new DeferredObject<DeduceType3, Diagnostic, Void>();
@@ -150,13 +151,13 @@ public interface PostBC_Processor {
 	}
 
 	class PostBC_Processor__VTE_ARG extends PostBC_Processor.__PostBC_Processor__VTE {
-		private final DeduceTypes2.DeduceClient1 deduceTypes2;
+		private final DeduceClient1 deduceTypes2;
 		private final Context fd_ctx;
 		private final VariableTableEntry variableTableEntry;
 		private final OS_Type vte_type_attached;
 
 		public PostBC_Processor__VTE_ARG(final VariableTableEntry aVariableTableEntry, final Context aFd_ctx,
-				final OS_Type aVte_type_attached, final DeduceTypes2.DeduceClient1 aDeduceTypes2) {
+				final OS_Type aVte_type_attached, final DeduceClient1 aDeduceTypes2) {
 			variableTableEntry = aVariableTableEntry;
 			fd_ctx = aFd_ctx;
 			vte_type_attached = aVte_type_attached;
@@ -169,7 +170,7 @@ public interface PostBC_Processor {
 		}
 
 		@Override
-		protected DeduceTypes2.DeduceClient1 deduceTypes2() {
+		protected DeduceClient1 deduceTypes2() {
 			return deduceTypes2;
 		}
 
@@ -190,13 +191,13 @@ public interface PostBC_Processor {
 	}
 
 	class PostBC_Processor__VTE_RESULT extends PostBC_Processor.__PostBC_Processor__VTE {
-		private final DeduceTypes2.DeduceClient1 deduceTypes2;
+		private final DeduceClient1 deduceTypes2;
 		private final Context fd_ctx;
 		private final VariableTableEntry variableTableEntry;
 		private final OS_Type vte_type_attached;
 
 		public PostBC_Processor__VTE_RESULT(final VariableTableEntry aVariableTableEntry, final Context aFd_ctx,
-				final OS_Type aVte_type_attached, final DeduceTypes2.DeduceClient1 aDeduceTypes2) {
+				final OS_Type aVte_type_attached, final DeduceClient1 aDeduceTypes2) {
 			variableTableEntry = aVariableTableEntry;
 			fd_ctx = aFd_ctx;
 			vte_type_attached = aVte_type_attached;
@@ -215,7 +216,7 @@ public interface PostBC_Processor {
 		// }
 
 		@Override
-		protected DeduceTypes2.DeduceClient1 deduceTypes2() {
+		protected DeduceClient1 deduceTypes2() {
 			return deduceTypes2;
 		}
 
@@ -261,13 +262,13 @@ public interface PostBC_Processor {
 	}
 
 	class PostBC_Processor__VTE_SELF extends PostBC_Processor.__PostBC_Processor__VTE {
-		private final DeduceTypes2.DeduceClient1 deduceTypes2;
+		private final DeduceClient1 deduceTypes2;
 		private final Context fd_ctx;
 		private final VariableTableEntry variableTableEntry;
 		private final OS_Type vte_type_attached;
 
 		public PostBC_Processor__VTE_SELF(final VariableTableEntry aVariableTableEntry, final Context aFd_ctx,
-				final OS_Type aVte_type_attached, final DeduceTypes2.DeduceClient1 aDeduceTypes2) {
+				final OS_Type aVte_type_attached, final DeduceClient1 aDeduceTypes2) {
 			variableTableEntry = aVariableTableEntry;
 			fd_ctx = aFd_ctx;
 			vte_type_attached = aVte_type_attached;
@@ -297,7 +298,7 @@ public interface PostBC_Processor {
 		 */
 
 		@Override
-		protected DeduceTypes2.DeduceClient1 deduceTypes2() {
+		protected DeduceClient1 deduceTypes2() {
 			return deduceTypes2;
 		}
 
@@ -318,13 +319,13 @@ public interface PostBC_Processor {
 	}
 
 	class PostBC_Processor__VTE_TEMP extends PostBC_Processor.__PostBC_Processor__VTE {
-		private final DeduceTypes2.DeduceClient1 deduceTypes2;
+		private final DeduceClient1 deduceTypes2;
 		private final Context fd_ctx;
 		private final VariableTableEntry variableTableEntry;
 		private final OS_Type vte_type_attached;
 
 		public PostBC_Processor__VTE_TEMP(final VariableTableEntry aVariableTableEntry, final Context aFd_ctx,
-				final OS_Type aVte_type_attached, final DeduceTypes2.DeduceClient1 aDeduceTypes2) {
+				final OS_Type aVte_type_attached, final DeduceClient1 aDeduceTypes2) {
 			variableTableEntry = aVariableTableEntry;
 			fd_ctx = aFd_ctx;
 			vte_type_attached = aVte_type_attached;
@@ -342,7 +343,7 @@ public interface PostBC_Processor {
 		 */
 
 		@Override
-		protected DeduceTypes2.DeduceClient1 deduceTypes2() {
+		protected DeduceClient1 deduceTypes2() {
 			return deduceTypes2;
 		}
 
@@ -367,13 +368,13 @@ public interface PostBC_Processor {
 	}
 
 	class PostBC_Processor__VTE_VAR extends PostBC_Processor.__PostBC_Processor__VTE {
-		private final DeduceTypes2.DeduceClient1 deduceTypes2;
+		private final DeduceClient1 deduceTypes2;
 		private final Context fd_ctx;
 		private final VariableTableEntry variableTableEntry;
 		private final OS_Type vte_type_attached;
 
 		public PostBC_Processor__VTE_VAR(final VariableTableEntry aVariableTableEntry, final Context aFd_ctx,
-				final OS_Type aVte_type_attached, final DeduceTypes2.DeduceClient1 aDeduceTypes2) {
+				final OS_Type aVte_type_attached, final DeduceClient1 aDeduceTypes2) {
 			variableTableEntry = aVariableTableEntry;
 			fd_ctx = aFd_ctx;
 			vte_type_attached = aVte_type_attached;
@@ -386,7 +387,7 @@ public interface PostBC_Processor {
 		}
 
 		@Override
-		protected DeduceTypes2.DeduceClient1 deduceTypes2() {
+		protected DeduceClient1 deduceTypes2() {
 			return deduceTypes2;
 		}
 
@@ -412,7 +413,7 @@ public interface PostBC_Processor {
 
 	@Contract("_, _, _ -> new")
 	static @NotNull PostBC_Processor make_VTE(@NotNull final VariableTableEntry aVariableTableEntry,
-			final Context aFd_ctx, final DeduceTypes2.DeduceClient1 aDeduceTypes2) {
+			final Context aFd_ctx, final DeduceClient1 aDeduceTypes2) {
 		final OS_Type vte_type_attached = aVariableTableEntry.getTypeTableEntry().getAttached();
 
 		switch (aVariableTableEntry.getVtt()) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/_LFOE_Q.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/_LFOE_Q.java
@@ -1,35 +1,31 @@
 package tripleo.elijah.stages.deduce.post_bytecode;
 
-import tripleo.elijah.Eventual;
-import tripleo.elijah.lang.i.IdentExpression;
-import tripleo.elijah.stages.deduce.DeducePhase;
-import tripleo.elijah.stages.deduce.FunctionInvocation;
-import tripleo.elijah.stages.deduce.NamespaceInvocation;
-import tripleo.elijah.stages.gen_fn.BaseEvaFunction;
-import tripleo.elijah.stages.gen_fn.GenerateFunctions;
-import tripleo.elijah.stages.gen_generic.ICodeRegistrar;
+import java.util.function.*;
 
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
 
-import java.util.function.Consumer;
-import java.util.function.Supplier;
+import tripleo.elijah.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.stages.deduce.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.gen_generic.*;
 
 interface _LFOE_Q {
 	void enqueue_ctor(final GenerateFunctions aGenerateFunctions,
-					  final @NotNull FunctionInvocation aFi,
+			final @NotNull FunctionInvocation aFi,
 					  final IdentExpression aConstructorName);
 
 	void enqueue_default_ctor(GenerateFunctions generateFunctions1,
-							  @NotNull FunctionInvocation fi,
+			@NotNull FunctionInvocation fi,
 							  ICodeRegistrar codeRegistrar,
 							  Consumer<Eventual<BaseEvaFunction>> cef);
 
 	void enqueue_function(final GenerateFunctions aGenerateFunctions,
-						  final @NotNull FunctionInvocation aFi,
+			final @NotNull FunctionInvocation aFi,
 						  final ICodeRegistrar cr);
 
 	void enqueue_function(final Supplier<GenerateFunctions> som,
-						  final @NotNull FunctionInvocation aFi,
+			final @NotNull FunctionInvocation aFi,
 						  final ICodeRegistrar aCr);
 
 	void enqueue_namespace(final Supplier<GenerateFunctions> som,
@@ -38,6 +34,6 @@ interface _LFOE_Q {
 						   final ICodeRegistrar aCr);
 
 	void enqueue_default_ctor(GenerateFunctions generateFunctions1,
-							  @NotNull FunctionInvocation fi,
+			@NotNull FunctionInvocation fi,
 							  Consumer<Eventual<BaseEvaFunction>> cef);
 }

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/__LFOE_Q.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/__LFOE_Q.java
@@ -1,25 +1,20 @@
 package tripleo.elijah.stages.deduce.post_bytecode;
 
-import tripleo.elijah.Eventual;
-import tripleo.elijah.lang.i.IdentExpression;
-import tripleo.elijah.stages.deduce.DeducePhase;
-import tripleo.elijah.stages.deduce.DeduceTypes2;
-import tripleo.elijah.stages.deduce.FunctionInvocation;
-import tripleo.elijah.stages.deduce.NamespaceInvocation;
+import java.util.function.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.stages.deduce.*;
 import tripleo.elijah.stages.gen_fn.*;
-import tripleo.elijah.stages.gen_generic.ICodeRegistrar;
-import tripleo.elijah.work.WorkList;
-import tripleo.elijah.work.WorkManager;
-
-import org.jetbrains.annotations.NotNull;
-
-import java.util.function.Consumer;
-import java.util.function.Supplier;
+import tripleo.elijah.stages.gen_generic.*;
+import tripleo.elijah.work.*;
 
 public class __LFOE_Q implements _LFOE_Q {
 	private final @NotNull GenerateFunctions generateFunctions;
 	private final          WorkList          wl;
-	private final @NotNull DeduceTypes2      deduceTypes2;
+	private final @NotNull DeduceTypes2 deduceTypes2;
 
 	public __LFOE_Q(WorkManager aWorkManager, WorkList aWorkList, final @NotNull DeduceTypes2 aDeduceTypes2) {
 		generateFunctions = aDeduceTypes2.phase.generatePhase.getGenerateFunctions(aDeduceTypes2.module);
@@ -38,7 +33,7 @@ public class __LFOE_Q implements _LFOE_Q {
 
 	@Override
 	public void enqueue_default_ctor(final GenerateFunctions generateFunctions1,
-									 final @NotNull FunctionInvocation fi,
+			final @NotNull FunctionInvocation fi,
 									 final Consumer<Eventual<BaseEvaFunction>> cef) {
 		// assert generateFunctions1 == generateFunctions;
 		final ICodeRegistrar codeRegistrar = deduceTypes2._phase().getCodeRegistrar();
@@ -47,7 +42,7 @@ public class __LFOE_Q implements _LFOE_Q {
 
 	@Override
 	public void enqueue_default_ctor(final GenerateFunctions generateFunctions1,
-									 final @NotNull FunctionInvocation fi,
+			final @NotNull FunctionInvocation fi,
 									 final ICodeRegistrar codeRegistrar,
 									 final Consumer<Eventual<BaseEvaFunction>> cef) {
 		assert generateFunctions1 == generateFunctions;
@@ -72,14 +67,14 @@ public class __LFOE_Q implements _LFOE_Q {
 
 	@Override
 	public void enqueue_function(final @NotNull Supplier<GenerateFunctions> som,
-								 final @NotNull FunctionInvocation aFi, final ICodeRegistrar cr) {
+			final @NotNull FunctionInvocation aFi, final ICodeRegistrar cr) {
 		final WlGenerateFunction wlgf = deduceTypes2._inj().new_WlGenerateFunction(som.get(), aFi, cr);
 		wl.addJob(wlgf);
 	}
 
 	@Override
 	public void enqueue_namespace(final @NotNull Supplier<GenerateFunctions> som,
-								  final @NotNull NamespaceInvocation aNsi, final DeducePhase.GeneratedClasses aGeneratedClasses,
+			final @NotNull NamespaceInvocation aNsi, final DeducePhase.GeneratedClasses aGeneratedClasses,
 								  final ICodeRegistrar aCr) {
 		wl.addJob(deduceTypes2._inj().new_WlGenerateNamespace(som.get(), aNsi, aGeneratedClasses, aCr));
 	}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/lfoe_action__FunctionInvocationDoneCallback.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/lfoe_action__FunctionInvocationDoneCallback.java
@@ -1,25 +1,18 @@
 package tripleo.elijah.stages.deduce.post_bytecode;
 
-import org.jdeferred2.DoneCallback;
+import java.util.*;
+import java.util.function.*;
 
-import tripleo.elijah.DebugFlags;
-import tripleo.elijah.ReadySupplier_1;
+import org.jdeferred2.*;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.*;
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.LangGlobals;
-import tripleo.elijah.stages.deduce.ClassInvocation;
-import tripleo.elijah.stages.deduce.DeduceTypes2;
-import tripleo.elijah.stages.deduce.FunctionInvocation;
-import tripleo.elijah.stages.gen_fn.ProcTableEntry;
-import tripleo.elijah.util.NotImplementedException;
-import tripleo.elijah.work.WorkList;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.Collection;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Consumer;
+import tripleo.elijah.lang.impl.*;
+import tripleo.elijah.stages.deduce.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.util.*;
+import tripleo.elijah.work.*;
 
 class lfoe_action__FunctionInvocationDoneCallback implements DoneCallback<FunctionInvocation> {
 	private final          DeduceElement3_ProcTableEntry deduceElement3ProcTableEntry;
@@ -58,7 +51,7 @@ class lfoe_action__FunctionInvocationDoneCallback implements DoneCallback<Functi
 		FunctionDef fd3 = fi.getFunction();
 
 		final ProcTableEntry principal = deduceElement3ProcTableEntry.getTablePrincipal();
-		final DeduceTypes2.DeduceTypes2Injector deduceTypes2Injector = deduceElement3ProcTableEntry._inj();
+		final DeduceTypes2Injector deduceTypes2Injector = deduceElement3ProcTableEntry._inj();
 
 		if (fd3 == LangGlobals.defaultVirtualCtor) {
 			if (ci == null) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/lfoe_action__FunctionInvocationDoneCallback.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/post_bytecode/lfoe_action__FunctionInvocationDoneCallback.java
@@ -16,12 +16,15 @@ import tripleo.elijah.work.*;
 
 class lfoe_action__FunctionInvocationDoneCallback implements DoneCallback<FunctionInvocation> {
 	private final          DeduceElement3_ProcTableEntry deduceElement3ProcTableEntry;
-	private final @NotNull DeduceTypes2                  deduceTypes2;
-	private final @NotNull Consumer<WorkList>            addJobs;
+	private final @NotNull DeduceTypes2 deduceTypes2;
+	private final @NotNull Consumer<WorkList> addJobs;
 	private final          __LFOE_Q                      q;
-	private final @NotNull WorkList                      wl;
+	private final @NotNull WorkList wl;
 
-	public lfoe_action__FunctionInvocationDoneCallback(final DeduceElement3_ProcTableEntry aDeduceElement3ProcTableEntry, final @NotNull DeduceTypes2 aDeduceTypes2, final @NotNull Consumer<WorkList> aAddJobs, final __LFOE_Q aQ, final @NotNull WorkList aWl) {
+	public lfoe_action__FunctionInvocationDoneCallback(
+			final DeduceElement3_ProcTableEntry aDeduceElement3ProcTableEntry,
+			final @NotNull DeduceTypes2 aDeduceTypes2, final @NotNull Consumer<WorkList> aAddJobs, final __LFOE_Q aQ,
+			final @NotNull WorkList aWl) {
 		deduceElement3ProcTableEntry = aDeduceElement3ProcTableEntry;
 		deduceTypes2                 = aDeduceTypes2;
 		addJobs                      = aAddJobs;
@@ -67,7 +70,8 @@ class lfoe_action__FunctionInvocationDoneCallback implements DoneCallback<Functi
 			Collection<ConstructorDef> cis = klass.getConstructors();
 
 			if (DebugFlags.FORCE_IGNORE) {
-				for (@NotNull ConstructorDef constructorDef : cis) {
+				for (@NotNull
+				ConstructorDef constructorDef : cis) {
 					final Iterable<FormalArgListItem> constructorDefArgs = constructorDef.getArgs();
 
 					if (!constructorDefArgs.iterator().hasNext()) { // zero-sized arg list

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/tastic/DT_External_2.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/tastic/DT_External_2.java
@@ -4,8 +4,8 @@ import org.jdeferred2.*;
 import org.jdeferred2.impl.*;
 import org.jetbrains.annotations.*;
 
-import tripleo.elijah.comp.Compilation0;
-import tripleo.elijah.comp.Finally.Outs;
+import tripleo.elijah.comp.*;
+import tripleo.elijah.comp.Finally.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.lang.nextgen.names.i.*;
@@ -117,7 +117,7 @@ public class DT_External_2 implements DT_External {
 		});
 	}
 
-	private DeduceTypes2.DeduceTypes2Injector _inj() {
+	private DeduceTypes2Injector _inj() {
 		return dc._deduceTypes2();
 	}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/tastic/DT_External_2.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/tastic/DT_External_2.java
@@ -216,7 +216,8 @@ public class DT_External_2 implements DT_External {
 			target_p2.then(target0 -> {
 
 				if (target0 == null) {
-					@NotNull Compilation0 c = el.getContext().module().getCompilation();
+					@NotNull
+					Compilation0 c = el.getContext().module().getCompilation();
 					if (c.reports().outputOn(Outs.OutDeduce_220))
 						tripleo.elijah.util.SimplePrintLoggerToRemoveSoon.println_err_4("542542  ");
 					return;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/tastic/FT_FCA_FunctionDef.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/tastic/FT_FCA_FunctionDef.java
@@ -1,14 +1,15 @@
 package tripleo.elijah.stages.deduce.tastic;
 
+import java.util.*;
+
 import org.jdeferred2.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.stages.deduce.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.util.*;
-
-import java.util.*;
 
 public class FT_FCA_FunctionDef {
 	private final FunctionDef fd;
@@ -19,7 +20,7 @@ public class FT_FCA_FunctionDef {
 		_dt2 = aDt2;
 	}
 
-	private DeduceTypes2.DeduceTypes2Injector _inj() {
+	private DeduceTypes2Injector _inj() {
 		return _dt2._inj();
 	}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/tastic/FT_FCA_IdentIA.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/tastic/FT_FCA_IdentIA.java
@@ -399,8 +399,8 @@ import tripleo.elijah_prolific.v.*;
 	}
 
 	private void __loop1__PROCEDURE_CALL(final ProcTableEntry pte,
-										 final @NotNull ProcedureCallExpression pce,
-										 final @NotNull FT_FCA_Ctx fdctx) {
+			final @NotNull ProcedureCallExpression pce,
+			final @NotNull FT_FCA_Ctx fdctx) {
 		final DeduceClient4 dc = fdctx.dc();
 		final ErrSink errSink = fdctx.errSink();
 		final TypeTableEntry             tte               = fdctx.tte();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/tastic/FT_FCA_IdentIA.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/tastic/FT_FCA_IdentIA.java
@@ -9,9 +9,15 @@
  */
 package tripleo.elijah.stages.deduce.tastic;
 
+import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
+
+import java.util.*;
+import java.util.stream.*;
+
 import org.jdeferred2.*;
 import org.jdeferred2.impl.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
@@ -22,12 +28,7 @@ import tripleo.elijah.stages.deduce.nextgen.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.util.*;
-import tripleo.elijah_prolific.v.V;
-
-import java.util.*;
-import java.util.stream.*;
-
-import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
+import tripleo.elijah_prolific.v.*;
 
 /*static*/ public class FT_FCA_IdentIA {
 
@@ -40,14 +41,14 @@ import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
 		private final          String             e_text;
 		private final Promise<GenType, Void, Void> p;
 		private final Context ctx;
-		private final DeduceTypes2.@NotNull DeduceClient4 dc;
+		private final @NotNull DeduceClient4 dc;
 		private final @NotNull InstructionArgument vte_ia;
 		boolean isDone;
 
 		public __FT_FCA_IdentIA_Runnable(final DeduceTypes2 aDt2, final @NotNull BaseEvaFunction aGeneratedFunction,
 				final @NotNull VariableTableEntry aVte, final @NotNull VariableTableEntry aVte1, final ErrSink aErrSink,
 				final String aE_text, final Promise<GenType, Void, Void> aP, final Context aCtx,
-				final DeduceTypes2.@NotNull DeduceClient4 aDc, final @NotNull InstructionArgument aVte_ia) {
+				final @NotNull DeduceClient4 aDc, final @NotNull InstructionArgument aVte_ia) {
 			dt2 = aDt2;
 			generatedFunction = aGeneratedFunction;
 			vte = aVte;
@@ -156,13 +157,13 @@ import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
 	}
 
 	public class FakeDC4 {
-		private final DeduceTypes2.DeduceClient4 dc4;
+		private final DeduceClient4 dc4;
 
-		public FakeDC4(final DeduceTypes2.DeduceClient4 aDc4) {
+		public FakeDC4(final DeduceClient4 aDc4) {
 			dc4 = aDc4;
 		}
 
-		public DeduceTypes2.DeduceTypes2Injector _deduceTypes2() {
+		public DeduceTypes2Injector _deduceTypes2() {
 			return dc4.get()._inj();
 		}
 
@@ -273,11 +274,11 @@ import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
 		private final BaseEvaFunction            generatedFunction;
 		private final TypeTableEntry             tte;
 		private final Context                    ctx;
-		private final ErrSink                    errSink;
-		private final DeduceTypes2.DeduceClient4 dc;
+		private final ErrSink errSink;
+		private final DeduceClient4 dc;
 
 		public FT_FCA_Ctx(BaseEvaFunction generatedFunction, TypeTableEntry tte, Context ctx, ErrSink errSink,
-						  DeduceTypes2.DeduceClient4 dc) {
+				DeduceClient4 dc) {
 			this.generatedFunction = generatedFunction;
 			this.tte               = tte;
 			this.ctx               = ctx;
@@ -301,7 +302,7 @@ import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
 			return errSink;
 		}
 
-		public DeduceTypes2.DeduceClient4 dc() {
+		public DeduceClient4 dc() {
 			return dc;
 		}
 
@@ -357,7 +358,7 @@ import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
 	}
 
 	private void __loop1__DOT_EXP(final @NotNull DotExpression de, final @NotNull FT_FCA_Ctx fdctx) {
-		final DeduceTypes2.DeduceClient4 dc = fdctx.dc();
+		final DeduceClient4 dc = fdctx.dc();
 		final ErrSink errSink = fdctx.errSink();
 		final TypeTableEntry tte = fdctx.tte();
 		final BaseEvaFunction generatedFunction = fdctx.generatedFunction();
@@ -400,8 +401,8 @@ import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
 	private void __loop1__PROCEDURE_CALL(final ProcTableEntry pte,
 										 final @NotNull ProcedureCallExpression pce,
 										 final @NotNull FT_FCA_Ctx fdctx) {
-		final DeduceTypes2.DeduceClient4 dc                = fdctx.dc();
-		final ErrSink                    errSink           = fdctx.errSink();
+		final DeduceClient4 dc = fdctx.dc();
+		final ErrSink errSink = fdctx.errSink();
 		final TypeTableEntry             tte               = fdctx.tte();
 		final BaseEvaFunction            generatedFunction = fdctx.generatedFunction();
 		final Context                    ctx               = fdctx.ctx();
@@ -460,7 +461,7 @@ import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
 
 	private void __vte_ia__is_null(final int aInstructionIndex, final @NotNull ProcTableEntry aPte, final int aI,
 			final @NotNull IdentExpression aExpression, final @NotNull BaseEvaFunction generatedFunction,
-			final Context ctx, final TypeTableEntry aTte, final DeduceTypes2.@NotNull DeduceClient4 dc,
+			final Context ctx, final TypeTableEntry aTte, final @NotNull DeduceClient4 dc,
 			final DeduceTypes2 dt2) {
 		int ia = generatedFunction.addIdentTableEntry(aExpression, ctx);
 		@NotNull
@@ -485,7 +486,7 @@ import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
 	private void __vte_ia__not_null(final @NotNull VariableTableEntry vte,
 			final @NotNull BaseEvaFunction generatedFunction, final @NotNull InstructionArgument vte_ia,
 			final TypeTableEntry aTte, final DeduceTypes2 dt2, final ErrSink errSink, final String e_text,
-			final Context ctx, final DeduceTypes2.@NotNull DeduceClient4 dc) {
+			final Context ctx, final @NotNull DeduceClient4 dc) {
 		final @NotNull VariableTableEntry vte1 = generatedFunction.getVarTableEntry(to_int(vte_ia));
 		final Promise<GenType, Void, Void> p = VTE_TypePromises.do_assign_call_args_ident_vte_promise(aTte, vte1);
 		@NotNull
@@ -496,7 +497,7 @@ import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
 
 	void do_assign_call_args_ident(@NotNull VariableTableEntry vte, int aInstructionIndex, @NotNull ProcTableEntry aPte,
 			int aI, @NotNull IdentExpression aExpression, final @NotNull FT_FCA_Ctx fdctx) {
-		final DeduceTypes2.DeduceClient4 dc = fdctx.dc();
+		final DeduceClient4 dc = fdctx.dc();
 		final ErrSink errSink = fdctx.errSink();
 		final TypeTableEntry aTte = fdctx.tte();
 		final BaseEvaFunction generatedFunction = fdctx.generatedFunction();
@@ -515,7 +516,7 @@ import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
 	}
 
 	void do_assign_call_GET_ITEM(@NotNull GetItemExpression gie, final @NotNull FT_FCA_Ctx fdctx) {
-		final DeduceTypes2.DeduceClient4 dc = fdctx.dc();
+		final DeduceClient4 dc = fdctx.dc();
 		final ErrSink errSink = fdctx.errSink();
 		final TypeTableEntry tte = fdctx.tte();
 		final BaseEvaFunction generatedFunction = fdctx.generatedFunction();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/tastic/FT_FnCallArgs.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/tastic/FT_FnCallArgs.java
@@ -55,7 +55,7 @@ public class FT_FnCallArgs implements ITastic {
 		 *
 		 */
 		public DoAssignCall(DeduceClient4 dc,
-							@NotNull BaseEvaFunction generatedFunction) {
+				@NotNull BaseEvaFunction generatedFunction) {
 			this.dc                = dc;
 			this.generatedFunction = generatedFunction;
 		}
@@ -103,8 +103,8 @@ public class FT_FnCallArgs implements ITastic {
 
 		}
 
-	private final @NotNull ElLog        LOG;
-	private final @NotNull DeduceTypes2 deduceTypes2;
+		private final @NotNull ElLog LOG;
+		private final @NotNull DeduceTypes2 deduceTypes2;
 	private final          FnCallArgs   fca;
 
 	@Contract(pure = true)
@@ -117,13 +117,13 @@ public class FT_FnCallArgs implements ITastic {
 
 	public static final class Packet_do_assign_call implements Packet {
 		private final @NotNull BaseEvaFunction generatedFunction;
-		private final @NotNull Context         ctx;
+		private final @NotNull Context ctx;
 		private final @NotNull IdentTableEntry idte;
 		private final          int             instructionIndex;
 
 		public Packet_do_assign_call(@NotNull BaseEvaFunction generatedFunction,
-									 @NotNull Context ctx,
-									 @NotNull IdentTableEntry idte,
+				@NotNull Context ctx,
+				@NotNull IdentTableEntry idte,
 									 int instructionIndex) {
 			this.generatedFunction = generatedFunction;
 			this.ctx               = ctx;
@@ -175,10 +175,10 @@ public class FT_FnCallArgs implements ITastic {
 
 	@Override
 	public void do_assign_call(final @NotNull BaseEvaFunction generatedFunction,
-							   final @NotNull Context ctx,
-							   final @NotNull IdentTableEntry idte,
-							   final @NotNull FnCallArgs fca,
-							   final @NotNull Instruction instruction) {
+			final @NotNull Context ctx,
+			final @NotNull IdentTableEntry idte,
+			final @NotNull FnCallArgs fca,
+			final @NotNull Instruction instruction) {
 		final int                     instructionIndex = instruction.getIndex();
 		final @NotNull ProcTableEntry pte = generatedFunction.getProcTableEntry(to_int(fca.getArg(0)));
 		for (final @NotNull TypeTableEntry tte : pte.getArgs()) {
@@ -193,7 +193,8 @@ public class FT_FnCallArgs implements ITastic {
 			}
 			case IDENT -> {
 				final @Nullable InstructionArgument vte_ia = generatedFunction.vte_lookup(((IdentExpression) e).getText());
-				final @NotNull List<TypeTableEntry> ll = deduceTypes2.getPotentialTypesVte((EvaFunction) generatedFunction, vte_ia);
+				final @NotNull List<TypeTableEntry> ll = deduceTypes2
+						.getPotentialTypesVte((EvaFunction) generatedFunction, vte_ia);
 
 				if (ll.size() == 1) {
 					tte.setAttached(ll.get(0).getAttached());
@@ -230,12 +231,13 @@ public class FT_FnCallArgs implements ITastic {
 	private void do_assign_call__callback(@Nullable OS_Element best, Packet ap) {
 		final Packet_do_assign_call   p                 = (Packet_do_assign_call) ap;
 		final BaseEvaFunction         generatedFunction = p.generatedFunction();
-		final @NotNull ProcTableEntry pte               = generatedFunction.getProcTableEntry(to_int(fca.getArg(0)));
+		final @NotNull ProcTableEntry pte = generatedFunction.getProcTableEntry(to_int(fca.getArg(0)));
 
 		do_assign_call__callback(generatedFunction, best, pte);
 	}
 
-	private void do_assign_call__callback(final @NotNull BaseEvaFunction generatedFunction, final @Nullable OS_Element best, final @NotNull ProcTableEntry pte) {
+	private void do_assign_call__callback(final @NotNull BaseEvaFunction generatedFunction,
+			final @Nullable OS_Element best, final @NotNull ProcTableEntry pte) {
 		if (best != null) {
 			pte.setResolvedElement(best);
 
@@ -269,14 +271,14 @@ public class FT_FnCallArgs implements ITastic {
 
 	@Override
 	public void do_assign_call(final @NotNull BaseEvaFunction generatedFunction,
-	                           final @NotNull Context ctx,
-	                           final @NotNull VariableTableEntry vte,
-	                           final @NotNull Instruction instruction,
+			final @NotNull Context ctx,
+			final @NotNull VariableTableEntry vte,
+			final @NotNull Instruction instruction,
 	                           final OS_Element aName) {
 		final DeduceClient4 client4 = deduceTypes2._inj().new_DeduceClient4(deduceTypes2);
 		final DoAssignCall dac = deduceTypes2._inj().new_DoAssignCall(client4, generatedFunction, this);
 		final int                        instructionIndex = instruction.getIndex();
-		final @NotNull ProcTableEntry    pte              = ((ProcIA) fca.getArg(0)).getEntry();
+		final @NotNull ProcTableEntry pte = ((ProcIA) fca.getArg(0)).getEntry();
 
 		if (aName instanceof IdentExpression ie) {
 			ie.getName().addUnderstanding(deduceTypes2._inj().new_ENU_FunctionCallTarget(pte));

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/tastic/FT_FnCallArgs.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/tastic/FT_FnCallArgs.java
@@ -9,7 +9,12 @@
  */
 package tripleo.elijah.stages.deduce.tastic;
 
+import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
+
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.lang.i.*;
@@ -19,10 +24,6 @@ import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.stages.logging.*;
 import tripleo.elijah.util.*;
-
-import java.util.*;
-
-import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
 
 public class FT_FnCallArgs implements ITastic {
 	public ElLog LOG() {
@@ -34,7 +35,7 @@ public class FT_FnCallArgs implements ITastic {
 	}
 
 	public static class NullFoundElement extends FoundElement {
-		public NullFoundElement(DeduceTypes2.@NotNull DeduceClient4 dc) {
+		public NullFoundElement(@NotNull DeduceClient4 dc) {
 			super(dc.getPhase());
 		}
 
@@ -47,13 +48,13 @@ public class FT_FnCallArgs implements ITastic {
 	 * Created 12/12/21 12:30 AM
 	 */
 		public static final class DoAssignCall {
-		private final          DeduceTypes2.DeduceClient4 dc;
-		private final @NotNull BaseEvaFunction            generatedFunction;
+			private final DeduceClient4 dc;
+			private final @NotNull BaseEvaFunction generatedFunction;
 
 		/**
 		 *
 		 */
-		public DoAssignCall(DeduceTypes2.DeduceClient4 dc,
+		public DoAssignCall(DeduceClient4 dc,
 							@NotNull BaseEvaFunction generatedFunction) {
 			this.dc                = dc;
 			this.generatedFunction = generatedFunction;
@@ -71,7 +72,7 @@ public class FT_FnCallArgs implements ITastic {
 			return dc.getErrSink();
 		}
 
-		public DeduceTypes2.DeduceClient4 dc() {
+		public DeduceClient4 dc() {
 			return dc;
 		}
 
@@ -272,8 +273,8 @@ public class FT_FnCallArgs implements ITastic {
 	                           final @NotNull VariableTableEntry vte,
 	                           final @NotNull Instruction instruction,
 	                           final OS_Element aName) {
-		final DeduceTypes2.DeduceClient4 client4          = deduceTypes2._inj().new_DeduceClient4(deduceTypes2);
-		final DoAssignCall               dac              = deduceTypes2._inj().new_DoAssignCall(client4, generatedFunction, this);
+		final DeduceClient4 client4 = deduceTypes2._inj().new_DeduceClient4(deduceTypes2);
+		final DoAssignCall dac = deduceTypes2._inj().new_DoAssignCall(client4, generatedFunction, this);
 		final int                        instructionIndex = instruction.getIndex();
 		final @NotNull ProcTableEntry    pte              = ((ProcIA) fca.getArg(0)).getEntry();
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/tastic/ITastic.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/deduce/tastic/ITastic.java
@@ -1,20 +1,17 @@
 package tripleo.elijah.stages.deduce.tastic;
 
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.lang.i.Context;
-import tripleo.elijah.lang.i.OS_Element;
-import tripleo.elijah.stages.gen_fn.BaseEvaFunction;
-import tripleo.elijah.stages.gen_fn.IdentTableEntry;
-import tripleo.elijah.stages.gen_fn.VariableTableEntry;
-import tripleo.elijah.stages.instructions.FnCallArgs;
-import tripleo.elijah.stages.instructions.Instruction;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.instructions.*;
 
 public interface ITastic {
 	void do_assign_call(@NotNull BaseEvaFunction generatedFunction,
-						@NotNull Context ctx,
-						@NotNull IdentTableEntry idte,
-						@NotNull FnCallArgs fca,
-						@NotNull Instruction instruction);
+			@NotNull Context ctx,
+			@NotNull IdentTableEntry idte,
+			@NotNull FnCallArgs fca,
+			@NotNull Instruction instruction);
 
 	void do_assign_call(BaseEvaFunction aGeneratedFunction,
 						Context aContext,

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/functionality/f292/F292_WriteRoot.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/functionality/f292/F292_WriteRoot.java
@@ -1,17 +1,19 @@
 package tripleo.elijah.stages.functionality.f292;
 
-import com.google.common.collect.Multimap;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.ci.CompilerInstructions;
-import tripleo.elijah.comp.nextgen.i.CP_Path;
-import tripleo.elijah.util.io.CharSink;
-import tripleo.elijah_prolific.v.V;
+import static tripleo.elijah.util.Helpers.*;
 
-import java.nio.file.Path;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.nio.file.*;
+import java.util.*;
+import java.util.stream.*;
 
-import static tripleo.elijah.util.Helpers.String_join;
+import org.jetbrains.annotations.*;
+
+import com.google.common.collect.*;
+
+import tripleo.elijah.ci.*;
+import tripleo.elijah.comp.nextgen.i.*;
+import tripleo.elijah.util.io.*;
+import tripleo.elijah_prolific.v.*;
 
 public class F292_WriteRoot {
 	private final String project_name;
@@ -21,7 +23,7 @@ public class F292_WriteRoot {
 	}
 
 	public void write_root(final @NotNull Multimap<CompilerInstructions, String> lsp_outputs,
-						   final @NotNull List<String> aDep_dirs,
+			final @NotNull List<String> aDep_dirs,
 						   final Path path2,
 						   final CharSink root_file,
 						   final CP_Path path2_) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/garish/GarishClass.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/garish/GarishClass.java
@@ -1,6 +1,9 @@
 package tripleo.elijah.stages.garish;
 
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.g.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.types.*;
@@ -11,8 +14,6 @@ import tripleo.elijah.stages.gen_generic.*;
 import tripleo.elijah.stages.gen_generic.pipeline_impl.*;
 import tripleo.elijah.util.*;
 import tripleo.elijah.world.i.*;
-
-import java.util.*;
 
 public class GarishClass implements GGarishClass {
 	private final LivingClass _lc;
@@ -51,11 +52,13 @@ public class GarishClass implements GGarishClass {
 		return sb.toString();
 	}
 
-	public void garish(final GenerateC aGenerateC, final GenerateResult gr, final @NotNull GenerateResultSink aResultSink) {
+	public void garish(final GenerateC aGenerateC, final GenerateResult gr,
+			final @NotNull GenerateResultSink aResultSink) {
 		getLiving().generateWith(aResultSink, this, gr, aGenerateC);
 	}
 
-	public @NotNull BufferTabbedOutputStream getImplBuffer(final @NotNull EvaClass x, final @NotNull CClassDecl decl, final String class_name, final int class_code) {
+	public @NotNull BufferTabbedOutputStream getImplBuffer(final @NotNull EvaClass x, final @NotNull CClassDecl decl,
+			final String class_name, final int class_code) {
 		final BufferTabbedOutputStream tos = new BufferTabbedOutputStream();
 
 		// TODO remove this block when constructors are added in dependent functions,
@@ -112,7 +115,8 @@ public class GarishClass implements GGarishClass {
 		return getHeaderBuffer(aGenerateC, evaClass, decl, class_name);
 	}
 
-	public @NotNull BufferTabbedOutputStream getHeaderBuffer(final @NotNull GenerateC aGenerateC, final @NotNull EvaClass x, final @NotNull CClassDecl decl, final String class_name) {
+	public @NotNull BufferTabbedOutputStream getHeaderBuffer(final @NotNull GenerateC aGenerateC,
+			final @NotNull EvaClass x, final @NotNull CClassDecl decl, final String class_name) {
 		final BufferTabbedOutputStream tosHdr = new BufferTabbedOutputStream();
 
 		tosHdr.put_string_ln("typedef struct {");

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/garish/GarishClass_Generator.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/garish/GarishClass_Generator.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.stages.garish;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.stages.gen_c.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.gen_generic.*;
@@ -14,10 +15,10 @@ public class GarishClass_Generator {
 		carrier = aEvaClass;
 	}
 
-	public void provide(final @NotNull GenerateResultSink   aResultSink,
-	                    final @NotNull GarishClass          aGarishClass,
-	                    final @NotNull GenerateResult       aGenerateResult,
-	                    final @NotNull GenerateC            aGenerateC) {
+	public void provide(final @NotNull GenerateResultSink aResultSink,
+			final @NotNull GarishClass aGarishClass,
+			final @NotNull GenerateResult aGenerateResult,
+			final @NotNull GenerateC aGenerateC) {
 		if (!generatedAlready) {
 			switch (carrier.getKlass().getType()) {
 			// Don't generate class definition for these three

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/garish/GarishNamespace.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/garish/GarishNamespace.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.stages.garish;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.stages.gen_c.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.gen_generic.*;
@@ -19,12 +20,12 @@ public class GarishNamespace {
 
 	public void garish(final GenerateC aGenerateC,
 	                   final GenerateResult gr,
-	                   final @NotNull GenerateResultSink aResultSink) {
+			final @NotNull GenerateResultSink aResultSink) {
 		getLiving().generateWith(aResultSink, this, gr, aGenerateC);
 	}
 
 	public @NotNull BufferTabbedOutputStream getHeaderBuffer(final @NotNull GenerateC aGenerateC,
-	                                                         final @NotNull EvaNamespace x, final String class_name, final int class_code) {
+			final @NotNull EvaNamespace x, final String class_name, final int class_code) {
 		final BufferTabbedOutputStream tosHdr = new BufferTabbedOutputStream();
 
 		tosHdr.put_string_ln("typedef struct {");

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/C2C_CodeForConstructor.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/C2C_CodeForConstructor.java
@@ -1,15 +1,16 @@
 package tripleo.elijah.stages.gen_c;
 
+import static tripleo.elijah.util.Helpers.*;
+
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.nextgen.outputstatement.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.gen_generic.*;
 import tripleo.elijah.util.*;
 import tripleo.util.buffer.*;
-
-import java.util.*;
-
-import static tripleo.elijah.util.Helpers.*;
 
 class C2C_CodeForConstructor implements Generate_Code_For_Method.C2C_Results {
 	final                  GenerateResult           gr;
@@ -23,8 +24,8 @@ class C2C_CodeForConstructor implements Generate_Code_For_Method.C2C_Results {
 	private C2C_Result bufHdr;
 
 	public C2C_CodeForConstructor(final Generate_Code_For_Method aGenerateCodeForMethod,
-	                              final @NotNull GenerateResultEnv aFileGen,
-	                              final @NotNull WhyNotGarish_Constructor aYf) {
+			final @NotNull GenerateResultEnv aFileGen,
+			final @NotNull WhyNotGarish_Constructor aYf) {
 		generateCodeForMethod = aGenerateCodeForMethod;
 
 		this.yf = aYf;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/CRI_Ident.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/CRI_Ident.java
@@ -1,16 +1,17 @@
 package tripleo.elijah.stages.gen_c;
 
+import java.util.*;
+import java.util.function.*;
+
 import org.jdeferred2.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.stages.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.util.*;
-
-import java.util.*;
-import java.util.function.*;
 
 class CRI_Ident {
 	private final BaseEvaFunction generatedFunction;
@@ -24,14 +25,15 @@ class CRI_Ident {
 	}
 
 	@Contract(value = "_, _, _ -> new", pure = true)
-	public static @NotNull CRI_Ident of(final IdentTableEntry aIdte, final BaseEvaFunction aGf, final GenerateC aGenerateC) {
+	public static @NotNull CRI_Ident of(final IdentTableEntry aIdte, final BaseEvaFunction aGf,
+			final GenerateC aGenerateC) {
 		return new CRI_Ident(aIdte, aGf, aGenerateC);
 	}
 
 	public @Nullable String getIdentIAPath(int i, final int sSize, final Generate_Code_For_Method.@NotNull AOG aog,
-										   final @NotNull List<String> sl, final String aValue, final @NotNull Consumer<CReference.Reference> addRef,
-										   final @NotNull List<InstructionArgument> s, final IdentIA ia2, final @NotNull CReference aCReference,
-										   final @NotNull CR_ReferenceItem item) {
+			final @NotNull List<String> sl, final String aValue, final @NotNull Consumer<CReference.Reference> addRef,
+			final @NotNull List<InstructionArgument> s, final IdentIA ia2, final @NotNull CReference aCReference,
+			final @NotNull CR_ReferenceItem item) {
 		final boolean[] skip = {false};
 		final OS_Element resolved_element = ite.getResolvedElement();
 		final String[]  text = {null};
@@ -188,12 +190,12 @@ class CRI_Ident {
 	}
 
 	private @Nullable EvaNode _re_is_PropertyStatement(final @NotNull Consumer<CReference.Reference> addRef,
-													   final Generate_Code_For_Method.@NotNull AOG aog,
+			final Generate_Code_For_Method.@NotNull AOG aog,
 													   final int sSize,
 													   final int i,
 													   final String aValue,
-													   final @NotNull Consumer<Void> skip,
-													   final @NotNull Consumer<String> text) {
+			final @NotNull Consumer<Void> skip,
+			final @NotNull Consumer<String> text) {
 		NotImplementedException.raise();
 		final EvaNode resolved1 = ite.type.resolved();
 		final int     code;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/CReference.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/CReference.java
@@ -9,8 +9,16 @@
  */
 package tripleo.elijah.stages.gen_c;
 
+import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
+import static tripleo.elijah.util.Helpers.*;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
 import org.apache.commons.lang3.tuple.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.nextgen.outputstatement.*;
@@ -18,13 +26,6 @@ import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.util.*;
 import tripleo.elijah_elevated.comp.backbone.*;
-
-import java.util.*;
-import java.util.function.*;
-import java.util.stream.*;
-
-import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
-import static tripleo.elijah.util.Helpers.*;
 
 /**
  * Created 1/9/21 7:12 AM
@@ -461,7 +462,7 @@ public class CReference {
 	}
 
 	public SpecialText getIdentIAPath(final @NotNull IdentIA ia2,
-									  final Generate_Code_For_Method.@NotNull AOG aog,
+			final Generate_Code_For_Method.@NotNull AOG aog,
 									  final String aValue) {
 		final BaseEvaFunction generatedFunction = ia2.gf;
 		final List<InstructionArgument> s = _getIdentIAPathList(ia2);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/Default_C2C_Result.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/Default_C2C_Result.java
@@ -1,12 +1,11 @@
 package tripleo.elijah.stages.gen_c;
 
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.lang.i.OS_Module;
-import tripleo.elijah.nextgen.outputstatement.EG_Statement;
-import tripleo.elijah.nextgen.outputstatement.EX_Explanation;
-import tripleo.elijah.stages.gen_generic.GenerateResult;
-import tripleo.elijah.stages.gen_generic.Old_GenerateResult;
-import tripleo.util.buffer.Buffer;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.nextgen.outputstatement.*;
+import tripleo.elijah.stages.gen_generic.*;
+import tripleo.util.buffer.*;
 
 class Default_C2C_Result implements C2C_Result {
 	private final Buffer buffer;
@@ -21,7 +20,7 @@ class Default_C2C_Result implements C2C_Result {
 	public Default_C2C_Result(final Buffer aBuffer,
 							  final GenerateResult.TY aTY,
 							  final String aExplanationMessage,
-							  final @NotNull WhyNotGarish_BaseFunction aWhyNotGarishFunction) {
+			final @NotNull WhyNotGarish_BaseFunction aWhyNotGarishFunction) {
 		buffer = aBuffer;
 		_ty = aTY;
 		explanation_message = aExplanationMessage;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/GCFM.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/GCFM.java
@@ -1,13 +1,14 @@
 package tripleo.elijah.stages.gen_c;
 
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.ci.*;
 import tripleo.elijah.nextgen.reactive.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.gen_generic.*;
 import tripleo.util.buffer.*;
-
-import java.util.*;
 
 public class GCFM implements Reactivable {
 
@@ -16,7 +17,8 @@ public class GCFM implements Reactivable {
 	private final @NotNull DeducedBaseEvaFunction gf;
 	private final GenerateResult gr;
 
-	public GCFM(final @NotNull List<C2C_Result> aRs, final @NotNull DeducedBaseEvaFunction aGf, final GenerateResult aGr) {
+	public GCFM(final @NotNull List<C2C_Result> aRs, final @NotNull DeducedBaseEvaFunction aGf,
+			final GenerateResult aGr) {
 		gf = aGf;
 		gr = aGr;
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/GCM_GF.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/GCM_GF.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.stages.gen_c;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.types.*;
@@ -21,7 +22,8 @@ class GCM_GF implements GCM_D {
 	}
 
 	@Override
-	public void find_return_type(final Generate_Method_Header aGenerate_method_header__, final Eventual<@NotNull String> ev) {
+	public void find_return_type(final Generate_Method_Header aGenerate_method_header__,
+			final Eventual<@NotNull String> ev) {
 		var fd = gf.getFD();
 
 		if (fd.returnType() instanceof RegularTypeName rtn) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/GI_ProcIA.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/GI_ProcIA.java
@@ -1,8 +1,13 @@
 package tripleo.elijah.stages.gen_c;
 
+import java.text.*;
+import java.util.*;
+import java.util.function.*;
+
 import org.apache.commons.lang3.tuple.*;
 import org.jdeferred2.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.diagnostic.*;
 import tripleo.elijah.diagnostic.Diagnostic.*;
@@ -14,10 +19,6 @@ import tripleo.elijah.stages.deduce.post_bytecode.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.util.*;
-
-import java.text.*;
-import java.util.*;
-import java.util.function.*;
 
 class GI_ProcIA implements GenerateC_Item {
 	private final GenerateC gc;
@@ -32,7 +33,7 @@ class GI_ProcIA implements GenerateC_Item {
 	}
 
 	public @NotNull Operation2<EG_Statement> action_CONSTRUCT(@NotNull Instruction aInstruction,
-															  @NotNull GenerateC gc) {
+			@NotNull GenerateC gc) {
 		final ProcTableEntry       pte = carrier.getEntry();
 		final List<TypeTableEntry> x   = pte.getArgs();
 		final int                  y   = aInstruction.getArgsSize();
@@ -49,7 +50,8 @@ class GI_ProcIA implements GenerateC_Item {
 
 			if (target instanceof IdentIA) {
 				// how to tell between named ctors and just a path?
-				@NotNull final IdentTableEntry target2 = ((IdentIA) target).getEntry();
+				@NotNull
+				final IdentTableEntry target2 = ((IdentIA) target).getEntry();
 				final String str = target2.getIdent().getText();
 
 				tripleo.elijah.util.SimplePrintLoggerToRemoveSoon.println_out_4("130  " + str);
@@ -102,7 +104,7 @@ class GI_ProcIA implements GenerateC_Item {
 	}
 
 	public @Nullable String getIdentIAPath_Proc(final @NotNull ProcTableEntry pte,
-												final @NotNull Consumer<Pair<String, CReference.Ref>> addRef) {
+			final @NotNull Consumer<Pair<String, CReference.Ref>> addRef) {
 		final String[]           text = new String[1];
 		final FunctionInvocation fi   = pte.getFunctionInvocation();
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/GenerateC.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/GenerateC.java
@@ -8,8 +8,15 @@
  */
 package tripleo.elijah.stages.gen_c;
 
+import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
 import org.apache.commons.lang3.tuple.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.ci.*;
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.lang.i.*;
@@ -31,12 +38,6 @@ import tripleo.elijah.world.i.*;
 import tripleo.elijah_elevated.comp.backbone.*;
 import tripleo.util.buffer.*;
 
-import java.util.*;
-import java.util.function.*;
-import java.util.stream.*;
-
-import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
-
 /**
  * Created 10/8/20 7:13 AM
  */
@@ -45,15 +46,15 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 	final                  GI_Repo                         _repo                     = new GI_Repo(this);
 	final                  Zone                            _zone                     = new Zone(this);
 	final                  CompilationEnclosure            ce;
-	final @NotNull         ErrSink                         errSink;
-	final @NotNull         ElLog                           LOG;
+	final @NotNull ErrSink errSink;
+	final @NotNull ElLog LOG;
 	private final          Map<EvaNode, WhyNotGarish_Item> a_directory               = new HashMap<>();
-	private final @NotNull GenerateResultEnv               _fileGen;
+	private final @NotNull GenerateResultEnv _fileGen;
 	final private          GenerateResultProgressive       generateResultProgressive = new GenerateResultProgressive();
 	public                 GenerateResultSink              resultSink;
 
 	public GenerateC(final @NotNull OutputFileFactoryParams aParams,
-					 final @NotNull GenerateResultEnv aFileGen) {
+			final @NotNull GenerateResultEnv aFileGen) {
 		_fileGen = aFileGen;
 
 		errSink = aParams.getErrSink();
@@ -97,11 +98,11 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 
 	@Override
 	public void generate_constructor(final @NotNull EvaConstructor aEvaConstructor,
-									 final @NotNull GenerateResult gr,
-									 final @NotNull WorkList wl,
-									 final @NotNull GenerateResultSink __aResultSink,
-									 final @NotNull WorkManager aWorkManager,
-									 final @NotNull GenerateResultEnv aFileGen) {
+			final @NotNull GenerateResult gr,
+			final @NotNull WorkList wl,
+			final @NotNull GenerateResultSink __aResultSink,
+			final @NotNull WorkManager aWorkManager,
+			final @NotNull GenerateResultEnv aFileGen) {
 		// TODO 10/16 argument ordering
 		generateCodeForConstructor(aFileGen, aEvaConstructor);
 		postGenerateCodeForConstructor(aEvaConstructor, wl, aFileGen);
@@ -109,16 +110,16 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 
 	@Override
 	public void generate_function(final @NotNull EvaFunction aEvaFunction,
-								  final @NotNull GenerateResult gr,
-								  final @NotNull WorkList wl,
-								  final @NotNull GenerateResultSink aResultSink) {
+			final @NotNull GenerateResult gr,
+			final @NotNull WorkList wl,
+			final @NotNull GenerateResultSink aResultSink) {
 		generateCodeForMethod(_fileGen, aEvaFunction);
 		postGenerateCodeForFunction(aEvaFunction, wl, _fileGen);
 	}
 
 	@Override
 	public @NotNull GenerateResult generateCode(final @NotNull Collection<EvaNode> lgn,
-												final @NotNull GenerateResultEnv aFileGen) {
+			final @NotNull GenerateResultEnv aFileGen) {
 		GenerateResult gr = new Old_GenerateResult();
 		WorkList       wl = new WorkList__();
 
@@ -149,9 +150,9 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 
 	@Override
 	public GenerateResult resultsFromNodes(final @NotNull List<EvaNode> aNodes,
-										   final @NotNull WorkManager wm,
-										   final @NotNull GenerateResultSink grs,
-										   final @NotNull GenerateResultEnv fg) {
+			final @NotNull WorkManager wm,
+			final @NotNull GenerateResultSink grs,
+			final @NotNull GenerateResultEnv fg) {
 		final GenerateResult gr2 = fg.gr();
 
 		if (fg.resultSink() != grs) {
@@ -163,10 +164,12 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 			if (generatedNode instanceof final @NotNull EvaContainerNC nc) {
 
 				nc.generateCode(_fileGen, this);
-				final @NotNull Collection<EvaNode> gn1 = (nc.functionMap.values()).stream().map(x -> (EvaNode) x).collect(Collectors.toList());
+				final @NotNull Collection<EvaNode> gn1 = (nc.functionMap.values()).stream().map(x -> (EvaNode) x)
+						.collect(Collectors.toList());
 				final GenerateResult               gr3 = this.generateCode(gn1, fg);
 				grs.additional(gr3);
-				final @NotNull Collection<EvaNode> gn2 = (nc.classMap.values()).stream().map(x -> (EvaNode) x).collect(Collectors.toList());
+				final @NotNull Collection<EvaNode> gn2 = (nc.classMap.values()).stream().map(x -> (EvaNode) x)
+						.collect(Collectors.toList());
 				final GenerateResult               gr4 = this.generateCode(gn2, fg);
 				grs.additional(gr4);
 			} else {
@@ -186,7 +189,8 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 		yf.resolveFileGenPromise(aGenerateResultEnv);
 	}
 
-	private void postGenerateCodeForFunction(final @NotNull EvaFunction aEvaFunction, final @NotNull WorkList wl, final @NotNull GenerateResultEnv fileGen) {
+	private void postGenerateCodeForFunction(final @NotNull EvaFunction aEvaFunction, final @NotNull WorkList wl,
+			final @NotNull GenerateResultEnv fileGen) {
 		for (IdentTableEntry identTableEntry : aEvaFunction.idte_list) {
 			if (identTableEntry.isResolved()) {
 				EvaNode x = identTableEntry.resolvedType();
@@ -215,9 +219,10 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 		}
 	}
 
-	//private void generateCodeForConstructor(final @NotNull EvaConstructor aEvaConstructor,
-	//										final @NotNull WorkList aWorkList,
-	//                                        final @NotNull GenerateResultEnv aFileGen) {
+	// private void generateCodeForConstructor(final @NotNull EvaConstructor
+	// aEvaConstructor,
+	// final @NotNull WorkList aWorkList,
+	// final @NotNull GenerateResultEnv aFileGen) {
 	//	if (aEvaConstructor.getFD() != null) {
 	//		Generate_Code_For_Method gcfm = new Generate_Code_For_Method(this, LOG);
 	//		gcfm.generateCodeForConstructor(aEvaConstructor, aFileGen);
@@ -237,7 +242,7 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 	//}
 
 	private void generateCodeForConstructor(final @NotNull GenerateResultEnv aGenerateResultEnv,
-											final @NotNull EvaConstructor aEvaConstructor) {
+			final @NotNull EvaConstructor aEvaConstructor) {
 		var yf = a_lookup((IEvaConstructor) aEvaConstructor);
 
 		if (true) {
@@ -261,7 +266,8 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 	//}
 
 //	@NotNull
-//	List<String> getArgumentStrings(final @NotNull BaseEvaFunction gf, final @NotNull Instruction instruction) {
+// List<String> getArgumentStrings(final @NotNull BaseEvaFunction gf, final
+// @NotNull Instruction instruction) {
 //		final List<String> sl3       = new ArrayList<String>();
 //		final int          args_size = instruction.getArgsSize();
 //		for (int i = 1; i < args_size; i++) {
@@ -275,7 +281,7 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 //				reference.getIdentIAPath((IdentIA) ia, Generate_Code_For_Method.AOG.GET, null);
 //				String text = reference.build();
 //				sl3.add(Emit.emit("/*673*/") + text);
-//			} else if (ia instanceof final @NotNull ConstTableIA c) {
+// } else if (ia instanceof final @NotNull ConstTableIA c) {
 //				ConstantTableEntry cte = gf.getConstTableEntry(c.getIndex());
 //				String             s   = new GetAssignmentValue().const_to_string(cte.initialValue);
 //				sl3.add(s);
@@ -292,8 +298,9 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 //	}
 
 //	@NotNull
-//	List<String> getArgumentStrings(final @NotNull Supplier<IFixedList<InstructionArgument>> instructionSupplier) {
-//		final @NotNull List<String> sl3       = new ArrayList<String>();
+// List<String> getArgumentStrings(final @NotNull
+// Supplier<IFixedList<InstructionArgument>> instructionSupplier) {
+// final @NotNull List<String> sl3 = new ArrayList<String>();
 //		final int                   args_size = instructionSupplier.get().size();
 //		for (int i = 1; i < args_size; i++) {
 //			final InstructionArgument ia = instructionSupplier.get().get(i);
@@ -306,7 +313,7 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 //				reference.getIdentIAPath((IdentIA) ia, Generate_Code_For_Method.AOG.GET, null);
 //				final String text = reference.build();
 //				sl3.add(Emit.emit("/*673*/") + text);
-//			} else if (ia instanceof final @NotNull ConstTableIA c) {
+// } else if (ia instanceof final @NotNull ConstTableIA c) {
 //				final ConstantTableEntry cte = c.getEntry();
 //				final String             s   = new GetAssignmentValue().const_to_string(cte.initialValue);
 //				sl3.add(s);
@@ -322,12 +329,14 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 //		return sl3;
 //	}
 
-	//public @NotNull List<String> getArgumentStrings(final @NotNull WhyNotGarish_BaseFunction aGf,
-	//                                                final @NotNull Instruction aInstruction) {
+// public @NotNull List<String> getArgumentStrings(final @NotNull
+// WhyNotGarish_BaseFunction aGf,
+// final @NotNull Instruction aInstruction) {
 	//	return getArgumentStrings(aGf.cheat(), aInstruction);
 	//}
 
-	private void postGenerateCodeForConstructor(final @NotNull EvaConstructor aEvaConstructor, final @NotNull WorkList wl, final @NotNull GenerateResultEnv aFileGen) {
+	private void postGenerateCodeForConstructor(final @NotNull EvaConstructor aEvaConstructor,
+			final @NotNull WorkList wl, final @NotNull GenerateResultEnv aFileGen) {
 		for (IdentTableEntry identTableEntry : aEvaConstructor.idte_list) {
 			identTableEntry.reactive().addResolveListener((IdentTableEntry x) -> {
 				generateIdent(x);
@@ -376,8 +385,8 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 	//}
 
 	//@NotNull
-	//String getRealTargetName(final @NotNull BaseEvaFunction gf,
-	//                         final @NotNull IdentIA target,
+	// String getRealTargetName(final @NotNull BaseEvaFunction gf,
+	// final @NotNull IdentIA target,
 	//                         final Generate_Code_For_Method.AOG aog,
 	//                         final String value) {
 	//	final int[]     state           = {0};
@@ -388,7 +397,8 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 	//	InstructionArgument backlink = identTableEntry.getBacklink();
 	//	final String        text     = identTableEntry.getIdent().getText();
 	//	if (backlink == null) {
-	//		if (identTableEntry.getResolvedElement() instanceof final @NotNull VariableStatement vs) {
+	// if (identTableEntry.getResolvedElement() instanceof final @NotNull
+	// VariableStatement vs) {
 	//			GI_VariableStatement vs2;
 	//			extracted(gf, vs, state, code, identTableEntry);
 	//		}
@@ -405,11 +415,11 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 	//	} else
 	//		ls.add(Emit.emit("/*872*/") + "vm" + text); // TODO blindly adding "vm" might not always work, also put in loop
 	//	while (backlink != null) {
-	//		if (backlink instanceof final @NotNull IntegerIA integerIA) {
+	// if (backlink instanceof final @NotNull IntegerIA integerIA) {
 	//			String realTargetName = getRealTargetName(gf, integerIA, Generate_Code_For_Method.AOG.ASSIGN);
 	//			ls.addFirst(Emit.emit("/*892*/") + realTargetName);
 	//			backlink = null;
-	//		} else if (backlink instanceof final @NotNull IdentIA identIA) {
+	// } else if (backlink instanceof final @NotNull IdentIA identIA) {
 	//			int             identIAIndex        = identIA.getIndex();
 	//			IdentTableEntry identTableEntry1    = gf.getIdentTableEntry(identIAIndex);
 	//			String          identTableEntryName = identTableEntry1.getIdent().getText();
@@ -430,7 +440,9 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 	//		return s;
 	//}
 
-	//private static void extracted(final @NotNull BaseEvaFunction gf, final @NotNull VariableStatement vs, final int[] state, final int[] code, final IdentTableEntry identTableEntry) {
+	// private static void extracted(final @NotNull BaseEvaFunction gf, final
+	// @NotNull VariableStatement vs, final int[] state, final int[] code, final
+	// IdentTableEntry identTableEntry) {
 	//	OS_Element parent = vs.getParent().getParent();
 	//	if (parent != gf.getFD()) {
 	//		// we want identTableEntry.resolved which will be a EvaMember
@@ -451,7 +463,7 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 	//		};
 	//
 	//		identTableEntry.onExternalRef((EvaNode er2) -> {
-	//			if (er2 instanceof final @NotNull EvaContainerNC nc) {
+	// if (er2 instanceof final @NotNull EvaContainerNC nc) {
 	//				if (!(nc instanceof EvaNamespace ns)) { throw new AssertionError(); } else {
 	//					//if (ns.isInstance()) {}
 	//					mod.setState(1);
@@ -476,7 +488,7 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 	@Override
 	public void generate_namespace(final @NotNull EvaNamespace x,
 								   final GenerateResult gr,
-								   final @NotNull GenerateResultSink aResultSink) {
+			final @NotNull GenerateResultSink aResultSink) {
 		final LivingNamespace ln = aResultSink.getLivingNamespaceForEva(x); // TODO could also add _living property
 		ln.getGarish().garish(this, gr, aResultSink);
 
@@ -531,14 +543,14 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 
 	public @NotNull String getAssignmentValue(final VariableTableEntry aSelf,
 											  final InstructionArgument aRhs,
-											  final @NotNull WhyNotGarish_BaseFunction aGf) {
+			final @NotNull WhyNotGarish_BaseFunction aGf) {
 		return getAssignmentValue(aSelf, aRhs, aGf.cheat());
 	}
 
 	@NotNull
 	String getAssignmentValue(VariableTableEntry value_of_this,
 							  final InstructionArgument value,
-							  final @NotNull BaseEvaFunction gf) {
+			final @NotNull BaseEvaFunction gf) {
 		GetAssignmentValue gav = new GetAssignmentValue();
 		if (value instanceof final @NotNull FnCallArgs fca) {
 			return gav.FnCallArgs(fca, gf, LOG);
@@ -566,7 +578,7 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 
 	@NotNull
 	List<String> getArgumentStrings(final @NotNull Supplier<IFixedList<InstructionArgument>> instructionSupplier) {
-		final @NotNull List<String> sl3       = new ArrayList<String>();
+		final @NotNull List<String> sl3 = new ArrayList<String>();
 		final int                   args_size = instructionSupplier.get().size();
 		for (int i = 1; i < args_size; i++) {
 			final InstructionArgument ia = instructionSupplier.get().get(i);
@@ -604,16 +616,19 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 		return zone_vte.getRealTargetName();
 	}
 
-	@NotNull String getTypeName(@NotNull TypeTableEntry tte) {
+	@NotNull
+	String getTypeName(@NotNull TypeTableEntry tte) {
 		return GetTypeName.forTypeTableEntry(tte, this);
 	}
 
 	@Deprecated
-	public String getRealTargetName(final @NotNull WhyNotGarish_BaseFunction aGf, final @NotNull IntegerIA aTarget, final Generate_Code_For_Method.AOG aAOG) {
+	public String getRealTargetName(final @NotNull WhyNotGarish_BaseFunction aGf, final @NotNull IntegerIA aTarget,
+			final Generate_Code_For_Method.AOG aAOG) {
 		return getRealTargetName(aGf.cheat(), aTarget, aAOG);
 	}
 
-	String getRealTargetName(final @NotNull BaseEvaFunction gf, final @NotNull IntegerIA target, final Generate_Code_For_Method.AOG aog) {
+	String getRealTargetName(final @NotNull BaseEvaFunction gf, final @NotNull IntegerIA target,
+			final Generate_Code_For_Method.AOG aog) {
 		final VariableTableEntry varTableEntry = gf.getVarTableEntry(target.getIndex());
 		return getRealTargetName(gf, varTableEntry);
 	}
@@ -628,7 +643,8 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 		return _repo;
 	}
 
-	public @NotNull List<String> getArgumentStrings(final @NotNull WhyNotGarish_BaseFunction aGf, final @NotNull Instruction aInstruction) {
+	public @NotNull List<String> getArgumentStrings(final @NotNull WhyNotGarish_BaseFunction aGf,
+			final @NotNull Instruction aInstruction) {
 		return getArgumentStrings(aGf.cheat(), aInstruction);
 	}
 
@@ -732,7 +748,8 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 		return LOG;
 	}
 
-	public void generateCodeForConstructor_1(@NotNull IEvaConstructor aEvaConstructor, final @NotNull GenerateResultEnv aGenerateResultEnv) {
+	public void generateCodeForConstructor_1(@NotNull IEvaConstructor aEvaConstructor,
+			final @NotNull GenerateResultEnv aGenerateResultEnv) {
 		final WhyNotGarish_Constructor yf = a_lookup(aEvaConstructor);
 		yf.resolveFileGenPromise(aGenerateResultEnv);
 	}
@@ -883,10 +900,11 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 		private final          BaseEvaFunction    gf;
 		private final          GenerateResult     gr;
 		private final          WorkList           wl;
-		private final @NotNull GenerateResultEnv  fileGen;
+		private final @NotNull GenerateResultEnv fileGen;
 		private                boolean            _isDone = false;
 
-		public WlGenerateFunctionC(@NotNull GenerateResultEnv fileGen, BaseEvaFunction aGf, final GenerateFiles aGenerateC) {
+		public WlGenerateFunctionC(@NotNull GenerateResultEnv fileGen, BaseEvaFunction aGf,
+				final GenerateFiles aGenerateC) {
 			gf = aGf;
 
 			gr         = fileGen.gr();
@@ -1043,7 +1061,8 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 			}
 		}
 
-		GetAssignmentValueArgsStatement getAssignmentValueArgs(final @NotNull Instruction inst, final @NotNull BaseEvaFunction gf, @NotNull ElLog LOG) {
+		GetAssignmentValueArgsStatement getAssignmentValueArgs(final @NotNull Instruction inst,
+				final @NotNull BaseEvaFunction gf, @NotNull ElLog LOG) {
 			var gavas = new GetAssignmentValueArgsStatement(inst);
 
 			final int args_size = inst.getArgsSize();
@@ -1095,13 +1114,16 @@ public class GenerateC implements CodeGenerator, GenerateFiles, ReactiveDimensio
 		}
 
 		// TODO look at me
-		public String forClassInvocation(@NotNull Instruction aInstruction, ClassInvocation aClsinv, @NotNull BaseEvaFunction gf, @NotNull ElLog LOG) {
+		public String forClassInvocation(@NotNull Instruction aInstruction, ClassInvocation aClsinv,
+				@NotNull BaseEvaFunction gf, @NotNull ElLog LOG) {
 			InstructionArgument     _arg0     = aInstruction.getArg(0);
-			@NotNull ProcTableEntry pte       = gf.getProcTableEntry(((ProcIA) _arg0).index());
+			@NotNull
+			ProcTableEntry pte = gf.getProcTableEntry(((ProcIA) _arg0).index());
 			final CtorReference     reference = new CtorReference();
 			reference.getConstructorPath(pte.expression_num, gf);
 			final GetAssignmentValueArgsStatement ava = getAssignmentValueArgs(aInstruction, gf, LOG);
-			@NotNull List<String>                 x   = ava.stringList();
+			@NotNull
+			List<String> x = ava.stringList();
 			reference.args(x);
 			return reference.build(aClsinv);
 		}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/Generate_Code_For_Method.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/Generate_Code_For_Method.java
@@ -8,9 +8,13 @@
  */
 package tripleo.elijah.stages.gen_c;
 
-import com.google.common.base.*;
+import java.util.*;
+
 import org.apache.commons.lang3.tuple.*;
 import org.jetbrains.annotations.*;
+
+import com.google.common.base.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.diagnostic.*;
@@ -27,8 +31,6 @@ import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.stages.logging.*;
 import tripleo.elijah.util.*;
 import tripleo.elijah.work.*;
-
-import java.util.*;
 
 /**
  * Created 6/21/21 5:53 AM
@@ -48,7 +50,8 @@ public class Generate_Code_For_Method {
 	void action_invariant(final @NotNull WhyNotGarish_BaseFunction yf, final Generate_Method_Header aGmh) {
 		tos.incr_tabs();
 		//
-		@NotNull final List<Instruction> instructions = yf.instructions();
+		@NotNull
+		final List<Instruction> instructions = yf.instructions();
 
 		for (int instruction_index = 0; instruction_index < instructions.size(); instruction_index++) {
 			final Instruction instruction = instructions.get(instruction_index);
@@ -347,8 +350,8 @@ public class Generate_Code_For_Method {
 	}
 
 	private void action_IS_A(final @NotNull Instruction instruction,
-							 final @NotNull BufferTabbedOutputStream tos,
-							 final @NotNull WhyNotGarish_BaseFunction gf) {
+			final @NotNull BufferTabbedOutputStream tos,
+			final @NotNull WhyNotGarish_BaseFunction gf) {
 
 		final IntegerIA testing_var_  = (IntegerIA) instruction.getArg(0);
 		final IntegerIA testing_type_ = (IntegerIA) instruction.getArg(1);
@@ -397,7 +400,7 @@ public class Generate_Code_For_Method {
 	}
 
 	private void action_DECL(final @NotNull Instruction instruction, final @NotNull BufferTabbedOutputStream tos,
-							 final @NotNull WhyNotGarish_BaseFunction gf) {
+			final @NotNull WhyNotGarish_BaseFunction gf) {
 		final Operation2<EG_Statement> op = _action_DECL(instruction, gf);
 
 		if (op.mode() == Mode.SUCCESS) {
@@ -409,7 +412,7 @@ public class Generate_Code_For_Method {
 	}
 
 	private void action_CAST(final @NotNull Instruction instruction, final @NotNull BufferTabbedOutputStream tos,
-							 final @NotNull WhyNotGarish_BaseFunction gf) {
+			final @NotNull WhyNotGarish_BaseFunction gf) {
 		final IntegerIA      vte_num_     = (IntegerIA) instruction.getArg(0);
 		final IntegerIA      vte_type_    = (IntegerIA) instruction.getArg(1);
 		final IntegerIA      vte_targ_    = (IntegerIA) instruction.getArg(2);
@@ -423,7 +426,7 @@ public class Generate_Code_For_Method {
 	}
 
 	private @NotNull Operation2<EG_Statement> _action_DECL(final @NotNull Instruction instruction,
-														   final @NotNull WhyNotGarish_BaseFunction yf) {
+			final @NotNull WhyNotGarish_BaseFunction yf) {
 		final SymbolIA  decl_type = (SymbolIA) instruction.getArg(0);
 		final IntegerIA vte_num   = (IntegerIA) instruction.getArg(1);
 
@@ -481,7 +484,7 @@ public class Generate_Code_For_Method {
 		}
 
 		final EvaNode res = vte.resolvedType();
-		//if (res instanceof final @NotNull EvaContainerNC nc) {
+		// if (res instanceof final @NotNull EvaContainerNC nc) {
 		//	if (nc instanceof EvaClass rec) {
 		//	} else if (nc instanceof EvaNamespace ren) {
 		//		den = this.gc.a_lookup(ren).ool();
@@ -554,7 +557,8 @@ public class Generate_Code_For_Method {
 		// VARIABLE WASN'T FULLY DEDUCED YET
 		// MTL A TEMP VARIABLE
 		//
-		@NotNull final Collection<TypeTableEntry> pt_ = vte.potentialTypes();
+		@NotNull
+		final Collection<TypeTableEntry> pt_ = vte.potentialTypes();
 		final List<TypeTableEntry>                pt  = new ArrayList<TypeTableEntry>(pt_);
 		if (pt.size() == 1) {
 			final TypeTableEntry ty = pt.get(0);
@@ -587,7 +591,7 @@ public class Generate_Code_For_Method {
 	}
 
 	void generateCodeForConstructor(final @NotNull DeducedEvaConstructor dgf,
-									final @NotNull GenerateResultEnv fileGen) {
+			final @NotNull GenerateResultEnv fileGen) {
 		final IEvaConstructor gf = dgf.getCarrier();
 		final GenerateResult           gr        = fileGen.gr();
 		final WorkList                 aWorkList = fileGen.wl();
@@ -609,34 +613,35 @@ public class Generate_Code_For_Method {
 	}
 
 /*
-	public void generateCodeForMethod2(final @NotNull DeducedBaseEvaFunction dgf, final @NotNull GenerateResultEnv aFileGen) {
-		assert false;
-
-		final BaseEvaFunction gf = (BaseEvaFunction) dgf.getCarrier();
-
-		assert gf.deducedAlready;
-
-		var yf = gc.a_lookup(gf);
-		//var dgf = yf.deduced(gf);
-
-        //assert dgf != null;
-        generateCodeForMethod(dgf, aFileGen);
-	}
-*/
+ * public void generateCodeForMethod2(final @NotNull DeducedBaseEvaFunction dgf,
+ * final @NotNull GenerateResultEnv aFileGen) {
+ * assert false;
+ * 
+ * final BaseEvaFunction gf = (BaseEvaFunction) dgf.getCarrier();
+ * 
+ * assert gf.deducedAlready;
+ * 
+ * var yf = gc.a_lookup(gf);
+ * //var dgf = yf.deduced(gf);
+ * 
+ * //assert dgf != null;
+ * generateCodeForMethod(dgf, aFileGen);
+ * }
+ */
 
 /*
-	public void generateCodeForMethod2(final @NotNull EvaConstructor gf) {
-		assert gf.deducedAlready;
+ * public void generateCodeForMethod2(final @NotNull EvaConstructor gf) {
+ * assert gf.deducedAlready;
+ * 
+ * final var yf = gc.a_lookup(gf);
+ * final var dgf = yf.deduced(gf);
+ * 
+ * assert dgf != null;
+ * generateCodeForConstructor(dgf, null); // TODO !! will fail
+ * }
+ */
 
-		final var yf = gc.a_lookup(gf);
-		final var dgf = yf.deduced(gf);
-
-		assert dgf != null;
-		generateCodeForConstructor(dgf, null); // TODO !! will fail
-	}
-*/
-
-	void generateCodeForMethod(final WhyNotGarish_Function yf, final @NotNull GenerateResultEnv aFileGen) {
+void generateCodeForMethod(final WhyNotGarish_Function yf, final @NotNull GenerateResultEnv aFileGen) {
 		final DeducedBaseEvaFunction dgf = yf.deduced();
 		final IEvaFunctionBase       gf  = dgf.getCarrier();
 		final BaseEvaFunction        bef = (BaseEvaFunction) gf;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/Generate_Method_Header.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/Generate_Method_Header.java
@@ -1,9 +1,14 @@
 package tripleo.elijah.stages.gen_c;
 
-import com.google.common.base.*;
-import com.google.common.collect.*;
+import java.util.*;
+import java.util.stream.*;
+
 import org.jdeferred2.*;
 import org.jetbrains.annotations.*;
+
+import com.google.common.base.*;
+import com.google.common.collect.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.types.*;
@@ -16,21 +21,19 @@ import tripleo.elijah.stages.logging.*;
 import tripleo.elijah.util.*;
 import tripleo.elijah_fluffy.util.*;
 
-import java.util.*;
-import java.util.stream.*;
-
 class Generate_Method_Header {
 
 	final                  String  args_string;
-	final @NotNull         String  header_string;
+	final @NotNull String header_string;
 	private final @NotNull EG_Statement args_statement;
 	private final @NotNull GenerateC gc;
 	private final          String  name;
-	private final @NotNull String  return_type;
+	private final @NotNull String return_type;
 	@Nullable              OS_Type type;
 	TypeTableEntry tte;
 
-	public Generate_Method_Header(final @NotNull WhyNotGarish_BaseFunction yf, final @NotNull GenerateC aGenerateC, final @NotNull ElLog LOG) {
+	public Generate_Method_Header(final @NotNull WhyNotGarish_BaseFunction yf, final @NotNull GenerateC aGenerateC,
+			final @NotNull ElLog LOG) {
 		var gf = yf.cheat();
 
 		gc = aGenerateC;
@@ -42,13 +45,15 @@ class Generate_Method_Header {
 		header_string = find_header_string(gf, LOG);
 	}
 
-	@NotNull String find_return_type(final BaseEvaFunction gf, final ElLog LOG) {
+	@NotNull
+	String find_return_type(final BaseEvaFunction gf, final ElLog LOG) {
 		final Eventual<String> ev = new Eventual<>();
 		discriminator(gf, LOG, gc).find_return_type(this, ev);
 		return EventualExtract.of(ev);
 	}
 
-	@NotNull EG_Statement find_args_statement(final @NotNull BaseEvaFunction gf) {
+	@NotNull
+	EG_Statement find_args_statement(final @NotNull BaseEvaFunction gf) {
 
 		final String rule = "gen_c:gcfm:Generate_Method_Header:find_args_statement";
 
@@ -62,7 +67,8 @@ class Generate_Method_Header {
 		return args;
 	}
 
-	@NotNull String find_header_string(final @NotNull BaseEvaFunction gf, final @NotNull ElLog LOG) {
+	@NotNull
+	String find_header_string(final @NotNull BaseEvaFunction gf, final @NotNull ElLog LOG) {
 		// NOTE getGenClass is always a class or namespace, getParent can be a function
 		final EvaContainerNC parent = (EvaContainerNC) gf.getGenClass();
 
@@ -102,16 +108,21 @@ class Generate_Method_Header {
 		final EvaContainerNC parent = (EvaContainerNC) gf.getGenClass();
 
 		if (parent instanceof EvaClass st) {
-			@NotNull final C_HeaderString chs = C_HeaderString.forClass(st, () -> GenerateC.GetTypeName.forGenClass(st, this.gc), return_type, name, args_string, LOG);
+			@NotNull
+			final C_HeaderString chs = C_HeaderString.forClass(st, () -> GenerateC.GetTypeName.forGenClass(st, this.gc),
+					return_type, name, args_string, LOG);
 
 			result = chs.getResult();
 		} else if (parent instanceof EvaNamespace) {
 			final EvaNamespace st = (EvaNamespace) parent;
 
-			@NotNull final C_HeaderString chs = C_HeaderString.forNamespace(st, () -> GenerateC.GetTypeName.forGenNamespace(st), return_type, name, args_string, LOG);
+			@NotNull
+			final C_HeaderString chs = C_HeaderString.forNamespace(st, () -> GenerateC.GetTypeName.forGenNamespace(st),
+					return_type, name, args_string, LOG);
 			result = chs.getResult();
 		} else {
-			@NotNull final C_HeaderString chs = C_HeaderString.forOther(parent, return_type, name, args_string);
+			@NotNull
+			final C_HeaderString chs = C_HeaderString.forOther(parent, return_type, name, args_string);
 			// result = String.format("%s %s(%s)", return_type, name, args_string);
 			result = chs.getResult();
 		}
@@ -119,12 +130,14 @@ class Generate_Method_Header {
 		return result;
 	}
 
-	@NotNull String __find_return_type(final @NotNull WhyNotGarish_BaseFunction gf, final @NotNull ElLog LOG) {
+	@NotNull
+	String __find_return_type(final @NotNull WhyNotGarish_BaseFunction gf, final @NotNull ElLog LOG) {
 		final _Closure__find_return_type cl = new _Closure__find_return_type();
 		return cl.call(gf, LOG, this);
 	}
 
-	@NotNull String find_args_string(final @NotNull BaseEvaFunction gf) {
+	@NotNull
+	String find_args_string(final @NotNull BaseEvaFunction gf) {
 		final String args;
 		if (false) {
 			args = Helpers.String_join(", ", Collections2.transform(gf.getFD().fal().falis(), new Function<FormalArgListItem, String>() {
@@ -157,16 +170,17 @@ class Generate_Method_Header {
 
 	class _Closure__find_return_type {
 
-		private String call(final @NotNull WhyNotGarish_BaseFunction gf, final @NotNull ElLog LOG, final Generate_Method_Header aGenerateMethodHeader) {
+		private String call(final @NotNull WhyNotGarish_BaseFunction gf, final @NotNull ElLog LOG,
+				final Generate_Method_Header aGenerateMethodHeader) {
 			Eventual<String> ev = new Eventual();
 			xcall(gf, LOG, aGenerateMethodHeader, ev);
 			return EventualExtract.of(ev);
 		}
 
 		private void xcall(final @NotNull WhyNotGarish_BaseFunction yf,
-						   final @NotNull ElLog LOG,
-						   final @NotNull Generate_Method_Header aGenerateMethodHeader,
-						   final @NotNull Eventual<String> ev) {
+				final @NotNull ElLog LOG,
+				final @NotNull Generate_Method_Header aGenerateMethodHeader,
+				final @NotNull Eventual<String> ev) {
 			String returnType = null;
 			if (yf.pointsToConstructor2()) {
 				// Get it from resolved

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/WhyNotGarish_BaseFunction.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/WhyNotGarish_BaseFunction.java
@@ -1,15 +1,16 @@
 package tripleo.elijah.stages.gen_c;
 
+import java.util.*;
+
 import org.apache.commons.lang3.tuple.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.nextgen.outputstatement.*;
 import tripleo.elijah.stages.gen_c.Generate_Code_For_Method.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.gen_generic.*;
 import tripleo.elijah.stages.instructions.*;
-
-import java.util.*;
 
 public abstract class WhyNotGarish_BaseFunction implements WhyNotGarish_Item {
 	/**
@@ -84,7 +85,8 @@ public abstract class WhyNotGarish_BaseFunction implements WhyNotGarish_Item {
 			// if there is no Result, there should be Value
 			result_index = getGf().vte_lookup("Value");
 			// but Value might be passed in. If it is, discard value
-			@NotNull final VariableTableEntry vte = ((IntegerIA) result_index).getEntry();
+			@NotNull
+			final VariableTableEntry vte = ((IntegerIA) result_index).getEntry();
 			if (vte.getVtt() != VariableTableType.RESULT)
 				result_index = null;
 			if (result_index == null)
@@ -99,7 +101,8 @@ public abstract class WhyNotGarish_BaseFunction implements WhyNotGarish_Item {
 	public @NotNull TypeTableEntry tte_for_self() {
 		@Nullable final InstructionArgument result_index = getGf().vte_lookup("self");
 		final IntegerIA                   resultIA = (IntegerIA) result_index;
-		@NotNull final VariableTableEntry vte      = resultIA.getEntry();
+		@NotNull
+		final VariableTableEntry vte = resultIA.getEntry();
 		assert vte.getVtt() == VariableTableType.SELF;
 
 		var tte1 = getGf().getTypeTableEntry(resultIA.getIndex());
@@ -127,7 +130,8 @@ public abstract class WhyNotGarish_BaseFunction implements WhyNotGarish_Item {
 		return text.reasonedForAOG(aAOG);
 	}
 
-	public Garish_TargetName getRealTargetName(final @NotNull GenerateC gc, final IdentIA target, final String assignmentValue) {
+	public Garish_TargetName getRealTargetName(final @NotNull GenerateC gc, final IdentIA target,
+			final String assignmentValue) {
 		final ZoneITE zi = gc._zone.get(target);
 
 		return zi.getRealTargetName3(assignmentValue);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/WhyNotGarish_Constructor.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/WhyNotGarish_Constructor.java
@@ -1,7 +1,10 @@
 package tripleo.elijah.stages.gen_c;
 
+import java.util.*;
+
 import org.apache.commons.lang3.tuple.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.comp.notation.*;
@@ -17,8 +20,6 @@ import tripleo.elijah.stages.gen_generic.pipeline_impl.*;
 import tripleo.elijah.stages.logging.*;
 import tripleo.elijah.util.*;
 import tripleo.elijah.work.*;
-
-import java.util.*;
 
 public class WhyNotGarish_Constructor extends WhyNotGarish_BaseFunction implements WhyNotGarish_Item {
 	private final WhyNotGarish_DeclaringContext __declaringContext;
@@ -169,7 +170,7 @@ public class WhyNotGarish_Constructor extends WhyNotGarish_BaseFunction implemen
 	private void generateIdent(@NotNull IdentTableEntry identTableEntry, @NotNull GenerateResultEnv aFileGen) {
 		assert identTableEntry.isResolved();
 
-		final @NotNull EvaNode x  = identTableEntry.resolvedType();
+		final @NotNull EvaNode x = identTableEntry.resolvedType();
 		final WorkList         wl = aFileGen.wl();
 
 		if (x instanceof final EvaClass evaClass) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/WhyNotGarish_Namespace.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/WhyNotGarish_Namespace.java
@@ -3,6 +3,7 @@ package tripleo.elijah.stages.gen_c;
 import org.apache.commons.lang3.tuple.*;
 import org.jdeferred2.impl.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.nextgen.reactive.*;
@@ -38,7 +39,7 @@ public class WhyNotGarish_Namespace implements WhyNotGarish_Item {
 
 		final LivingRepo                  world = generateC._ce().getCompilation().world();
 		final GarishNamespace             gn    = world.getNamespace(en).getGarish();
-		final @NotNull GenerateResultSink sink  = aFileGen.resultSink();
+		final @NotNull GenerateResultSink sink = aFileGen.resultSink();
 
 		if (sink != null) {
 			new GarishNamespace__addClass_1(gn, aFileGen.gr(), generateC).action(sink);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/ZoneITE.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/ZoneITE.java
@@ -12,7 +12,8 @@ public interface ZoneITE extends ZoneTargettedMember {
 
 	ZoneVariableStatement getVariableStatement();
 
-	@NotNull String getRealTargetName2(Generate_Code_For_Method.AOG aog, String value);
+	@NotNull
+	String getRealTargetName2(Generate_Code_For_Method.AOG aog, String value);
 
 	Garish_TargetName getRealTargetName3(String aAssignmentValue);
 }

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/c_ast1/C_HeaderString.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/c_ast1/C_HeaderString.java
@@ -1,17 +1,12 @@
 package tripleo.elijah.stages.gen_c.c_ast1;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
+import java.util.function.*;
 
-import tripleo.elijah.comp.Finally_;
-import tripleo.elijah.comp.Compilation;
-import tripleo.elijah.comp.Compilation0;
-import tripleo.elijah.stages.gen_fn.EvaClass;
-import tripleo.elijah.stages.gen_fn.EvaContainerNC;
-import tripleo.elijah.stages.gen_fn.EvaNamespace;
-import tripleo.elijah.stages.logging.ElLog;
+import org.jetbrains.annotations.*;
 
-import java.util.function.Supplier;
+import tripleo.elijah.comp.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.logging.*;
 
 public class C_HeaderString {
 	public static @NotNull C_HeaderString forClass(final EvaClass aEvaClass,
@@ -19,7 +14,8 @@ public class C_HeaderString {
 			final @NotNull String args_string, final @NotNull ElLog LOG) {
 		final String class_name0 = classNameSupplier.get();
 
-		@NotNull Compilation c = (@NotNull Compilation) aEvaClass.getElement().getContext().module().getCompilation();
+		@NotNull
+		Compilation c = (@NotNull Compilation) aEvaClass.getElement().getContext().module().getCompilation();
 		if (c.reports().outputOn(Finally_.Outs.Out_999022)) {
 			LOG.info("234 class_name >> " + class_name0);
 		}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/internal/DefaultDeducedBaseEvaFunction.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_c/internal/DefaultDeducedBaseEvaFunction.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.stages.gen_c.internal;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.stages.deduce.nextgen.*;
@@ -15,15 +16,16 @@ public class DefaultDeducedBaseEvaFunction implements DeducedBaseEvaFunction {
 		carrier = aEvaFunction;
 	}
 
-	//public void addDependentFunction(@NotNull final FunctionInvocation aFunction) {
+	// public void addDependentFunction(@NotNull final FunctionInvocation aFunction)
+	// {
 	//	carrier.addDependentFunction(aFunction);
 	//}
 	//
-	//public void addDependentType(@NotNull final GenType aType) {
+	// public void addDependentType(@NotNull final GenType aType) {
 	//	carrier.addDependentType(aType);
 	//}
 	//
-	//public @NotNull List<FunctionInvocation> dependentFunctions() {
+	// public @NotNull List<FunctionInvocation> dependentFunctions() {
 	//	return carrier.dependentFunctions();
 	//}
 	//
@@ -31,7 +33,7 @@ public class DefaultDeducedBaseEvaFunction implements DeducedBaseEvaFunction {
 	//	return carrier.dependentFunctionSubject();
 	//}
 	//
-	//public @NotNull List<GenType> dependentTypes() {
+	// public @NotNull List<GenType> dependentTypes() {
 	//	return carrier.dependentTypes();
 	//}
 	//
@@ -39,11 +41,12 @@ public class DefaultDeducedBaseEvaFunction implements DeducedBaseEvaFunction {
 	//	return carrier.dependentTypesSubject();
 	//}
 	//
-	//public void noteDependencies(final @NotNull Dependency d) {
+	// public void noteDependencies(final @NotNull Dependency d) {
 	//	carrier.noteDependencies(d);
 	//}
 	//
-	//public @NotNull DT_Resolvabley _getIdentIAResolvable(final @NotNull IdentIA aIdentIA) {
+	// public @NotNull DT_Resolvabley _getIdentIAResolvable(final @NotNull IdentIA
+	// aIdentIA) {
 	//	return carrier._getIdentIAResolvable(aIdentIA);
 	//}
 	//
@@ -68,12 +71,13 @@ public class DefaultDeducedBaseEvaFunction implements DeducedBaseEvaFunction {
 	//}
 	//
 	//@Override
-	//public @NotNull Label addLabel() {
+	// public @NotNull Label addLabel() {
 	//	return carrier.addLabel();
 	//}
 	//
 	//@Override
-	//public @NotNull Label addLabel(final String base_name, final boolean append_int) {
+	// public @NotNull Label addLabel(final String base_name, final boolean
+	// append_int) {
 	//	return carrier.addLabel(base_name, append_int);
 	//}
 	//
@@ -82,7 +86,8 @@ public class DefaultDeducedBaseEvaFunction implements DeducedBaseEvaFunction {
 	//	return carrier.addVariableTableEntry(name, vtt, type, el);
 	//}
 	//
-	//public @NotNull DR_Type buildDrTypeFromNonGenericTypeName(final TypeName aNonGenericTypeName) {
+	// public @NotNull DR_Type buildDrTypeFromNonGenericTypeName(final TypeName
+	// aNonGenericTypeName) {
 	//	return carrier.buildDrTypeFromNonGenericTypeName(aNonGenericTypeName);
 	//}
 	//
@@ -101,7 +106,9 @@ public class DefaultDeducedBaseEvaFunction implements DeducedBaseEvaFunction {
 	//}
 	//
 	//@Override
-	//public @NotNull InstructionArgument get_assignment_path(final @NotNull IExpression expression, final @NotNull GenerateFunctions generateFunctions, final @NotNull Context context) {
+	// public @NotNull InstructionArgument get_assignment_path(final @NotNull
+	// IExpression expression, final @NotNull GenerateFunctions generateFunctions,
+	// final @NotNull Context context) {
 	//	return carrier.get_assignment_path(expression, generateFunctions, context);
 	//}
 
@@ -122,7 +129,7 @@ public class DefaultDeducedBaseEvaFunction implements DeducedBaseEvaFunction {
 	}
 
 	//@Override
-	//public @NotNull ConstantTableEntry getConstTableEntry(final int index) {
+	// public @NotNull ConstantTableEntry getConstTableEntry(final int index) {
 	//	return carrier.getConstTableEntry(index);
 	//}
 	//
@@ -132,12 +139,12 @@ public class DefaultDeducedBaseEvaFunction implements DeducedBaseEvaFunction {
 	//}
 	//
 	//@Override
-	//public @NotNull Dependency getDependency() {
+	// public @NotNull Dependency getDependency() {
 	//	return carrier.getDependency();
 	//}
 	//
 	//@Override
-	//public @NotNull String getFunctionName() {
+	// public @NotNull String getFunctionName() {
 	//	return carrier.getFunctionName();
 	//}
 	//
@@ -159,17 +166,18 @@ public class DefaultDeducedBaseEvaFunction implements DeducedBaseEvaFunction {
 	}
 
 	//@Override
-	//public @NotNull String getIdentIAPathNormal(final @NotNull IdentIA ia2) {
+	// public @NotNull String getIdentIAPathNormal(final @NotNull IdentIA ia2) {
 	//	return carrier.getIdentIAPathNormal(ia2);
 	//}
 	//
 	//@Override
-	//public @NotNull IdentTableEntry getIdentTableEntry(final int index) {
+	// public @NotNull IdentTableEntry getIdentTableEntry(final int index) {
 	//	return carrier.getIdentTableEntry(index);
 	//}
 	//
 	//@Override
-	//public @Nullable IdentTableEntry getIdentTableEntryFor(final @NotNull IExpression expression) {
+	// public @Nullable IdentTableEntry getIdentTableEntryFor(final @NotNull
+	// IExpression expression) {
 	//	return carrier.getIdentTableEntryFor(expression);
 	//}
 	//
@@ -188,12 +196,12 @@ public class DefaultDeducedBaseEvaFunction implements DeducedBaseEvaFunction {
 	}
 
 	//@Override
-	//public @NotNull ProcTableEntry getProcTableEntry(final int index) {
+	// public @NotNull ProcTableEntry getProcTableEntry(final int index) {
 	//	return carrier.getProcTableEntry(index);
 	//}
 	//
 	//@Override
-	//public @NotNull TypeTableEntry getTypeTableEntry(final int index) {
+	// public @NotNull TypeTableEntry getTypeTableEntry(final int index) {
 	//	return carrier.getTypeTableEntry(index);
 	//}
 
@@ -202,32 +210,36 @@ public class DefaultDeducedBaseEvaFunction implements DeducedBaseEvaFunction {
 	}
 
 	//@Override
-	//public @NotNull VariableTableEntry getVarTableEntry(final int index) {
+	// public @NotNull VariableTableEntry getVarTableEntry(final int index) {
 	//	return carrier.getVarTableEntry(index);
 	//}
 	//
 	//@Override
-	//public @NotNull List<Instruction> instructions() {
+	// public @NotNull List<Instruction> instructions() {
 	//	return carrier.instructions();
 	//}
 	//
 	//@Override
-	//public @NotNull List<Label> labels() {
+	// public @NotNull List<Label> labels() {
 	//	return carrier.labels();
 	//}
 	//
 	//@Override
-	//public @NotNull TypeTableEntry newTypeTableEntry(final TypeTableEntry.@NotNull Type type1, final OS_Type type) {
+	// public @NotNull TypeTableEntry newTypeTableEntry(final
+	// TypeTableEntry.@NotNull Type type1, final OS_Type type) {
 	//	return carrier.newTypeTableEntry(type1, type);
 	//}
 	//
 	//@Override
-	//public @NotNull TypeTableEntry newTypeTableEntry(final TypeTableEntry.@NotNull Type type1, final OS_Type type, final IExpression expression) {
+	// public @NotNull TypeTableEntry newTypeTableEntry(final
+	// TypeTableEntry.@NotNull Type type1, final OS_Type type, final IExpression
+	// expression) {
 	//	return carrier.newTypeTableEntry(type1, type, expression);
 	//}
 	//
 	//@Override
-	//public @NotNull TypeTableEntry newTypeTableEntry(final TypeTableEntry.@NotNull Type type1,
+	// public @NotNull TypeTableEntry newTypeTableEntry(final
+	// TypeTableEntry.@NotNull Type type1,
 	//                                        final OS_Type type,
 	//                                        final IExpression expression,
 	//                                        final TableEntryIV aTableEntryIV) {
@@ -235,7 +247,8 @@ public class DefaultDeducedBaseEvaFunction implements DeducedBaseEvaFunction {
 	//}
 	//
 	//@Override
-	//public @NotNull TypeTableEntry newTypeTableEntry(final TypeTableEntry.@NotNull Type type1,
+	// public @NotNull TypeTableEntry newTypeTableEntry(final
+	// TypeTableEntry.@NotNull Type type1,
 	//                                                 final OS_Type type,
 	//                                                 final TableEntryIV aTableEntryIV) {
 	//	return carrier.newTypeTableEntry(type1, type, aTableEntryIV);
@@ -247,12 +260,12 @@ public class DefaultDeducedBaseEvaFunction implements DeducedBaseEvaFunction {
 	//}
 	//
 	//@Override
-	//public void onGenClass(final @NotNull OnGenClass aOnGenClass) {
+	// public void onGenClass(final @NotNull OnGenClass aOnGenClass) {
 	//	carrier.onGenClass(aOnGenClass);
 	//}
 	//
 	//@Override
-	//public void place(final @NotNull Label label) {
+	// public void place(final @NotNull Label label) {
 	//	carrier.place(label);
 	//}
 
@@ -277,12 +290,12 @@ public class DefaultDeducedBaseEvaFunction implements DeducedBaseEvaFunction {
 	}
 
 	//@Override
-	//public void resolveTypeDeferred(final @NotNull GenType aType) {
+	// public void resolveTypeDeferred(final @NotNull GenType aType) {
 	//	carrier.resolveTypeDeferred(aType);
 	//}
 	//
 	//@Override
-	//public void setClass(@NotNull final EvaNode aNode) {
+	// public void setClass(@NotNull final EvaNode aNode) {
 	//	carrier.setClass(aNode);
 	//}
 	//
@@ -315,7 +328,7 @@ public class DefaultDeducedBaseEvaFunction implements DeducedBaseEvaFunction {
 	}
 
 	//@Override
-	//public @NotNull FunctionDef getFD() {
+	// public @NotNull FunctionDef getFD() {
 	//	return carrier.getFD();
 	//}
 	//

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/BaseEvaFunction.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/BaseEvaFunction.java
@@ -8,7 +8,13 @@
  */
 package tripleo.elijah.stages.gen_fn;
 
+import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
+
+import java.util.*;
+import java.util.function.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
@@ -22,17 +28,12 @@ import tripleo.elijah.util.*;
 import tripleo.elijah.world.impl.*;
 import tripleo.util.range.Range;
 
-import java.util.*;
-import java.util.function.*;
-
-import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
-
 /**
  * Created 9/10/20 2:57 PM
  */
 public abstract class BaseEvaFunction
 		extends AbstractDependencyTracker
-		implements EvaNode, DeduceTypes2.ExpectationBase, IDependencyReferent, IEvaFunctionBase {
+		implements EvaNode, ExpectationBase, IDependencyReferent, IEvaFunctionBase {
 	private final    Eventual<EvaClass>             _p_assignEvaClass = new Eventual<>();
 	private final    Eventual<GenType>              _p_assignGenType  = new Eventual<>();
 	private final    Dependency                     dependency        = new Dependency(this);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/BaseEvaFunction.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/BaseEvaFunction.java
@@ -38,18 +38,18 @@ public abstract class BaseEvaFunction
 	private final    Eventual<GenType>              _p_assignGenType  = new Eventual<>();
 	private final    Dependency                     dependency        = new Dependency(this);
 	private final    List<Label>                    labelList        = new ArrayList<>();
-	public @NotNull  List<DR_Item>                  drs               = new ArrayList<>();
+	public @NotNull List<DR_Item> drs = new ArrayList<>();
 	public           DefaultLivingFunction          _living;
-	public @NotNull  List<ConstantTableEntry>       cte_list         = new ArrayList<>();
+	public @NotNull List<ConstantTableEntry> cte_list = new ArrayList<>();
 	public           boolean                        deducedAlready;
-	public @NotNull  List<Integer>                  deferred_calls   = new ArrayList<>();
+	public @NotNull List<Integer> deferred_calls = new ArrayList<>();
 	public           FunctionInvocation             fi;
-	public @NotNull  List<IdentTableEntry>          idte_list        = new ArrayList<>();
-	public @NotNull  List<Instruction>              instructionsList = new ArrayList<>();
-	public @NotNull  List<ProcTableEntry>           prte_list        = new ArrayList<>();
-	public @NotNull  List<TypeTableEntry>           tte_list         = new ArrayList<>();
-	public @NotNull  List<VariableTableEntry>       vte_list         = new ArrayList<>();
-	private @NotNull Map<OS_Element, DeduceElement> elements         = new HashMap<>();
+	public @NotNull List<IdentTableEntry> idte_list = new ArrayList<>();
+	public @NotNull List<Instruction> instructionsList = new ArrayList<>();
+	public @NotNull List<ProcTableEntry> prte_list = new ArrayList<>();
+	public @NotNull List<TypeTableEntry> tte_list = new ArrayList<>();
+	public @NotNull List<VariableTableEntry> vte_list = new ArrayList<>();
+	private @NotNull Map<OS_Element, DeduceElement> elements = new HashMap<>();
 	private          int                            _nextTemp         = 0;
 	private          __Reactive                     _reactive;
 	private          EvaNode                        genClass;
@@ -225,8 +225,8 @@ public abstract class BaseEvaFunction
 
 	@Override
 	public @NotNull InstructionArgument get_assignment_path(final @NotNull IExpression expression,
-															final @NotNull GenerateFunctions generateFunctions,
-															final @NotNull Context context) {
+			final @NotNull GenerateFunctions generateFunctions,
+			final @NotNull Context context) {
 		switch (expression.getKind()) {
 		case DOT_EXP -> {
 			final DotExpression       de        = (DotExpression) expression;
@@ -561,9 +561,9 @@ public abstract class BaseEvaFunction
 	}
 
 	private @NotNull InstructionArgument get_assignment_path(@NotNull final InstructionArgument prev,
-															 @NotNull final IExpression expression,
-															 @NotNull final GenerateFunctions generateFunctions,
-															 @NotNull final Context context) {
+			@NotNull final IExpression expression,
+			@NotNull final GenerateFunctions generateFunctions,
+			@NotNull final Context context) {
 		switch (expression.getKind()) {
 		case DOT_EXP: {
 			final DotExpression       de        = (DotExpression) expression;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/EvaClass.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/EvaClass.java
@@ -8,7 +8,11 @@
  */
 package tripleo.elijah.stages.gen_fn;
 
+import java.util.*;
+import java.util.function.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.g.*;
 import tripleo.elijah.lang.i.*;
@@ -21,9 +25,6 @@ import tripleo.elijah.stages.garish.*;
 import tripleo.elijah.stages.gen_generic.*;
 import tripleo.elijah.util.*;
 import tripleo.elijah.world.i.*;
-
-import java.util.*;
-import java.util.function.*;
 
 /**
  * Created 10/29/20 4:26 AM
@@ -105,7 +106,8 @@ public class EvaClass extends EvaContainerNC implements GEvaClass {
 							OS_BuiltinType resolved = (OS_BuiltinType) potentialTypes.get(1).getResolved();
 
 							try {
-								@NotNull final GenType rt = ResolveType.resolve_type(resolvedClass1.getContext().module(),
+								@NotNull
+								final GenType rt = ResolveType.resolve_type(resolvedClass1.getContext().module(),
 																					 resolved, resolvedClass1.getContext(), aDeduceTypes2._LOG(), aDeduceTypes2);
 								int y = 2;
 
@@ -118,7 +120,8 @@ public class EvaClass extends EvaContainerNC implements GEvaClass {
 							OS_BuiltinType resolved = (OS_BuiltinType) potentialTypes.get(0).getResolved();
 
 							try {
-								@NotNull final GenType rt = aDeduceTypes2.resolve_type(resolved, resolvedClass2.getContext());
+								@NotNull
+								final GenType rt = aDeduceTypes2.resolve_type(resolved, resolvedClass2.getContext());
 								int y = 2;
 
 								potentialTypes = Helpers.List_of(rt);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/EvaFunction.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/EvaFunction.java
@@ -8,11 +8,12 @@
  */
 package tripleo.elijah.stages.gen_fn;
 
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.stages.deduce.nextgen.*;
-
-import java.util.*;
 
 /**
  * Created 6/27/21 9:40 AM
@@ -67,9 +68,9 @@ public class EvaFunction extends BaseEvaFunction {
 		if (fd == null) {
 			return "<EvaFunction {{unattached}}>";
 		} else {
-			final @NotNull Collection<FormalArgListItem> args   = fd.getArgs();
+			final @NotNull Collection<FormalArgListItem> args = fd.getArgs();
 			final @Nullable OS_Element                    parent = fd.getParent();
-			final @NotNull String                        name   = fd.name();
+			final @NotNull String name = fd.name();
 
 			//noinspection SpellCheckingInspection
 			String pparent;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/EvaNamespace.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/EvaNamespace.java
@@ -8,21 +8,19 @@
  */
 package tripleo.elijah.stages.gen_fn;
 
+import java.util.function.*;
+
+import org.jetbrains.annotations.*;
+
 import lombok.*;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.UnintendedUseException;
-import tripleo.elijah.g.GEvaNamespace;
+import tripleo.elijah.*;
+import tripleo.elijah.g.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
-import tripleo.elijah.nextgen.reactive.DefaultReactive;
-import tripleo.elijah.nextgen.reactive.Reactive;
-import tripleo.elijah.stages.gen_generic.CodeGenerator;
-import tripleo.elijah.stages.gen_generic.GenerateResultEnv;
-import tripleo.elijah.stages.gen_generic.ICodeRegistrar;
+import tripleo.elijah.nextgen.reactive.*;
+import tripleo.elijah.stages.gen_generic.*;
 import tripleo.elijah.util.*;
-import tripleo.elijah.world.impl.DefaultLivingNamespace;
-
-import java.util.function.Consumer;
+import tripleo.elijah.world.impl.*;
 
 /**
  * Created 12/22/20 5:39 PM
@@ -106,7 +104,7 @@ public class EvaNamespace extends EvaContainerNC implements GNCoded, GEvaNamespa
 	}
 
 //	@Override
-//	public @NotNull Maybe<VarTableEntry> getVariable(String aVarName) {
+// public @NotNull Maybe<VarTableEntry> getVariable(String aVarName) {
 //		for (VarTableEntry varTableEntry : varTable) {
 //			if (varTableEntry.nameToken.getText().equals(aVarName))
 //				return new Maybe<>(varTableEntry, null);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/GenType.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/GenType.java
@@ -84,7 +84,7 @@ public interface GenType {
 						final @Nullable OS_Element el2 = lrl2.chooseBest(null);
 
 						// TODO test next 4 lines are copies of above
-						if (el2 instanceof final @NotNull ClassStatement classStatement2) {
+							if (el2 instanceof final @NotNull ClassStatement classStatement2) {
 							gt.setResolved(classStatement2.getOS_Type());
 						} else
 							throw new NotImplementedException();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/GenType.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/GenType.java
@@ -1,20 +1,17 @@
 package tripleo.elijah.stages.gen_fn;
 
-import org.jdeferred2.DoneCallback;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import tripleo.elijah.comp.i.ErrSink;
+import java.util.function.*;
+
+import org.jdeferred2.*;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.comp.i.*;
 import tripleo.elijah.contexts.*;
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.util.Mode;
 import tripleo.elijah.stages.deduce.*;
-import tripleo.elijah.stages.deduce.nextgen.DR_Type;
-import tripleo.elijah.stages.logging.ElLog;
-import tripleo.elijah.util.NotImplementedException;
-import tripleo.elijah.util.Operation2;
-
-import java.util.function.Supplier;
+import tripleo.elijah.stages.deduce.nextgen.*;
+import tripleo.elijah.stages.logging.*;
+import tripleo.elijah.util.*;
 
 public interface GenType {
 	/**
@@ -65,7 +62,7 @@ public interface GenType {
 			final LookupResultList lrl = tn.getContext().lookup(tn.getName());
 			final @Nullable OS_Element el = lrl.chooseBest(null);
 
-			DeduceTypes2.ProcessElement.processElement(el, new DeduceTypes2.IElementProcessor() {
+			ProcessElement.processElement(el, new IElementProcessor() {
 				private void __hasElement__typeNameElement(
 						final @NotNull OS_TypeNameElement typeNameElement) {
 					assert aGenericPart != null;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/GenerateFunctions.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/GenerateFunctions.java
@@ -7,14 +7,21 @@
  */
 package tripleo.elijah.stages.gen_fn;
 
-import com.google.common.collect.*;
+import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
+import static tripleo.elijah.util.Helpers.*;
+
+import java.util.*;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jdeferred2.*;
 import org.jetbrains.annotations.*;
+
+import com.google.common.collect.*;
+
 import tripleo.elijah.comp.*;
 import tripleo.elijah.comp.notation.*;
 import tripleo.elijah.entrypoints.*;
-import tripleo.elijah.g.GGenerateFunctions;
+import tripleo.elijah.g.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.lang.types.*;
@@ -22,18 +29,13 @@ import tripleo.elijah.lang2.*;
 import tripleo.elijah.nextgen.reactive.*;
 import tripleo.elijah.pre_world.*;
 import tripleo.elijah.stages.deduce.*;
-import tripleo.elijah.stages.gen_fn_c.GenFnC;
+import tripleo.elijah.stages.gen_fn_c.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.stages.inter.*;
 import tripleo.elijah.stages.logging.*;
 import tripleo.elijah.util.*;
 import tripleo.elijah.work.*;
 import tripleo.util.range.Range;
-
-import java.util.*;
-
-import static tripleo.elijah.stages.deduce.DeduceTypes2.*;
-import static tripleo.elijah.util.Helpers.*;
 
 /**
  * Created 9/10/20 2:28 PM
@@ -43,7 +45,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 
 	final                  OS_Module     module;
 	final                  GeneratePhase phase;
-	private final @NotNull ElLog         LOG;
+	private final @NotNull ElLog LOG;
 	private final          GenFnC        bc;
 	//private final IPipelineAccess pa;
 
@@ -58,7 +60,8 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 		bc.addLog(LOG);
 	}
 
-	//public GenerateFunctions(final OS_Module aModule, @NotNull PipelineLogic aPipelineLogic,
+	// public GenerateFunctions(final OS_Module aModule, @NotNull PipelineLogic
+	// aPipelineLogic,
 	//		final IPipelineAccess pa0) {
 	//	pa = pa0;
 	//	phase = aPipelineLogic.generatePhase;
@@ -105,7 +108,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 	private int addConstantTableEntry2(final String name,
 									   final IExpression initialValue,
 									   final OS_Type type,
-									   final @NotNull BaseEvaFunction gf) {
+			final @NotNull BaseEvaFunction gf) {
 		final @NotNull TypeTableEntry tte = gf.newTypeTableEntry(TypeTableEntry.Type.TRANSIENT, type, initialValue);
 		final @NotNull ConstantTableEntry cte = new ConstantTableEntry(gf.cte_list.size(), name, initialValue, tte);
 
@@ -139,7 +142,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 
 	private int addTempTableEntry(final OS_Type type,
 								  final @Nullable IdentExpression name,
-								  final @NotNull  BaseEvaFunction gf,
+			final @NotNull BaseEvaFunction gf,
 								  final @Nullable OS_Element el) {
 		final @org.jetbrains.annotations.Nullable String theName;
 		final int num;
@@ -339,7 +342,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 	private void generate_item_assignment(final StatementWrapper aStatementWrapper, @NotNull final IExpression x,
 			@NotNull final BaseEvaFunction gf, final @NotNull Context cctx) {
 //		LOG.err(String.format("801 %s %s", x.getLeft(), ((BasicBinaryExpressionImpl) x).getRight()));
-		final @NotNull BasicBinaryExpression bbe = (BasicBinaryExpression) x;
+final @NotNull BasicBinaryExpression bbe = (BasicBinaryExpression) x;
 		final IExpression right1 = bbe.getRight();
 		final @NotNull Generate_item_assignment gia = new Generate_item_assignment();
 		switch (right1.getKind()) {
@@ -460,7 +463,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 
 	public @NotNull EvaConstructor generateConstructor(@NotNull ConstructorDef aConstructorDef,
 													   ClassStatement parent, // TODO Namespace constructors
-													   @NotNull FunctionInvocation aFunctionInvocation) {
+			@NotNull FunctionInvocation aFunctionInvocation) {
 		final @NotNull EvaConstructor gf = new EvaConstructor(aConstructorDef);
 		gf.setFunctionInvocation(aFunctionInvocation);
 		if (parent instanceof ClassStatement) {
@@ -521,8 +524,8 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 
 	public void generateFromEntryPoints(final @NotNull GN_PL_Run2.GenerateFunctionsRequest rq) {
 		final @NotNull List<EntryPoint> epl = rq.mod().entryPoints();
-		final @NotNull IClassGenerator dcg  = rq.classGenerator();
-		final @NotNull ModuleThing      mt  = null;//rq.mt();
+		final @NotNull IClassGenerator dcg = rq.classGenerator();
+		final @NotNull ModuleThing mt = null;// rq.mt();
 
 		if (epl.isEmpty()) {
 			return;
@@ -556,7 +559,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 	EvaFunction generateFunction(@NotNull final FunctionDef fd, final OS_Element parent,
 			@NotNull FunctionInvocation aFunctionInvocation) {
 //		LOG.err("601.1 fn "+fd.name() + " " + parent);
-		final @NotNull EvaFunction gf = new EvaFunction(fd);
+final @NotNull EvaFunction gf = new EvaFunction(fd);
 		if (parent instanceof ClassStatement)
 			gf.addVariableTableEntry("self", VariableTableType.SELF, gf.newTypeTableEntry(TypeTableEntry.Type.SPECIFIED,
 																						  ((ClassStatement) parent).getOS_Type(), IdentExpressionImpl.forString("self")), null);
@@ -645,7 +648,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 				throw new NotImplementedException();
 			} else if (item instanceof FunctionDef) {
 				// throw new NotImplementedException();
-//				@NotNull EvaFunction f = generateFunction((FunctionDef) item, namespace1);
+				// @NotNull EvaFunction f = generateFunction((FunctionDef) item, namespace1);
 //				gn.addFunction((FunctionDef) item, f);
 			} else if (item instanceof DefFunctionDef) {
 				throw new NotImplementedException();
@@ -676,9 +679,10 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 	// region add-table-entries
 	//
 
-	@NotNull List<TypeTableEntry> get_args_types(final @org.jetbrains.annotations.Nullable ExpressionList args,
-	                                    final @NotNull BaseEvaFunction gf,
-	                                    final @NotNull Context aContext) {
+	@NotNull
+	List<TypeTableEntry> get_args_types(final @org.jetbrains.annotations.Nullable ExpressionList args,
+			final @NotNull BaseEvaFunction gf,
+			final @NotNull Context aContext) {
 		final @NotNull List<TypeTableEntry> R = new ArrayList<TypeTableEntry>();
 		if (args != null) {
 			for (final @NotNull IExpression arg : args) {
@@ -696,8 +700,8 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 	}
 
 	private static TypeTableEntry craftTypeForIdentExpression(final @NotNull BaseEvaFunction gf,
-	                                                          final @NotNull Context aContext,
-	                                                          final @NotNull IExpression arg,
+			final @NotNull Context aContext,
+			final @NotNull IExpression arg,
 	                                                          final IdentExpression identExpression) {
 		final @org.jetbrains.annotations.Nullable InstructionArgument x = gf.vte_lookup(identExpression.getText());
 		final TypeTableEntry                                          tte;
@@ -806,8 +810,8 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 	}
 
 	private @NotNull InstructionArgument simplify_dot_expression(final @NotNull DotExpression dotExpression,
-																 final @NotNull BaseEvaFunction gf,
-																 final @NotNull Context cctx) {
+			final @NotNull BaseEvaFunction gf,
+			final @NotNull Context cctx) {
 		@NotNull
 		InstructionArgument x = gf.get_assignment_path(dotExpression, this, cctx);
 		LOG.info("1117 " + x);
@@ -991,7 +995,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 				final @NotNull IdentExpression expr_kind_name = Helpers0
 						.string_to_ident(SpecialFunctions.of(expressionKind));
 //					TypeTableEntry tte = gf.newTypeTableEntry(TypeTableEntry.Type.TRANSIENT, null, expr_kind_name);
-				final @NotNull TypeTableEntry tte_left = gf.newTypeTableEntry(TypeTableEntry.Type.TRANSIENT, null,
+final @NotNull TypeTableEntry tte_left = gf.newTypeTableEntry(TypeTableEntry.Type.TRANSIENT, null,
 						left);
 				final @NotNull TypeTableEntry tte_right = gf.newTypeTableEntry(TypeTableEntry.Type.TRANSIENT, null,
 						right);
@@ -1030,7 +1034,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 				final @NotNull IdentExpression expr_kind_name = Helpers0
 						.string_to_ident(SpecialFunctions.of(expressionKind));
 //					TypeTableEntry tte = gf.newTypeTableEntry(TypeTableEntry.Type.TRANSIENT, null, expr_kind_name);
-				final @NotNull TypeTableEntry tte_left = gf.newTypeTableEntry(TypeTableEntry.Type.TRANSIENT, null,
+final @NotNull TypeTableEntry tte_left = gf.newTypeTableEntry(TypeTableEntry.Type.TRANSIENT, null,
 						left);
 				final int pte = addProcTableEntry(expr_kind_name, null, List_of(tte_left), gf);
 				final int tmp = addTempTableEntry(new OS_BuiltinType(BuiltInTypes.Boolean), gf);
@@ -1177,21 +1181,21 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 
 	static class GIA__procedure_call__one {
 
-		private final @NotNull Instruction               expression_to_call;
+		private final @NotNull Instruction expression_to_call;
 		private final          IExpression               left;
 		private final @NotNull List<InstructionArgument> list_of_fn_call;
 		private final          InstructionArgument       lookup;
-		private final @NotNull TypeTableEntry            tte;
+		private final @NotNull TypeTableEntry tte;
 		private final          Context                   cctx;
 		private final @NotNull Generate_item_assignment generate_item_assign;
 		private final BaseEvaFunction gf;
 		private final GenerateFunctions gfs;
 
 		public GIA__procedure_call__one(final @NotNull BasicBinaryExpression bbe,
-										final @NotNull BaseEvaFunction gf,
-										final @NotNull Context cctx,
-										final @NotNull Generate_item_assignment generate_item_assignment,
-										final @NotNull ProcedureCallExpression pce,
+				final @NotNull BaseEvaFunction gf,
+				final @NotNull Context cctx,
+				final @NotNull Generate_item_assignment generate_item_assignment,
+				final @NotNull ProcedureCallExpression pce,
 										final GenerateFunctions gfs1) {
 			this.gf = gf;
 			this.cctx = cctx;
@@ -1267,7 +1271,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 		}
 
 		int addVariableTableEntry(final String aText, final @NotNull TypeTableEntry aTte,
-								  final @NotNull BaseEvaFunction aGf, final IdentExpression aIdentExpression) {
+				final @NotNull BaseEvaFunction aGf, final IdentExpression aIdentExpression) {
 			return gfs.addVariableTableEntry(aText, aTte, aGf, aIdentExpression);
 		}
 
@@ -1315,20 +1319,21 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 //				throw new NotImplementedException();
 			} else if (item instanceof ClassStatement) {
 //				final ClassStatement classStatement = (ClassStatement) item;
-//				@NotNull EvaClass gen_c = generateClass(classStatement);
+// @NotNull EvaClass gen_c = generateClass(classStatement);
 //				gc.addClass(classStatement, gen_c);
 			} else if (item instanceof ConstructorDef) {
 //				final ConstructorDef constructorDef = (ConstructorDef) item;
-//				@NotNull GeneratedConstructor f = generateConstructor(constructorDef, klass, null); // TODO remove this null
+// @NotNull GeneratedConstructor f = generateConstructor(constructorDef, klass,
+// null); // TODO remove this null
 //				gc.addConstructor(constructorDef, f);
 			} else if (item instanceof DestructorDef) {
 				throw new NotImplementedException();
 			} else if (item instanceof DefFunctionDef) {
-//				@NotNull EvaFunction f = generateFunction((DefFunctionDef) item, klass);
+				// @NotNull EvaFunction f = generateFunction((DefFunctionDef) item, klass);
 //				gc.addFunction((DefFunctionDef) item, f);
 			} else if (item instanceof FunctionDef) {
 				// README handled in WlGenerateFunction
-//				@NotNull EvaFunction f = generateFunction((FunctionDef) item, klass);
+				// @NotNull EvaFunction f = generateFunction((FunctionDef) item, klass);
 //				gc.addFunction((FunctionDef) item, f);
 			} else if (item instanceof NamespaceStatement) {
 				throw new NotImplementedException();
@@ -1344,7 +1349,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 				//
 				an = (AccessNotation) item;
 //				gc.addAccessNotation(an);
-			} else if (item instanceof @NotNull final PropertyStatement ps) {
+} else if (item instanceof @NotNull final PropertyStatement ps) {
 				LOG.err("307 Skipping property for now");
 			} else {
 				LOG.err("305 " + item.getClass().getName());
@@ -1369,7 +1374,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 		}
 
 		public void generate_construct_statement(@NotNull ConstructStatement aConstructStatement,
-												 @NotNull BaseEvaFunction gf, @NotNull Context cctx) {
+				@NotNull BaseEvaFunction gf, @NotNull Context cctx) {
 			final IExpression left = aConstructStatement.getExpr(); // TODO need type of this expr, not expr!!
 			final ExpressionList args = aConstructStatement.getArgs();
 			//
@@ -1470,7 +1475,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 			add_i(gf, InstructionName.AGNK, List_of(new IntegerIA(loop_iterator, gf), ia1), cctx);
 //			else
 //				add_i(gf, InstructionName.AGN, List_of(new IntegerIA(loop_iterator), ia1), cctx);
-			final @NotNull Label label_top = gf.addLabel("top", true);
+final @NotNull Label label_top = gf.addLabel("top", true);
 			gf.place(label_top);
 			final @NotNull Label label_bottom = gf.addLabel("bottom" + label_top.getIndex(), false);
 			add_i(gf, InstructionName.JE, List_of(new IntegerIA(loop_iterator, gf),
@@ -1489,7 +1494,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 		}
 
 		private void generate_loop_FROM_TO_TYPE(@NotNull Loop loop, @NotNull BaseEvaFunction gf,
-												@NotNull Context cctx) {
+				@NotNull Context cctx) {
 			final IdentExpression iterNameToken = loop.getIterNameToken();
 			final String iterName = iterNameToken.getText();
 			final int iter_temp = addTempTableEntry(null, iterNameToken, gf, iterNameToken); // TODO deduce later
@@ -1525,7 +1530,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 				final InstructionArgument i = simplify_expression(expr, gf, cctx);
 //				LOG.info("710 " + i);
 
-				@NotNull
+@NotNull
 				Label label_next = gf.addLabel();
 				final @NotNull Label label_end = gf.addLabel();
 
@@ -1590,7 +1595,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 		}
 
 		private void generate_statement_wrapper(final StatementWrapper aStatementWrapper, @NotNull IExpression x,
-												@NotNull ExpressionKind expressionKind, @NotNull BaseEvaFunction gf, @NotNull Context cctx) {
+				@NotNull ExpressionKind expressionKind, @NotNull BaseEvaFunction gf, @NotNull Context cctx) {
 //			LOG.err("106-1 "+x.getKind()+" "+x);
 			if (x.is_simple()) {
 //				int i = addTempTableEntry(x.getType(), gf);
@@ -1655,7 +1660,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 		}
 
 		private void generate_variable_sequence(@NotNull VariableSequence item, @NotNull BaseEvaFunction gf,
-												@NotNull Context cctx) {
+				@NotNull Context cctx) {
 			for (final @NotNull VariableStatement vs : item.items()) {
 				int state = 0;
 //				LOG.info("8004 " + vs);
@@ -1734,7 +1739,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 	class Generate_item_assignment {
 
 		public void dot(@NotNull BaseEvaFunction gf, @NotNull DotExpression left, @NotNull IExpression right,
-						@NotNull Context cctx) {
+				@NotNull Context cctx) {
 			final InstructionArgument simple_left = simplify_expression(left, gf, cctx);
 			final InstructionArgument simple_right = simplify_expression(right, gf, cctx);
 
@@ -1801,7 +1806,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 		}
 
 		public void mathematical(@NotNull BaseEvaFunction gf, @NotNull IExpression left, ExpressionKind kind,
-								 @NotNull IExpression right1, @NotNull Context cctx) {
+				@NotNull IExpression right1, @NotNull Context cctx) {
 			// TODO doesn't use kind
 			final @NotNull TypeTableEntry tte = gf.newTypeTableEntry(TypeTableEntry.Type.SPECIFIED, null, right1);
 
@@ -1823,7 +1828,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 		}
 
 		public void neg(@NotNull BaseEvaFunction gf, @NotNull IExpression left, ExpressionKind aKind,
-						@NotNull IExpression right1, @NotNull Context cctx) {
+				@NotNull IExpression right1, @NotNull Context cctx) {
 			// TODO doesn't use kind
 			final @NotNull TypeTableEntry tte = gf.newTypeTableEntry(TypeTableEntry.Type.SPECIFIED, null, right1);
 
@@ -1845,7 +1850,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 		}
 
 		public void numeric(@NotNull BaseEvaFunction gf, @NotNull IExpression left, @NotNull NumericExpression ne,
-							@NotNull Context cctx) {
+				@NotNull Context cctx) {
 			@NotNull
 			final InstructionArgument agn_path = gf.get_assignment_path(left, GenerateFunctions.this, cctx);
 			final int cte = addConstantTableEntry("", ne, null, gf);
@@ -1855,7 +1860,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 		}
 
 		public void procedure_call(final StatementWrapper aStatementWrapper, @NotNull BaseEvaFunction gf,
-								   @NotNull BasicBinaryExpression bbe, @NotNull ProcedureCallExpression pce, @NotNull Context cctx) {
+				@NotNull BasicBinaryExpression bbe, @NotNull ProcedureCallExpression pce, @NotNull Context cctx) {
 			/*
 			 * final IExpression left = bbe.getLeft();
 			 *
@@ -1902,7 +1907,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 		}
 
 		public void string_literal(@NotNull BaseEvaFunction gf, @NotNull IExpression left, StringExpression right,
-								   @NotNull Context aContext) {
+				@NotNull Context aContext) {
 			@NotNull
 			final InstructionArgument agn_path = gf.get_assignment_path(left, GenerateFunctions.this, aContext);
 			final int cte = addConstantTableEntry("", right,
@@ -1925,7 +1930,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 		}
 
 		public void generate_construct_statement(@NotNull ConstructStatement aConstructStatement,
-												 @NotNull BaseEvaFunction gf, @NotNull Context cctx) {
+				@NotNull BaseEvaFunction gf, @NotNull Context cctx) {
 			final IExpression left = aConstructStatement.getExpr(); // TODO need type of this expr, not expr!!
 			final ExpressionList args = aConstructStatement.getArgs();
 			//
@@ -2026,7 +2031,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 			add_i(gf, InstructionName.AGNK, List_of(new IntegerIA(loop_iterator, gf), ia1), cctx);
 //			else
 //				add_i(gf, InstructionName.AGN, List_of(new IntegerIA(loop_iterator), ia1), cctx);
-			final @NotNull Label label_top = gf.addLabel("top", true);
+final @NotNull Label label_top = gf.addLabel("top", true);
 			gf.place(label_top);
 			final @NotNull Label label_bottom = gf.addLabel("bottom" + label_top.getIndex(), false);
 			add_i(gf, InstructionName.JE, List_of(new IntegerIA(loop_iterator, gf),
@@ -2080,7 +2085,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 				final InstructionArgument i = simplify_expression(expr, gf, cctx);
 //				LOG.info("710 " + i);
 
-				@NotNull
+@NotNull
 				Label label_next = gf.addLabel();
 				final @NotNull Label label_end = gf.addLabel();
 
@@ -2145,7 +2150,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 		}
 
 		private void generate_statement_wrapper(final StatementWrapper aStatementWrapper, @NotNull IExpression x,
-												@NotNull ExpressionKind expressionKind, @NotNull BaseEvaFunction gf, @NotNull Context cctx) {
+				@NotNull ExpressionKind expressionKind, @NotNull BaseEvaFunction gf, @NotNull Context cctx) {
 //			LOG.err("106-1 "+x.getKind()+" "+x);
 			if (x.is_simple()) {
 //				int i = addTempTableEntry(x.getType(), gf);
@@ -2210,7 +2215,7 @@ public class GenerateFunctions implements ReactiveDimension, GGenerateFunctions 
 		}
 
 		private void generate_variable_sequence(@NotNull VariableSequence item, @NotNull EvaFunction gf,
-												@NotNull Context cctx) {
+				@NotNull Context cctx) {
 			for (final @NotNull VariableStatement vs : item.items()) {
 				int state = 0;
 //				LOG.info("8004 " + vs);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/GeneratePhase.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/GeneratePhase.java
@@ -8,41 +8,41 @@
  */
 package tripleo.elijah.stages.gen_fn;
 
-import lombok.Getter;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import tripleo.elijah.comp.PipelineLogic;
-import tripleo.elijah.comp.i.extra.IPipelineAccess;
-import tripleo.elijah.comp.i.ModuleListener;
-import tripleo.elijah.g.*;
-import tripleo.elijah.lang.i.OS_Module;
-import tripleo.elijah.nextgen.reactive.ReactiveDimension;
-import tripleo.elijah.stages.gen_fn_c.GenFnC;
-import tripleo.elijah.stages.gen_generic.ICodeRegistrar;
-import tripleo.elijah.stages.logging.*;
-import tripleo.elijah.stages.logging.ElLog.Verbosity;
-import tripleo.elijah.util.NotImplementedException;
-import tripleo.elijah.work.*;
+import java.util.*;
 
-import java.util.HashMap;
-import java.util.Map;
+import org.jetbrains.annotations.*;
+
+import lombok.*;
+import tripleo.elijah.comp.*;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.comp.i.extra.*;
+import tripleo.elijah.g.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.nextgen.reactive.*;
+import tripleo.elijah.stages.gen_fn_c.*;
+import tripleo.elijah.stages.gen_generic.*;
+import tripleo.elijah.stages.logging.*;
+import tripleo.elijah.stages.logging.ElLog.*;
+import tripleo.elijah.util.*;
+import tripleo.elijah.work.*;
 
 /**
  * Created 5/16/21 12:35 AM
  */
 public class GeneratePhase implements ReactiveDimension, ModuleListener {
-	private @NotNull final PipelineLogic   pipelineLogic;
+	private @NotNull final PipelineLogic pipelineLogic;
 	private @NotNull final IPipelineAccess pa;
 
 	@Getter
 	private final @NotNull ElLog_.Verbosity verbosity;
 	@Getter
-	private final @NotNull WorkManager      wm = new WorkManager__();
+	private final @NotNull WorkManager wm = new WorkManager__();
 	private final @NotNull Map<OS_Module, GenerateFunctions> generateFunctions = new HashMap<OS_Module, GenerateFunctions>();
 	@Getter
 	private @Nullable ICodeRegistrar codeRegistrar;
 
-	public GeneratePhase(ElLog_.Verbosity aVerbosity, final @NotNull IPipelineAccess aPa, PipelineLogic aPipelineLogic) {
+	public GeneratePhase(ElLog_.Verbosity aVerbosity, final @NotNull IPipelineAccess aPa,
+			PipelineLogic aPipelineLogic) {
 		verbosity = aVerbosity;
 		pipelineLogic = aPipelineLogic;
 		pa = aPa;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/IEvaConstructor.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/IEvaConstructor.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.stages.gen_fn;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.nextgen.reactive.*;
@@ -12,7 +13,7 @@ public interface IEvaConstructor extends
 		EvaNode,
 		DependencyTracker,
 		IDependencyReferent,
-		DeduceTypes2.ExpectationBase {
+		ExpectationBase {
 
 	Eventual<DeduceElement3_Constructor> de3_Promise();
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/IEvaConstructor.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/IEvaConstructor.java
@@ -18,7 +18,8 @@ public interface IEvaConstructor extends
 	Eventual<DeduceElement3_Constructor> de3_Promise();
 
 	@Override
-	@NotNull FunctionDef getFD();
+	@NotNull
+	FunctionDef getFD();
 
 	@Override
 	@Nullable VariableTableEntry getSelf();
@@ -27,7 +28,8 @@ public interface IEvaConstructor extends
 	String identityString();
 
 	@Override
-	@NotNull OS_Module module();
+	@NotNull
+	OS_Module module();
 
 	String name();
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/IEvaFunctionBase.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/IEvaFunctionBase.java
@@ -1,6 +1,9 @@
 package tripleo.elijah.stages.gen_fn;
 
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.nextgen.reactive.*;
@@ -8,8 +11,6 @@ import tripleo.elijah.stages.deduce.*;
 import tripleo.elijah.stages.gen_generic.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.util.range.Range;
-
-import java.util.*;
 
 public interface IEvaFunctionBase extends EvaNode {
 	int add(InstructionName aName, List<InstructionArgument> args_, Context ctx);
@@ -20,9 +21,11 @@ public interface IEvaFunctionBase extends EvaNode {
 
 	int addIdentTableEntry(IdentExpression ident, Context context);
 
-	@NotNull Label addLabel();
+	@NotNull
+	Label addLabel();
 
-	@NotNull Label addLabel(String base_name, boolean append_int);
+	@NotNull
+	Label addLabel(String base_name, boolean append_int);
 
 	int addVariableTableEntry(String name, VariableTableType vtt, TypeTableEntry type, OS_Element el);
 
@@ -30,12 +33,15 @@ public interface IEvaFunctionBase extends EvaNode {
 
 	@Nullable Label findLabel(int index);
 
-	@NotNull InstructionArgument get_assignment_path(@NotNull IExpression expression, @NotNull GenerateFunctions generateFunctions, Context context);
+	@NotNull
+	InstructionArgument get_assignment_path(@NotNull IExpression expression,
+			@NotNull GenerateFunctions generateFunctions, Context context);
 
 	@Deprecated
 	void setCode(int aCode);
 
-	@NotNull ConstantTableEntry getConstTableEntry(int index);
+	@NotNull
+	ConstantTableEntry getConstTableEntry(int index);
 
 	Context getContextFromPC(int pc);
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/IdentTableEntry.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/IdentTableEntry.java
@@ -11,9 +11,13 @@ package tripleo.elijah.stages.gen_fn;
 
 //import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.util.*;
+import java.util.function.*;
+
 import org.jdeferred2.*;
 import org.jdeferred2.impl.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.nextgen.reactive.*;
@@ -24,14 +28,11 @@ import tripleo.elijah.stages.deduce.post_bytecode.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.util.*;
 
-import java.util.*;
-import java.util.function.*;
-
 /**
  * Created 9/12/20 10:27 PM
  */
 public class IdentTableEntry extends BaseTableEntry1
-		implements Constructable, TableEntryIV, DeduceTypes2.ExpectationBase, IDeduceResolvable {
+		implements Constructable, TableEntryIV, ExpectationBase, IDeduceResolvable {
 	private class __StatusListener__ITE_SetResolvedElement implements StatusListener {
 		@Override
 		public void onChange(@NotNull IElementHolder eh, Status newStatus) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/ProcTableEntry.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/ProcTableEntry.java
@@ -8,17 +8,18 @@
  */
 package tripleo.elijah.stages.gen_fn;
 
+import java.util.*;
+
 import org.jdeferred2.*;
 import org.jdeferred2.impl.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.stages.deduce.*;
 import tripleo.elijah.stages.deduce.post_bytecode.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.util.*;
-
-import java.util.*;
 
 /**
  * Created 9/12/20 10:07 PM
@@ -100,7 +101,7 @@ public class ProcTableEntry extends BaseTableEntry implements TableEntryIV {
 		return __dt2;
 	}
 
-	public DeduceTypes2.DeduceTypes2Injector _inj() {
+	public DeduceTypes2Injector _inj() {
 		return _deduceTypes2()._inj();
 	}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/VarTableEntry.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/VarTableEntry.java
@@ -1,15 +1,16 @@
 package tripleo.elijah.stages.gen_fn;
 
+import java.util.*;
+
 import org.jdeferred2.*;
 import org.jdeferred2.impl.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.types.*;
 import tripleo.elijah.stages.deduce.*;
 import tripleo.elijah.stages.deduce.post_bytecode.*;
 import tripleo.elijah.util.*;
-
-import java.util.*;
 
 public class VarTableEntry {
 	public static class ConnectionPair {
@@ -28,15 +29,15 @@ public class VarTableEntry {
 	}
 
 	public final           IExpression                                        initialValue;
-	public final @NotNull  IdentExpression                                    nameToken;
+	public final @NotNull IdentExpression nameToken;
 	public final           VariableStatement                                  vs;
 	private final          DeferredObject<OS_Type, Void, Void>                _p_resolve_varType               = new DeferredObject<>();
-	private final @NotNull OS_Element                                         parent;
+	private final @NotNull OS_Element parent;
 	private final          RegisterClassInvocation_env                        passthruEnv;
-	public @NotNull        List<ConnectionPair>                               connectionPairs                  = new ArrayList<>();
-	public @NotNull        List<TypeTableEntry>                               potentialTypes                   = new ArrayList<TypeTableEntry>();
+	public @NotNull List<ConnectionPair> connectionPairs = new ArrayList<>();
+	public @NotNull List<TypeTableEntry> potentialTypes = new ArrayList<TypeTableEntry>();
 	public                 TypeName                                           typeName;
-	public @NotNull        DeferredObject<UpdatePotentialTypesCB, Void, Void> _p_updatePotentialTypesCBPromise = new DeferredObject<>();
+	public @NotNull DeferredObject<UpdatePotentialTypesCB, Void, Void> _p_updatePotentialTypesCBPromise = new DeferredObject<>();
 	public                 OS_Type                                            varType;
 
 	UpdatePotentialTypesCB updatePotentialTypesCB;
@@ -46,8 +47,8 @@ public class VarTableEntry {
 	DeduceElement3_VarTableEntry _de3;
 
 	public VarTableEntry(final VariableStatement aVs, final @NotNull IdentExpression aNameToken,
-						 final IExpression aInitialValue, final @NotNull TypeName aTypeName,
-						 final @NotNull OS_Element aElement) {
+			final IExpression aInitialValue, final @NotNull TypeName aTypeName,
+			final @NotNull OS_Element aElement) {
 		vs           = aVs;
 		nameToken    = aNameToken;
 		initialValue = aInitialValue;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/VariableTableEntry.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/VariableTableEntry.java
@@ -8,22 +8,23 @@
  */
 package tripleo.elijah.stages.gen_fn;
 
+import java.util.*;
+
 import org.jdeferred2.*;
 import org.jdeferred2.impl.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.stages.deduce.*;
 import tripleo.elijah.stages.deduce.post_bytecode.*;
 import tripleo.elijah.stages.instructions.*;
 import tripleo.elijah.util.*;
 
-import java.util.*;
-
 /**
  * Created 9/10/20 4:51 PM
  */
 public class VariableTableEntry extends BaseTableEntry1
-		implements Constructable, TableEntryIV, DeduceTypes2.ExpectationBase {
+		implements Constructable, TableEntryIV, ExpectationBase {
 	private final DeferredObject2<GenType, Void, Void> typeDeferred = new DeferredObject2<GenType, Void, Void>();
 	private final VariableTableType vtt;
 	private final int index;
@@ -171,7 +172,7 @@ public class VariableTableEntry extends BaseTableEntry1
 		return name;
 	}
 
-	public @NotNull PostBC_Processor getPostBC_Processor(Context aFd_ctx, DeduceTypes2.DeduceClient1 aDeduceClient1) {
+	public @NotNull PostBC_Processor getPostBC_Processor(Context aFd_ctx, DeduceClient1 aDeduceClient1) {
 		return PostBC_Processor.make_VTE(this, aFd_ctx, aDeduceClient1);
 	}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/WlGenerateCtor.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/WlGenerateCtor.java
@@ -8,8 +8,11 @@
  */
 package tripleo.elijah.stages.gen_fn;
 
+import java.util.*;
+
 import org.jdeferred2.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.stages.deduce.*;
@@ -17,8 +20,6 @@ import tripleo.elijah.stages.deduce.nextgen.*;
 import tripleo.elijah.stages.gen_generic.*;
 import tripleo.elijah.util.*;
 import tripleo.elijah.work.*;
-
-import java.util.*;
 
 /**
  * Created 7/3/21 6:24 AM
@@ -33,7 +34,7 @@ public class WlGenerateCtor implements WorkJob {
 
 	@Contract(pure = true)
 	public WlGenerateCtor(@NotNull GenerateFunctions aGenerateFunctions,
-						  @NotNull FunctionInvocation aFunctionInvocation,
+			@NotNull FunctionInvocation aFunctionInvocation,
 						  @Nullable IdentExpression aConstructorName,
 						  final ICodeRegistrar aCodeRegistrar) {
 		generateFunctions = aGenerateFunctions;
@@ -45,7 +46,7 @@ public class WlGenerateCtor implements WorkJob {
 	public WlGenerateCtor(final OS_Module aModule,
 						  final IdentExpression aNameNode,
 						  final FunctionInvocation aFunctionInvocation,
-						  final @NotNull DeduceCreationContext aCl) {
+			final @NotNull DeduceCreationContext aCl) {
 		this(aCl.getGeneratePhase().getGenerateFunctions(aModule),
 			 aFunctionInvocation,
 			 aNameNode,

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/WlGenerateDefaultCtor.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/WlGenerateDefaultCtor.java
@@ -9,6 +9,7 @@
 package tripleo.elijah.stages.gen_fn;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
@@ -22,7 +23,7 @@ import tripleo.elijah.work.*;
  */
 public class WlGenerateDefaultCtor implements WorkJob {
 	private final          FunctionInvocation    functionInvocation;
-	private final @NotNull GenerateFunctions     generateFunctions;
+	private final @NotNull GenerateFunctions generateFunctions;
 	private final          ICodeRegistrar        codeRegistrar;
 	private                boolean               _isDone = false;
 	private                BaseEvaFunction       Result;
@@ -36,7 +37,7 @@ public class WlGenerateDefaultCtor implements WorkJob {
 
 	public WlGenerateDefaultCtor(final OS_Module module,
 								 final FunctionInvocation aFunctionInvocation,
-								 final @NotNull DeduceCreationContext crcl) {
+			final @NotNull DeduceCreationContext crcl) {
 		this(crcl.getGeneratePhase().getGenerateFunctions(module),
 			 aFunctionInvocation,
 			 crcl,
@@ -87,7 +88,8 @@ public class WlGenerateDefaultCtor implements WorkJob {
 				final OS_Element classStatement = cd.getParent();
 				assert classStatement instanceof ClassStatement;
 
-				final @NotNull EvaConstructor gf = generateFunctions.generateConstructor(cd, (ClassStatement) classStatement, functionInvocation);
+				final @NotNull EvaConstructor gf = generateFunctions.generateConstructor(cd,
+						(ClassStatement) classStatement, functionInvocation);
 				// lgf.add(gf);
 
 				final ClassInvocation ci = functionInvocation.getClassInvocation();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/WlGenerateFunction.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_fn/WlGenerateFunction.java
@@ -8,19 +8,15 @@
  */
 package tripleo.elijah.stages.gen_fn;
 
+import org.jetbrains.annotations.*;
+
 import lombok.*;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import tripleo.elijah.lang.i.FunctionDef;
-import tripleo.elijah.lang.i.NamespaceStatement;
-import tripleo.elijah.lang.i.OS_Element;
-import tripleo.elijah.lang.i.OS_Module;
+import tripleo.elijah.lang.i.*;
 import tripleo.elijah.stages.deduce.*;
-import tripleo.elijah.stages.deduce.nextgen.DeduceCreationContext;
-import tripleo.elijah.stages.gen_generic.ICodeRegistrar;
-import tripleo.elijah.util.SimplePrintLoggerToRemoveSoon;
-import tripleo.elijah.work.WorkJob;
-import tripleo.elijah.work.WorkManager;
+import tripleo.elijah.stages.deduce.nextgen.*;
+import tripleo.elijah.stages.gen_generic.*;
+import tripleo.elijah.util.*;
+import tripleo.elijah.work.*;
 
 /**
  * Created 5/16/21 12:46 AM
@@ -44,7 +40,7 @@ public class WlGenerateFunction implements WorkJob {
 
 	public WlGenerateFunction(final OS_Module aModule,
 							  final FunctionInvocation aFunctionInvocation,
-							  final @NotNull DeduceCreationContext aCl) {
+			final @NotNull DeduceCreationContext aCl) {
 		this(aCl.getGeneratePhase().getGenerateFunctions(aModule),
 			 aFunctionInvocation,
 			 aCl.getDeducePhase().getCodeRegistrar());

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_generic/GenerateFiles_.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_generic/GenerateFiles_.java
@@ -1,26 +1,30 @@
 package tripleo.elijah.stages.gen_generic;
 
-import com.google.common.collect.Collections2;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.stages.gen_fn.EvaClass;
-import tripleo.elijah.stages.gen_fn.EvaFunction;
-import tripleo.elijah.stages.gen_fn.EvaNode;
-import tripleo.elijah.stages.gen_fn.IEvaConstructor;
+import java.util.*;
 
-import java.util.Collection;
+import org.jetbrains.annotations.*;
+
+import com.google.common.collect.*;
+
+import tripleo.elijah.stages.gen_fn.*;
 
 public enum GenerateFiles_ {
 	;
 
-	@NotNull public static Collection<EvaNode> classes_to_list_of_generated_nodes(@NotNull Collection<EvaClass> aEvaClasses) {
+	@NotNull
+	public static Collection<EvaNode> classes_to_list_of_generated_nodes(@NotNull Collection<EvaClass> aEvaClasses) {
 		return Collections2.transform(aEvaClasses, t -> t);
 	}
 
-	@NotNull public static Collection<EvaNode> constructors_to_list_of_generated_nodes(@NotNull Collection<IEvaConstructor> aEvaConstructors) {
+	@NotNull
+	public static Collection<EvaNode> constructors_to_list_of_generated_nodes(
+			@NotNull Collection<IEvaConstructor> aEvaConstructors) {
 		return Collections2.transform(aEvaConstructors, input -> input);
 	}
 
-	@NotNull public static Collection<EvaNode> functions_to_list_of_generated_nodes(@NotNull Collection<EvaFunction> generatedFunctions) {
+	@NotNull
+	public static Collection<EvaNode> functions_to_list_of_generated_nodes(
+			@NotNull Collection<EvaFunction> generatedFunctions) {
 		return Collections2.transform(generatedFunctions, input -> input);
 	}
 }

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_generic/New_GenerateResultItem.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_generic/New_GenerateResultItem.java
@@ -1,20 +1,21 @@
 package tripleo.elijah.stages.gen_generic;
 
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.ci.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.util.buffer.*;
-
-import java.util.*;
 
 public class New_GenerateResultItem implements GenerateResultItem {
 	private final Old_GenerateResultItem ogri;
 
 	public New_GenerateResultItem(final GenerateResult.@NotNull TY aTy,
-								  final @NotNull Buffer aBuffer,
-								  final @NotNull EvaNode aNode,
-								  final @NotNull LibraryStatementPart aLsp,
-								  final @NotNull Dependency aDependency,
+			final @NotNull Buffer aBuffer,
+			final @NotNull EvaNode aNode,
+			final @NotNull LibraryStatementPart aLsp,
+			final @NotNull Dependency aDependency,
 								  final int aCounter) {
 		ogri = new Old_GenerateResultItem(aTy, aBuffer, aNode, aLsp, aDependency, aCounter);
 	}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_generic/Old_GenerateResultItem.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_generic/Old_GenerateResultItem.java
@@ -7,13 +7,14 @@
  */
 package tripleo.elijah.stages.gen_generic;
 
+import java.util.*;
+import java.util.stream.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.ci.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.util.buffer.*;
-
-import java.util.*;
-import java.util.stream.*;
 
 /**
  * Created 4/27/21 1:12 AM
@@ -30,10 +31,10 @@ public class Old_GenerateResultItem implements GenerateResultItem {
 
 	@Contract(pure = true)
 	public Old_GenerateResultItem(final @NotNull Old_GenerateResult.TY aTy,
-								  final @NotNull Buffer aBuffer,
-								  final @NotNull EvaNode aNode,
-								  final @NotNull LibraryStatementPart aLsp,
-								  final @NotNull Dependency aDependency,
+			final @NotNull Buffer aBuffer,
+			final @NotNull EvaNode aNode,
+			final @NotNull LibraryStatementPart aLsp,
+			final @NotNull Dependency aDependency,
 								  final int aCounter) {
 		ty = aTy;
 		buffer = aBuffer;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_generic/Sub_GenerateResult.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_generic/Sub_GenerateResult.java
@@ -1,16 +1,17 @@
 package tripleo.elijah.stages.gen_generic;
 
+import java.util.*;
+import java.util.function.*;
+
+import org.jetbrains.annotations.*;
+
 import io.reactivex.rxjava3.core.Observer;
 import io.reactivex.rxjava3.subjects.*;
-import org.jetbrains.annotations.*;
 import tripleo.elijah.ci.*;
 import tripleo.elijah.stages.gen_c.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.util.*;
 import tripleo.util.buffer.*;
-
-import java.util.*;
-import java.util.function.*;
 
 public class Sub_GenerateResult implements GenerateResult {
 	final List<Old_GenerateResultItem> _res = new ArrayList<Old_GenerateResultItem>();
@@ -64,8 +65,8 @@ public class Sub_GenerateResult implements GenerateResult {
 	 */
 	@Override
 	public void addConstructor(@NotNull EvaConstructor aEvaConstructor,
-							   @NotNull Buffer aBuffer,
-							   @NotNull TY aTY,
+			@NotNull Buffer aBuffer,
+			@NotNull TY aTY,
 							   LibraryStatementPart aLsp) {
 		addFunction(aEvaConstructor, aBuffer, aTY, aLsp);
 	}

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_generic/pipeline_impl/ProcessedNode1.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/gen_generic/pipeline_impl/ProcessedNode1.java
@@ -1,16 +1,12 @@
 package tripleo.elijah.stages.gen_generic.pipeline_impl;
 
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.lang.i.OS_Module;
-import tripleo.elijah.stages.gen_fn.EvaClass;
-import tripleo.elijah.stages.gen_fn.EvaContainerNC;
-import tripleo.elijah.stages.gen_fn.EvaNode;
-import tripleo.elijah.stages.gen_generic.GenerateFiles;
-import tripleo.elijah.stages.gen_generic.GenerateFiles_;
-import tripleo.elijah.stages.gen_generic.GenerateResult;
-import tripleo.elijah.stages.gen_generic.GenerateResultEnv;
+import java.util.*;
 
-import java.util.Collection;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.stages.gen_generic.*;
 
 public class ProcessedNode1 implements ProcessedNode {
 
@@ -38,7 +34,8 @@ public class ProcessedNode1 implements ProcessedNode {
 	public void processClassMap(final @NotNull GenerateFiles ggc, final @NotNull GenerateResultEnv aFileGen) {
 		final EvaContainerNC nc = (EvaContainerNC) evaNode;
 
-		final @NotNull Collection<EvaNode> gn2 = GenerateFiles_.classes_to_list_of_generated_nodes(nc.classMap.values());
+		final @NotNull Collection<EvaNode> gn2 = GenerateFiles_
+				.classes_to_list_of_generated_nodes(nc.classMap.values());
 		GenerateResult gr4 = ggc.generateCode(gn2, aFileGen);
 		aFileGen.gr().additional(gr4);
 		aFileGen.resultSink().additional(gr4);
@@ -49,7 +46,8 @@ public class ProcessedNode1 implements ProcessedNode {
 		final EvaContainerNC nc = (EvaContainerNC) evaNode;
 
 		if (nc instanceof final @NotNull EvaClass evaClass) {
-			final @NotNull Collection<EvaNode> gn2 = GenerateFiles_.constructors_to_list_of_generated_nodes(evaClass.constructors.values());
+			final @NotNull Collection<EvaNode> gn2 = GenerateFiles_
+					.constructors_to_list_of_generated_nodes(evaClass.constructors.values());
 			GenerateResult gr3 = ggc.generateCode(gn2, aFileGen);
 
 			aFileGen.gr().additional(gr3);
@@ -75,7 +73,8 @@ public class ProcessedNode1 implements ProcessedNode {
 	public void processFunctions(final @NotNull GenerateFiles ggc, final @NotNull GenerateResultEnv aFileGen) {
 		final EvaContainerNC nc = (EvaContainerNC) evaNode;
 
-		final @NotNull Collection<EvaNode> gn1 = GenerateFiles_.functions_to_list_of_generated_nodes(nc.functionMap.values());
+		final @NotNull Collection<EvaNode> gn1 = GenerateFiles_
+				.functions_to_list_of_generated_nodes(nc.functionMap.values());
 		GenerateResult gr2 = ggc.generateCode(gn1, aFileGen);
 		aFileGen.gr().additional(gr2);
 		aFileGen.resultSink().additional(gr2);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/generate/OutputStrategyC.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/generate/OutputStrategyC.java
@@ -8,19 +8,16 @@
  */
 package tripleo.elijah.stages.generate;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import tripleo.elijah.ci.CompilerInstructions;
-import tripleo.elijah.ci.LibraryStatementPart;
+import java.io.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.ci.*;
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.lang.impl.LangGlobals;
+import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.nextgen.outputtree.*;
 import tripleo.elijah.stages.gen_fn.*;
-import tripleo.elijah.stages.gen_generic.GenerateResult;
-import tripleo.elijah.stages.gen_generic.Old_GenerateResult;
-
-import java.io.File;
+import tripleo.elijah.stages.gen_generic.*;
 
 /**
  * Created 1/13/21 5:54 AM
@@ -332,7 +329,7 @@ public class OutputStrategyC {
 	}
 
 	public @NotNull EOT_FileNameProvider nameForFunction1(final @NotNull EvaFunction aGf,
-														  final GenerateResult.@NotNull TY aTy) {
+			final GenerateResult.@NotNull TY aTy) {
 		return new OSC_NFF(nameForFunction(aGf, aTy));
 	}
 
@@ -372,7 +369,7 @@ public class OutputStrategyC {
 	}
 
 	public EOT_FileNameProvider nameForNamespace1(final @NotNull EvaNamespace aX,
-												  final GenerateResult.@NotNull TY aTy) {
+			final GenerateResult.@NotNull TY aTy) {
 		return new OSC_NFN_(aX, aTy);
 	}
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/inter/ModuleThing.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/inter/ModuleThing.java
@@ -1,15 +1,14 @@
 package tripleo.elijah.stages.inter;
 
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.entrypoints.EntryPoint;
-import tripleo.elijah.g.*;
-import tripleo.elijah.lang.i.OS_Module;
-import tripleo.elijah.stages.gen_fn.EvaFunction;
-import tripleo.small.ES_Symbol;
+import java.util.*;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.entrypoints.*;
+import tripleo.elijah.g.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.small.*;
 
 public class ModuleThing implements GModuleThing {
 	public static final class GeneralDescription {
@@ -52,8 +51,8 @@ public class ModuleThing implements GModuleThing {
 
 		}
 
-	private final @NotNull List<EntryPoint> entryPoints;
-	private final @NotNull List<EvaFunction> evaFunctions = new ArrayList<>();
+		private final @NotNull List<EntryPoint> entryPoints;
+		private final @NotNull List<EvaFunction> evaFunctions = new ArrayList<>();
 	private final OS_Module mod;
 
 	private GeneralDescription generalDescription;

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/write_stage/pipeline_impl/AmazingClass.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/write_stage/pipeline_impl/AmazingClass.java
@@ -1,11 +1,12 @@
 package tripleo.elijah.stages.write_stage.pipeline_impl;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.comp.*;
-import tripleo.elijah.comp.i.extra.IPipelineAccess;
+import tripleo.elijah.comp.i.extra.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.nextgen.output.*;
-import tripleo.elijah.stages.garish.GarishClass;
+import tripleo.elijah.stages.garish.*;
 import tripleo.elijah.stages.gen_c.*;
 import tripleo.elijah.stages.gen_fn.*;
 
@@ -16,7 +17,7 @@ class AmazingClass implements Amazing {
 	private final EvaClass                         c;
 
 	public AmazingClass(final @NotNull EvaClass c,
-	                    final @NotNull WPIS_GenerateOutputs.OutputItems aOutputItems,
+			final @NotNull WPIS_GenerateOutputs.OutputItems aOutputItems,
 	                    final IPipelineAccess aPa) {
 		this.c      = c;
 		mod         = c.module();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/write_stage/pipeline_impl/AmazingFunction.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/write_stage/pipeline_impl/AmazingFunction.java
@@ -1,8 +1,14 @@
 package tripleo.elijah.stages.write_stage.pipeline_impl;
 
-import com.google.common.base.*;
+import static tripleo.elijah.util.Helpers.*;
+
+import java.util.*;
+
 import org.jdeferred2.*;
 import org.jetbrains.annotations.*;
+
+import com.google.common.base.*;
+
 import tripleo.elijah.comp.i.extra.*;
 import tripleo.elijah.comp.notation.*;
 import tripleo.elijah.lang.i.*;
@@ -15,10 +21,6 @@ import tripleo.elijah.stages.logging.*;
 import tripleo.elijah.work.*;
 import tripleo.elijah_elevated.comp.backbone.*;
 
-import java.util.*;
-
-import static tripleo.elijah.util.Helpers.*;
-
 class AmazingFunction implements Amazing {
 	private final NG_OutputFunction                of;
 	private final BaseEvaFunction                  f;
@@ -28,9 +30,9 @@ class AmazingFunction implements Amazing {
 	private final IPipelineAccess                  pa;
 
 	public AmazingFunction(final @NotNull BaseEvaFunction aBaseEvaFunction,
-						   final @NotNull WPIS_GenerateOutputs.OutputItems aOutputItems,
-						   final @NotNull GenerateResult aGenerateResult,
-						   final @NotNull IPipelineAccess aPa) {
+			final @NotNull WPIS_GenerateOutputs.OutputItems aOutputItems,
+			final @NotNull GenerateResult aGenerateResult,
+			final @NotNull IPipelineAccess aPa) {
 		// given
 		f      = aBaseEvaFunction;
 		mod    = aBaseEvaFunction.module();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/write_stage/pipeline_impl/WPIS_GenerateOutputs.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/write_stage/pipeline_impl/WPIS_GenerateOutputs.java
@@ -1,11 +1,16 @@
 package tripleo.elijah.stages.write_stage.pipeline_impl;
 
+import java.util.*;
+import java.util.function.*;
+
+import org.jetbrains.annotations.*;
+
 import com.google.common.base.*;
 import com.google.common.collect.*;
-import org.jetbrains.annotations.*;
+
 import tripleo.elijah.comp.*;
 import tripleo.elijah.comp.graph.i.*;
-import tripleo.elijah.comp.nextgen.inputtree.EIT_ModuleInput;
+import tripleo.elijah.comp.nextgen.inputtree.*;
 import tripleo.elijah.comp.nextgen.pn.*;
 import tripleo.elijah.comp.nextgen.pw.*;
 import tripleo.elijah.lang.i.*;
@@ -18,10 +23,7 @@ import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.gen_generic.*;
 import tripleo.elijah.stages.generate.*;
 import tripleo.elijah.util.*;
-import tripleo.elijah_elevated.comp.backbone.CompilationEnclosure;
-
-import java.util.*;
-import java.util.function.*;
+import tripleo.elijah_elevated.comp.backbone.*;
 
 public class WPIS_GenerateOutputs implements WP_Individual_Step, PN_signalCalculateFinishParse {
 
@@ -75,9 +77,9 @@ public class WPIS_GenerateOutputs implements WP_Individual_Step, PN_signalCalcul
 	}
 
 	private void pmPN_signalCalculateFinishParse(final @NotNull GenerateResult result,
-												 final @NotNull List<EvaClass> cs,
-												 final @NotNull List<EvaNamespace> ns,
-												 final @NotNull List<BaseEvaFunction> fs,
+			final @NotNull List<EvaClass> cs,
+			final @NotNull List<EvaNamespace> ns,
+			final @NotNull List<BaseEvaFunction> fs,
 												 final OutputItems itms) {
 		var p = new PM_signalCalculateFinishParse(result, cs, ns, fs, itms);
 		ping(p);
@@ -154,8 +156,8 @@ public class WPIS_GenerateOutputs implements WP_Individual_Step, PN_signalCalcul
 	private static class MyWritable implements Writable {
 		final          Collection<EG_Statement> value;
 		final          EOT_FileNameProvider     filename;
-		final @NotNull List<EG_Statement>       list;
-		final @NotNull EG_SequenceStatement            statement;
+		final @NotNull List<EG_Statement> list;
+		final @NotNull EG_SequenceStatement statement;
 		private final  NG_OutputRequest                outputRequest;
 
 		public MyWritable(final Map.@NotNull Entry<NG_OutputRequest, Collection<EG_Statement>> aEntry) {

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/write_stage/pipeline_impl/WPIS_WriteBuffers.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/write_stage/pipeline_impl/WPIS_WriteBuffers.java
@@ -1,26 +1,25 @@
 package tripleo.elijah.stages.write_stage.pipeline_impl;
 
+import static tripleo.elijah.util.Helpers.*;
+
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+
 import org.jdeferred2.impl.*;
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.*;
 import tripleo.elijah.comp.*;
 import tripleo.elijah.comp.graph.i.*;
-import tripleo.elijah.comp.nextgen.i.CP_Path;
-import tripleo.elijah.comp.nextgen.i.CP_Paths;
+import tripleo.elijah.comp.nextgen.i.*;
 import tripleo.elijah.comp.nextgen.pn.*;
 import tripleo.elijah.nextgen.inputtree.*;
 import tripleo.elijah.nextgen.outputstatement.*;
 import tripleo.elijah.nextgen.outputtree.*;
 import tripleo.elijah.stages.gen_generic.*;
 import tripleo.elijah.util.*;
-
-import java.io.*;
-import java.nio.file.*;
-import java.util.*;
-
-import static tripleo.elijah.util.Helpers.List_of;
-
-import tripleo.elijah_prolific.v.V;
+import tripleo.elijah_prolific.v.*;
 import tripleo.wrap.File;
 
 public class WPIS_WriteBuffers implements WP_Individual_Step, SC_I {
@@ -45,8 +44,8 @@ public class WPIS_WriteBuffers implements WP_Individual_Step, SC_I {
 	}
 	@NotNull
 	private static EOT_OutputFile createOutputFile(final LSPrintStream.LSResult ls,
-												   final @NotNull Compilation c,
-												   final @NotNull CP_Paths paths) {
+			final @NotNull Compilation c,
+			final @NotNull CP_Paths paths) {
 		final CP_Path or    = paths.outputRoot();
 		final File    file1 = or.subFile("buffers.txt").toFile(); // TODO subFile vs child
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/write_stage/pipeline_impl/WP_Flow.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/stages/write_stage/pipeline_impl/WP_Flow.java
@@ -1,24 +1,22 @@
 package tripleo.elijah.stages.write_stage.pipeline_impl;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.comp.WritePipeline;
+import java.util.*;
+
+import org.apache.commons.lang3.tuple.*;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.comp.*;
 import tripleo.elijah.comp.graph.i.*;
 import tripleo.elijah.comp.i.extra.*;
-import tripleo.elijah.util.Ok;
-import tripleo.elijah.util.Operation;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
+import tripleo.elijah.util.*;
 
 public class WP_Flow extends CK_AbstractStepsContext {
 	private final List<WP_Individual_Step> steps = new ArrayList<>();
 	private       WritePipeline            writePipeline;
 	private final OPS                     myOps;
 
-	public WP_Flow(final WritePipeline aWritePipeline, final @NotNull IPipelineAccess aPa, final @NotNull Collection<? extends WP_Individual_Step> s) {
+	public WP_Flow(final WritePipeline aWritePipeline, final @NotNull IPipelineAccess aPa,
+			final @NotNull Collection<? extends WP_Individual_Step> s) {
 		writePipeline = aWritePipeline;
 		steps.addAll(s);
 		myOps = new OPS(writePipeline, this);

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/world/i/LivingClass.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/world/i/LivingClass.java
@@ -1,12 +1,10 @@
 package tripleo.elijah.world.i;
 
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.g.GEvaClass;
-import tripleo.elijah.g.GGarishClass;
-import tripleo.elijah.g.GGenerateResult;
-import tripleo.elijah.g.GGenerateResultSink;
-import tripleo.elijah.lang.i.ClassStatement;
-import tripleo.elijah.stages.gen_generic.GenerateFiles;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.g.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.stages.gen_generic.*;
 
 public interface LivingClass extends LivingNode {
 	GEvaClass evaNode();
@@ -19,5 +17,6 @@ public interface LivingClass extends LivingNode {
 
 	void setCode(int aCode);
 
-	void generateWith(GGenerateResultSink aResultSink, @NotNull GGarishClass aGarishClass, GGenerateResult aGr, GenerateFiles aGenerateFiles);
+	void generateWith(GGenerateResultSink aResultSink, @NotNull GGarishClass aGarishClass, GGenerateResult aGr,
+			GenerateFiles aGenerateFiles);
 }

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/world/i/LivingRepo.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/world/i/LivingRepo.java
@@ -1,25 +1,17 @@
 package tripleo.elijah.world.i;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import tripleo.elijah.comp.Compilation0;
-import tripleo.elijah.g.GLivingRepo;
-import tripleo.elijah.lang.i.ClassStatement;
-import tripleo.elijah.lang.i.OS_Module;
-import tripleo.elijah.lang.i.OS_Package;
-import tripleo.elijah.lang.i.Qualident;
-import tripleo.elijah.lang.impl.BaseFunctionDef;
-import tripleo.elijah.stages.gen_fn.BaseEvaFunction;
-import tripleo.elijah.stages.gen_fn.EvaClass;
-import tripleo.elijah.stages.gen_fn.EvaNamespace;
-import tripleo.elijah.util.CompletableProcess;
-import tripleo.elijah.world.impl.DefaultLivingClass;
-import tripleo.elijah.world.impl.DefaultLivingFunction;
-import tripleo.elijah.world.impl.DefaultLivingNamespace;
-
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 import java.util.function.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.comp.*;
+import tripleo.elijah.g.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.lang.impl.*;
+import tripleo.elijah.stages.gen_fn.*;
+import tripleo.elijah.util.*;
+import tripleo.elijah.world.impl.*;
 
 public interface LivingRepo extends GLivingRepo {
 	Collection<WorldModule> getMods__();
@@ -56,7 +48,8 @@ public interface LivingRepo extends GLivingRepo {
 
 	List<ClassStatement> findClass(String main);
 
-	@Nullable WorldModule findModule(final @NotNull OS_Module mod);
+	@Nullable
+	WorldModule findModule(final @NotNull OS_Module mod);
 
 	LivingClass getClass(EvaClass aEvaClass);
 

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/world/impl/DefaultLivingClass.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/world/impl/DefaultLivingClass.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.world.impl;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.g.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.stages.garish.*;
@@ -12,7 +13,7 @@ import tripleo.elijah.world.i.*;
 
 public class DefaultLivingClass implements LivingClass {
 	private final          ClassStatement _element;
-	private final @NotNull EvaClass       _gc;
+	private final @NotNull EvaClass _gc;
 	private @Nullable      GarishClass    _garish;
 
 	private int     _code;
@@ -57,7 +58,7 @@ public class DefaultLivingClass implements LivingClass {
 	@Override
 	@Contract(mutates = "this")
 	public void generateWith(final GGenerateResultSink   aResultSink,
-							 final @NotNull GGarishClass aGarishClass,
+			final @NotNull GGarishClass aGarishClass,
 							 final GGenerateResult       aGenerateResult,
 							 final GenerateFiles        aGenerateFiles) {
 		if (_generatedFlag) { return; }

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah/world/impl/DefaultLivingRepo.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah/world/impl/DefaultLivingRepo.java
@@ -1,7 +1,13 @@
 package tripleo.elijah.world.impl;
 
-import com.google.common.collect.*;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
 import org.jetbrains.annotations.*;
+
+import com.google.common.collect.*;
+
 import tripleo.elijah.comp.*;
 import tripleo.elijah.entrypoints.*;
 import tripleo.elijah.lang.i.*;
@@ -9,10 +15,6 @@ import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.util.*;
 import tripleo.elijah.world.i.*;
-
-import java.util.*;
-import java.util.function.*;
-import java.util.stream.*;
 
 public class DefaultLivingRepo implements LivingRepo {
 	private final @NotNull ObservableCompletableProcess<WorldModule> wmo = new ObservableCompletableProcess<>();
@@ -129,8 +131,8 @@ public class DefaultLivingRepo implements LivingRepo {
 
 	//@Override
 	public void addModule(final @NotNull OS_Module mod,
-	                      final @NotNull String aFilename,
-	                      final @NotNull Compilation aC) {
+			final @NotNull String aFilename,
+			final @NotNull Compilation aC) {
 //		tripleo.elijah.util.SimplePrintLoggerToRemoveSoon.println_out_4("LivingRepo::addModule >> " + aFilename);
 
 //		var t = aC.getCompilerInputListener();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah_elevated/comp/backbone/CompilationEnclosure.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah_elevated/comp/backbone/CompilationEnclosure.java
@@ -1,8 +1,12 @@
 package tripleo.elijah_elevated.comp.backbone;
 
-import io.reactivex.rxjava3.annotations.*;
+import java.util.*;
+import java.util.function.*;
+
 import org.jetbrains.annotations.*;
-import tripleo.elijah.Eventual;
+
+import io.reactivex.rxjava3.annotations.*;
+import tripleo.elijah.*;
 import tripleo.elijah.comp.*;
 import tripleo.elijah.comp.graph.i.*;
 import tripleo.elijah.comp.i.*;
@@ -10,28 +14,25 @@ import tripleo.elijah.comp.i.extra.*;
 import tripleo.elijah.comp.impl.*;
 import tripleo.elijah.comp.internal.*;
 import tripleo.elijah.comp.nextgen.i.*;
-import tripleo.elijah.g.GCompilationEnclosure;
-import tripleo.elijah.g.GPipelineAccess;
+import tripleo.elijah.g.*;
 import tripleo.elijah.lang.i.*;
-import tripleo.elijah.nextgen.inputtree.EIT_ModuleList;
+import tripleo.elijah.nextgen.inputtree.*;
 import tripleo.elijah.nextgen.reactive.*;
 import tripleo.elijah.pre_world.*;
 import tripleo.elijah.stages.gen_fn.*;
 import tripleo.elijah.stages.generate.*;
 import tripleo.elijah.stages.inter.*;
-import tripleo.elijah.stages.logging.ElLog;
+import tripleo.elijah.stages.logging.*;
 import tripleo.elijah.stages.write_stage.pipeline_impl.*;
 import tripleo.elijah.world.i.*;
-
-import java.util.*;
-import java.util.function.*;
 
 public interface CompilationEnclosure extends Asseverable, GCompilationEnclosure {
 	void addEntryPoint(@NotNull Mirror_EntryPoint aMirrorEntryPoint, IClassGenerator dcg);
 
 	void addModuleListener(ModuleListener aModuleListener);
 
-	@NotNull ModuleThing addModuleThing(OS_Module aMod);
+	@NotNull
+	ModuleThing addModuleThing(OS_Module aMod);
 
 	void addReactive(@NotNull Reactivable r);
 
@@ -41,7 +42,8 @@ public interface CompilationEnclosure extends Asseverable, GCompilationEnclosure
 
 	void AssertOutFile(@NotNull NG_OutputRequest aOutputRequest);
 
-	@NotNull Eventual<AccessBus> getAccessBusPromise();
+	@NotNull
+	Eventual<AccessBus> getAccessBusPromise();
 
 	@Contract(pure = true)
 	CB_Output getCB_Output();
@@ -50,7 +52,8 @@ public interface CompilationEnclosure extends Asseverable, GCompilationEnclosure
 	Compilation getCompilation();
 
 	@Contract(pure = true)
-	@NotNull ICompilationAccess getCompilationAccess();
+	@NotNull
+	ICompilationAccess getCompilationAccess();
 
 	void setCompilationAccess(@NotNull ICompilationAccess aca);
 
@@ -81,7 +84,8 @@ public interface CompilationEnclosure extends Asseverable, GCompilationEnclosure
 	IPipelineAccess getPipelineAccess();
 
 	@Contract(pure = true)
-	@NotNull Eventual<IPipelineAccess> getPipelineAccessPromise();
+	@NotNull
+	Eventual<IPipelineAccess> getPipelineAccessPromise();
 
 	@Contract(pure = true)
 	PipelineLogic getPipelineLogic();

--- a/elevated-potential.core.impl/src/main/java/tripleo/elijah_prolific/v/V.java
+++ b/elevated-potential.core.impl/src/main/java/tripleo/elijah_prolific/v/V.java
@@ -1,16 +1,17 @@
 package tripleo.elijah_prolific.v;
 
-import org.jetbrains.annotations.*;
-import tripleo.elijah.comp.*;
-import tripleo.elijah.nextgen.outputstatement.*;
-import tripleo.elijah.nextgen.outputtree.*;
-import tripleo.elijah.stages.gen_generic.*;
+import static tripleo.elijah.util.Helpers.*;
 
 import java.io.*;
 import java.util.*;
 import java.util.stream.*;
 
-import static tripleo.elijah.util.Helpers.*;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.comp.*;
+import tripleo.elijah.nextgen.outputstatement.*;
+import tripleo.elijah.nextgen.outputtree.*;
+import tripleo.elijah.stages.gen_generic.*;
 
 public class V {
 	private static final List<String> logs = new ArrayList<>();
@@ -49,7 +50,7 @@ public class V {
 		final String x = "{{V.exit}}";
 		addLog(x);
 
-		final @NotNull EOT_OutputTree ot            = aCompilation.getOutputTree();
+		final @NotNull EOT_OutputTree ot = aCompilation.getOutputTree();
 		final EG_Naming               naming        = new EG_Naming("placeholder-naming");
 		final List<EG_Statement>      statementList = logs.stream().map(EG_SingleStatement::new).collect(Collectors.toList());
 		final EG_Statement            statement     = new EG_SequenceStatement(naming, statementList);

--- a/elevated-potential.core.impl/src/test/java/tripleo/elijah/stages/gen_fn/TestGenFunction.java
+++ b/elevated-potential.core.impl/src/test/java/tripleo/elijah/stages/gen_fn/TestGenFunction.java
@@ -58,7 +58,7 @@
 //public class TestGenFunction {
 //
 //	@Contract(value = " -> new", pure = true)
-//	public static CompilationFlow.@NotNull CompilationFlowMember parseElijah() {
+// public static CompilationFlow.@NotNull CompilationFlowMember parseElijah() {
 //		return new CompilationFlow.CompilationFlowMember() {
 //			@Override
 //			public void doIt(final Compilation cc, final CompilationFlow flow) {
@@ -171,7 +171,7 @@
 //		final List<EvaNode> lgc = flow.generateAllTopLevelClasses(m);
 //		state.lgc = lgc;
 //
-//		@NotNull List<EvaNode> lgf = flow.extractFunctions(lgc);
+// @NotNull List<EvaNode> lgf = flow.extractFunctions(lgc);
 //
 //		//here
 //		flow.printInstructions(lgf);
@@ -196,7 +196,8 @@
 //		private Compilation  comp;
 //		private GeneratePhase generatePhase;
 //
-//		private void generateResults(final @NotNull List<EvaNode> lgc, final @NotNull generateCode result) {
+// private void generateResults(final @NotNull List<EvaNode> lgc, final @NotNull
+/// generateCode result) {
 //			GenerateResult gr = new Old_GenerateResult();
 //
 //			final DefaultGenerateResultSink grs = result.grs();
@@ -214,7 +215,7 @@
 //		@NotNull
 //		private generateCode getGenerateCode(final OS_Module m,
 //											 final WorkManager wm,
-//											 final @NotNull List<EvaNode> lgf,
+// final @NotNull List<EvaNode> lgf,
 //											 final EvaPipeline aGp) {
 //			final ErrSink                   errSink   = comp.getErrSink();
 //			final ElLog.Verbosity           verbosity = Compilation.gitlabCIVerbosity();
@@ -228,7 +229,7 @@
 //			return result;
 //		}
 //
-//		private void printFunctionTables(final @NotNull List<EvaNode> lgf) {
+// private void printFunctionTables(final @NotNull List<EvaNode> lgf) {
 //			for (final EvaNode gn : lgf) {
 //				if (gn instanceof final EvaFunction gf) {
 //					tripleo.elijah.util.Stupidity.println_out_2("----------------------------------------------------------");
@@ -242,14 +243,14 @@
 //
 //		private void deduceModule(final OS_Module m,
 //								  final List<EvaNode> lgc,
-//								  final @NotNull List<EvaNode> lgf) {
+// final @NotNull List<EvaNode> lgf) {
 //			final DeducePhase  dp  = comp.getCompilationEnclosure().getPipelineLogic().dp;
 //			final DeduceTypes2 dt2 = dp.deduceModule(m, lgc, Compilation.gitlabCIVerbosity());
 //			dt2.deduceFunctions(lgf);
 //			dp.finish();
 //		}
 //
-//		private void printInstructions(final @NotNull List<EvaNode> lgf) {
+// private void printInstructions(final @NotNull List<EvaNode> lgf) {
 //			for (final EvaNode gn : lgf) {
 //				if (gn instanceof final EvaFunction gf) {
 //					for (final Instruction instruction : gf.instructions()) {
@@ -259,7 +260,8 @@
 //			}
 //		}
 //
-//		private @NotNull List<EvaNode> extractFunctions(final @NotNull List<EvaNode> lgc) {
+// private @NotNull List<EvaNode> extractFunctions(final @NotNull List<EvaNode>
+/// lgc) {
 //			final List<EvaNode> lgf = new ArrayList<>();
 //			for (EvaNode generatedNode : lgc) {
 //				if (generatedNode instanceof EvaClass)

--- a/elevated-potential.core.impl/src/test/java/tripleo/elijah/test_help/Boilerplate.java
+++ b/elevated-potential.core.impl/src/test/java/tripleo/elijah/test_help/Boilerplate.java
@@ -1,31 +1,26 @@
 package tripleo.elijah.test_help;
 
-import org.jetbrains.annotations.NotNull;
+import static tripleo.elijah.util.Helpers.*;
+
+import java.util.*;
+
+import org.jetbrains.annotations.*;
+
 import tripleo.elijah.comp.*;
-import tripleo.elijah_elevated.comp.backbone.CompilationEnclosure;
-import tripleo.elijah.comp.i.ICompilationAccess;
-import tripleo.elijah.comp.i.extra.IPipelineAccess;
-import tripleo.elijah.comp.i.ProcessRecord;
+import tripleo.elijah.comp.i.*;
+import tripleo.elijah.comp.i.extra.*;
 import tripleo.elijah.comp.internal.*;
-import tripleo.elijah.comp.notation.GM_GenerateModule;
-import tripleo.elijah.comp.notation.GM_GenerateModuleRequest;
-import tripleo.elijah.comp.notation.GN_GenerateNodesIntoSink;
-import tripleo.elijah.comp.notation.GN_GenerateNodesIntoSinkEnv;
-import tripleo.elijah.lang.i.OS_Module;
-import tripleo.elijah.lang.impl.OS_ModuleImpl;
-import tripleo.elijah.nextgen.inputtree.EIT_ModuleList;
-import tripleo.elijah.stages.deduce.DeducePhase;
+import tripleo.elijah.comp.notation.*;
+import tripleo.elijah.lang.i.*;
+import tripleo.elijah.lang.impl.*;
+import tripleo.elijah.nextgen.inputtree.*;
+import tripleo.elijah.stages.deduce.*;
 import tripleo.elijah.stages.gen_generic.*;
-import tripleo.elijah.stages.gen_generic.pipeline_impl.DefaultGenerateResultSink;
-import tripleo.elijah.stages.gen_generic.pipeline_impl.GenerateResultSink;
-import tripleo.elijah.stages.gen_generic.pipeline_impl.ProcessedNode;
+import tripleo.elijah.stages.gen_generic.pipeline_impl.*;
 import tripleo.elijah.stages.logging.*;
 import tripleo.elijah.work.*;
-import tripleo.elijah.world.impl.DefaultWorldModule;
-
-import java.util.List;
-
-import static tripleo.elijah.util.Helpers.List_of;
+import tripleo.elijah.world.impl.*;
+import tripleo.elijah_elevated.comp.backbone.*;
 
 // TODO replace with CompilationFlow
 public class Boilerplate {
@@ -55,7 +50,8 @@ public class Boilerplate {
 		CR_State crState;
 		crState = new CR_State(aca);
 		cr = new CompilationRunner(aca, crState,
-				() -> new DefaultCompilationBus((@NotNull CompilationEnclosure) aca.getCompilation().getCompilationEnclosure()));
+				() -> new DefaultCompilationBus(
+						(@NotNull CompilationEnclosure) aca.getCompilation().getCompilationEnclosure()));
 		crState.setRunner(cr);
 
 		final CompilationEnclosure compilationEnclosure = (CompilationEnclosure) comp.getCompilationEnclosure();

--- a/elevated-potential.core.impl/src/test/java/tripleo/elijah/test_help/XX.java
+++ b/elevated-potential.core.impl/src/test/java/tripleo/elijah/test_help/XX.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.test_help;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang.impl.*;
 import tripleo.elijah.lang.types.*;
@@ -16,7 +17,7 @@ public enum XX {
 	}
 
 	public static @NotNull TypeTableEntry regularTypeName_specifyTableEntry(final IdentExpression aIdentExpression,
-	                                                                        final @NotNull BaseEvaFunction aBaseGeneratedFunction, final @NotNull String aTypeName) {
+			final @NotNull BaseEvaFunction aBaseGeneratedFunction, final @NotNull String aTypeName) {
 		final RegularTypeName typeName = RegularTypeNameImpl.makeWithStringTypeName(aTypeName);
 		final OS_Type type = new OS_UserType(typeName);
 		final TypeTableEntry tte = aBaseGeneratedFunction.newTypeTableEntry(TypeTableEntry.Type.SPECIFIED, type,

--- a/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/CaseChoiceNode.java
+++ b/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/CaseChoiceNode.java
@@ -23,7 +23,7 @@ public class CaseChoiceNode {
 	public @Nullable        ScopeNode              right;
 	private @Nullable       String                 _defaultName;
 
-	public CaseChoiceNode(final @NotNull NumericExpression expr1, final CaseHdrNode header) {
+	public CaseChoiceNode(final @NotNull  NumericExpression expr1, final CaseHdrNode header) {
 		// TODO Auto-generated constructor stub
 		left         = new ExpressionNode(expr1);
 		this.header  = header;

--- a/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/CaseHdrNode.java
+++ b/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/CaseHdrNode.java
@@ -32,7 +32,7 @@ public class CaseHdrNode implements Node {
 		this.expr = expr;
 	}
 
-	public @NotNull String simpleGenText() {
+	public @NotNull  String simpleGenText() {
 		if (expr instanceof VariableReferenceNode3) {
 			return expr.genText();
 		}

--- a/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/ExpressionNode.java
+++ b/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/ExpressionNode.java
@@ -146,7 +146,7 @@ public class ExpressionNode implements IExpressionNode {
 		return "vai"; // TODO hardcoded
 	}
 
-	static @NotNull String getStringPCE(final @NotNull ProcedureCallExpression expr) {
+	static @NotNull  String getStringPCE(final @NotNull  ProcedureCallExpression expr) {
 		final int code = 1000; // TODO hardcoded
 		return Helpers.getFunctionName(code, expr.getLeft().toString(), expr.exprList());
 	}
@@ -157,7 +157,7 @@ public class ExpressionNode implements IExpressionNode {
 	}
 
 	@Override
-	public @NotNull String genType() {
+	public @NotNull  String genType() {
 		return "u64";  // TODO harcoded
 	}
 

--- a/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/ExpressionNodeBuilder.java
+++ b/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/ExpressionNodeBuilder.java
@@ -39,7 +39,7 @@ public class ExpressionNodeBuilder {
 
 	@NotNull
 	@Contract("_, _, _, _ -> new")
-	public static IExpression binex(final TypeRef rt, final VariableReferenceImpl left, final @NotNull ExpressionOperators middle, final IExpression right) {
+	public static IExpression binex(final TypeRef rt, final VariableReferenceImpl left, final @NotNull  ExpressionOperators middle, final IExpression right) {
 		// TODO Auto-generated method stub
 		final ExpressionKind middle1 = Helpers.ExpressionOperatorToExpressionType(middle);
 		return new BasicBinaryExpressionImpl(left, middle1, right);
@@ -47,7 +47,7 @@ public class ExpressionNodeBuilder {
 
 	@NotNull
 	@Contract("_, _, _, _ -> new")
-	public static IExpression binex(final TypeRef rt, final VariableReferenceImpl left, final @NotNull ExpressionOperators middle, final @NotNull TmpSSACtxNode right) { // todo wrong again
+	public static IExpression binex(final TypeRef rt, final VariableReferenceImpl left, final @NotNull  ExpressionOperators middle, final @NotNull  TmpSSACtxNode right) { // todo wrong again
 		// TODO Auto-generated method stub
 		final ExpressionKind middle1 = Helpers.ExpressionOperatorToExpressionType(middle);
 		return new BasicBinaryExpressionImpl(left, middle1, new StringExpressionImpl(tripleo.elijah.util.Helpers0.makeToken(right.text()))); // TODO !!!
@@ -62,7 +62,7 @@ public class ExpressionNodeBuilder {
 
 	@NotNull
 	@Contract(value = "_, _, _, _ -> new", pure = true)
-	public static IExpressionNode binex(final @NotNull TypeRef rt, final VariableReferenceNode3 varref, final ExpressionOperators operators, final TmpSSACtxNode node) {
+	public static IExpressionNode binex(final @NotNull  TypeRef rt, final VariableReferenceNode3 varref, final ExpressionOperators operators, final TmpSSACtxNode node) {
 		return new IExpressionNode() {
 			@Override
 			public @org.jetbrains.annotations.Nullable IExpression getExpr() {
@@ -112,7 +112,7 @@ public class ExpressionNodeBuilder {
 	}
 
 	@NotNull
-	public static IExpressionNode fncall(final @NotNull MethRef aMeth, final @NotNull List<LocalAgnTmpNode> of) { // TODO no so wrong anymore
+	public static IExpressionNode fncall(final @NotNull  MethRef aMeth, final @NotNull  List<LocalAgnTmpNode> of) { // TODO no so wrong anymore
 		final ProcedureCallExpression pce1 = new ProcedureCallExpressionImpl();
 		final Qualident               xyz  = new QualidentImpl();
 		final Token                   t    = new CommonToken();
@@ -126,7 +126,7 @@ public class ExpressionNodeBuilder {
 		//
 		return new IExpressionNode() {
 			@Override
-			public @NotNull IExpression getExpr() {
+			public @NotNull  IExpression getExpr() {
 				return pce1;
 			}
 
@@ -151,7 +151,7 @@ public class ExpressionNodeBuilder {
 			}
 
 			@Override
-			public @NotNull String genText(final CompilerContext cctx) {
+			public @NotNull  String genText(final CompilerContext cctx) {
 				final TypeRef       p    = aMeth.getParent();
 				final int           code = p.getCode();
 				final String        s    = String.format("z%d%s", code, pce1.getLeft().toString());
@@ -175,7 +175,7 @@ public class ExpressionNodeBuilder {
 					@Nullable
 					@Override
 					public String apply(@Nullable IExpression input) {
-						@NotNull final IExpression arg = input;
+						@NotNull  final IExpression arg = input;
 						final String               s2;
 						if (arg instanceof VariableReferenceImpl) {
 							s2 = ((VariableReferenceImpl) arg).getName();
@@ -210,7 +210,7 @@ public class ExpressionNodeBuilder {
 		};
 	}
 
-	public static @NotNull IExpressionNode fncall(final String string, final @NotNull List<LocalAgnTmpNode> of) { // todo wrong
+	public static @NotNull  IExpressionNode fncall(final String string, final @NotNull  List<LocalAgnTmpNode> of) { // todo wrong
 		// TODO Auto-generated method stub
 		final ProcedureCallExpression pce1 = new ProcedureCallExpressionImpl();
 		final Qualident               xyz  = new QualidentImpl();
@@ -223,7 +223,7 @@ public class ExpressionNodeBuilder {
 		//
 		return new IExpressionNode() {
 			@Override
-			public @NotNull IExpression getExpr() {
+			public @NotNull  IExpression getExpr() {
 				return pce1;
 			}
 
@@ -273,7 +273,7 @@ public class ExpressionNodeBuilder {
 		};
 	}
 
-//	public static IExpressionNode fncall(String string, List<@NotNull NumericExpression> list_of) {
+//	public static IExpressionNode fncall(String string, List<@NotNull  NumericExpression> list_of) {
 //		final ExpressionList expl = Helpers.LocalAgnTmpNodeToListVarRef(of);
 //		return fncall(string, expl);
 //	}
@@ -322,7 +322,7 @@ public class ExpressionNodeBuilder {
 			_right  = right;
 		}
 
-		static @NotNull String printableExpression(@NotNull final IExpression expression) {
+		static @NotNull  String printableExpression(@NotNull  final IExpression expression) {
 //			if (expression instanceof OS_Integer) {
 //				return Integer.toString(((OS_Integer) expression).getValue());
 //			} else

--- a/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/ExpressionOperators.java
+++ b/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/ExpressionOperators.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.NotNull;
 public enum ExpressionOperators {
 	OP_MINUS, OP_MULT;
 
-	@NotNull
+	@NotNull 
 	public String getSymbol() {
 		final String middle1;
 		switch (this) {

--- a/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/Helpers.java
+++ b/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/Helpers.java
@@ -19,7 +19,7 @@ import java.util.List;
  */
 public class Helpers {
 	@NotNull
-	static ExpressionList LocalAgnTmpNodeToListVarRef(final @NotNull List<LocalAgnTmpNode> of) {
+	static ExpressionList LocalAgnTmpNodeToListVarRef(final @NotNull  List<LocalAgnTmpNode> of) {
 		final ExpressionList expl = new ExpressionListImpl();
 		for (final LocalAgnTmpNode node : of) {
 			final VariableReferenceImpl vr = new VariableReferenceImpl();
@@ -31,7 +31,7 @@ public class Helpers {
 	}
 
 	@NotNull
-	static ExpressionKind ExpressionOperatorToExpressionType(final @NotNull ExpressionOperators middle) {
+	static ExpressionKind ExpressionOperatorToExpressionType(final @NotNull  ExpressionOperators middle) {
 		final ExpressionKind middle1;
 		switch (middle) {
 		case OP_MINUS:
@@ -47,7 +47,7 @@ public class Helpers {
 	}
 
 	@NotNull
-	public static String getFunctionName(final int code, final String aStr, final @NotNull ExpressionList expressionList) {
+	public static String getFunctionName(final int code, final String aStr, final @NotNull  ExpressionList expressionList) {
 		final StringBuilder sb = new StringBuilder();
 		sb.append("z");
 		sb.append(code);

--- a/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/IntegerNode.java
+++ b/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/IntegerNode.java
@@ -56,17 +56,17 @@ public class IntegerNode implements IExpressionNode {
 	}
 
 	@Override
-	public @NotNull String genText(final CompilerContext cctx) {
+	public @NotNull  String genText(final CompilerContext cctx) {
 		return Integer.toString(((NumericExpression) _expr).getValue());
 	}
 
 	@Override
-	public @NotNull String genType() {
+	public @NotNull  String genType() {
 		return "u64"; // TODO hardcoded
 	}
 
 	@Override
-	public @NotNull String genText() {
+	public @NotNull  String genText() {
 		return Integer.toString(((NumericExpression) _expr).getValue());
 	}
 

--- a/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/LocalAgnTmpNode.java
+++ b/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/LocalAgnTmpNode.java
@@ -23,7 +23,7 @@ public class LocalAgnTmpNode {
 	private int             n;
 	private @Nullable String declared = null;
 
-	public LocalAgnTmpNode(final @NotNull TmpSSACtxNode tmpSSACtxNode, final IExpressionNode node) {
+	public LocalAgnTmpNode(final @NotNull  TmpSSACtxNode tmpSSACtxNode, final IExpressionNode node) {
 		// TODO Auto-generated constructor stub
 		this.agnTo = tmpSSACtxNode;
 //		this.expr = expression;
@@ -73,7 +73,7 @@ public class LocalAgnTmpNode {
 		this.agnWhat = agnWhat;
 	}
 
-	public @NotNull ExpressionNode getLeft() {
+	public @NotNull  ExpressionNode getLeft() {
 		return new VariableReferenceNode2(declared, "Z0*", false); // TODO semi-hardcoded
 	}
 }

--- a/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/LocalDeclAgnNode.java
+++ b/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/LocalDeclAgnNode.java
@@ -15,12 +15,12 @@ import tripleo.elijah.util.NotImplementedException;
  */
 public class LocalDeclAgnNode {
 
-//	public LocalDeclAgnNode(String string, @NotNull OS_Integer integer) {
+//	public LocalDeclAgnNode(String string, @NotNull  OS_Integer integer) {
 //		// TODO Auto-generated constructor stub
 //		NotImplementedException.raise();
 //	}
 
-	public LocalDeclAgnNode(final String string, @NotNull final NumericExpression integer) {
+	public LocalDeclAgnNode(final String string, @NotNull  final NumericExpression integer) {
 		// TODO Auto-generated constructor stub
 		NotImplementedException.raise();
 	}

--- a/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/MethHdrNode.java
+++ b/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/MethHdrNode.java
@@ -32,15 +32,15 @@ import java.util.List;
  */
 public class MethHdrNode implements Node {
 
-	final public @NotNull   MethNameNode       methName;
+	final public @NotNull    MethNameNode       methName;
 	private final @Nullable TypeRef            returnType2;
 	private final           Node               _parent;
-	private final @NotNull  List<ArgumentNode> argument_types;
+	private final @NotNull   List<ArgumentNode> argument_types;
 	private final           int                _code;
 	public                  int                argCount;
 	public @Nullable        TypeNameNode       returnType;
 
-	public MethHdrNode(final Node parent, @NonNull final IdentExpression return_type, final String method_name, final @NotNull List<ArgumentNode> argument_types, final int code) {
+	public MethHdrNode(final Node parent, @NonNull final IdentExpression return_type, final String method_name, final @NotNull  List<ArgumentNode> argument_types, final int code) {
 		_parent             = parent;
 		_code               = code;
 		methName            = new MethNameNode(method_name, this);
@@ -51,7 +51,7 @@ public class MethHdrNode implements Node {
 		returnType2 = null;
 	}
 
-	public MethHdrNode(final TypeRef retType, final Node parent, final String methodName, final @NotNull List<ArgumentNode> argumentTypes, final int code) {
+	public MethHdrNode(final TypeRef retType, final Node parent, final String methodName, final @NotNull  List<ArgumentNode> argumentTypes, final int code) {
 		_parent        = parent;
 		_code          = code;
 		methName       = new MethNameNode(methodName, this);
@@ -70,12 +70,12 @@ public class MethHdrNode implements Node {
 		NotImplementedException.raise();
 	}
 
-	public @NotNull Iterable<ArgumentNode> ArgumentsIterator() {
+	public @NotNull  Iterable<ArgumentNode> ArgumentsIterator() {
 		// TODO Auto-generated method stub
 		return new Iterable<ArgumentNode>() {
 
 			@Override
-			public @NotNull Iterator<ArgumentNode> iterator() {
+			public @NotNull  Iterator<ArgumentNode> iterator() {
 
 				return new Iterator<ArgumentNode>() {
 

--- a/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/ReturnAgnNode.java
+++ b/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/ReturnAgnNode.java
@@ -25,7 +25,7 @@ public class ReturnAgnNode {
 	public  ExpressionNode  expr;
 	private LocalAgnTmpNode _latn;
 
-	public ReturnAgnNode(final @NotNull IExpression expression) {
+	public ReturnAgnNode(final @NotNull  IExpression expression) {
 		// TODO Auto-generated constructor stub
 		expr = new ExpressionNode(expression);
 	}

--- a/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/TmpSSACtxNode.java
+++ b/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/TmpSSACtxNode.java
@@ -35,7 +35,7 @@ public class TmpSSACtxNode {
 		this._ctx = cctx;
 	}
 
-	public @NotNull String text() {
+	public @NotNull  String text() {
 		return ExpressionNode.getStringPCE((ProcedureCallExpression) getExprType());
 		//"--------------------"; // TODO hardcoded
 	}
@@ -52,7 +52,7 @@ public class TmpSSACtxNode {
 		this._node = node;
 	}
 
-	public @NotNull IExpressionNode getType() {
+	public @NotNull  IExpressionNode getType() {
 		if (_node != null)
 			return _node;
 		return new ExpressionNode(getExprType());

--- a/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/VariableReferenceNode.java
+++ b/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/VariableReferenceNode.java
@@ -29,7 +29,7 @@ public class VariableReferenceNode {
 		return null;
 	}
 
-	public @NotNull String genText() {
+	public @NotNull  String genText() {
 		NotImplementedException.raise();
 		return "vtn"; // TODO hardcoded
 	}

--- a/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/VariableReferenceNode2.java
+++ b/elijah-compiler-gen/src/main/java/tripleo/elijah/gen/nodes/VariableReferenceNode2.java
@@ -52,7 +52,7 @@ public class VariableReferenceNode2 extends ExpressionNode {
 //		return null;
 //	}
 
-	private void setText(final @NotNull IdentExpression identExpression) {
+	private void setText(final @NotNull  IdentExpression identExpression) {
 		//NotImplementedException.raise();
 		_declared = identExpression.getText();
 		_perm     = true;

--- a/elijah-compiler-gen/src/test/java/tripleo/elijah/gen/FactorialR.java
+++ b/elijah-compiler-gen/src/test/java/tripleo/elijah/gen/FactorialR.java
@@ -44,7 +44,7 @@ public class FactorialR /* extends TestCase */ {
 	protected void tearDown() throws Exception {
 	}
 
-	void main2_el(final CompilerContext cctx, final @NotNull GenBuffer gbn) {
+	void main2_el(final CompilerContext cctx, final @NotNull  GenBuffer gbn) {
 		final ModuleRef prelude = new ModuleRef(null, -1);
 		final TypeRef   sys_int = new TypeRef(prelude, prelude, "SystemInteger", BuiltInTypes.SystemInteger.getCode());
 		final ModuleRef main2   = new ModuleRef("main2/main2.elijjah", 10000);
@@ -93,18 +93,18 @@ public class FactorialR /* extends TestCase */ {
 	}
 	
 	
-	private @NotNull NumericExpression convertToLocalAgnTmpNode2(final IExpressionNode fncall) {
+	private @NotNull  NumericExpression convertToLocalAgnTmpNode2(final IExpressionNode fncall) {
 		throw new NotImplementedException();
 	}
 
-	private List<LocalAgnTmpNode> convertToLocalAgnTmpNode(final List<@NotNull NumericExpression> list_of) {
+	private List<LocalAgnTmpNode> convertToLocalAgnTmpNode(final List<@NotNull  NumericExpression> list_of) {
 		// TODO Auto-generated method stub
 		final List<LocalAgnTmpNode> r = null;
 		throw new NotImplementedException();
 //		return r;
 	}
 
-	public void factorial_r(final @NotNull CompilerContext cctx, final @NotNull GenBuffer gbn) {
+	public void factorial_r(final @NotNull  CompilerContext cctx, final @NotNull  GenBuffer gbn) {
 		final ModuleRef prelude = new ModuleRef(null, -1);
 		final TypeRef   u64     = new TypeRef(prelude, prelude, "u64", 81);
 		final ModuleRef main_m  = new ModuleRef("fact.elijah", -2);
@@ -167,7 +167,7 @@ public class FactorialR /* extends TestCase */ {
 
 	}
 
-	public void GenMethHdr(final @NotNull CompilerContext cctx, final @NotNull MethHdrNode node, final @NotNull GenBuffer gbn) {
+	public void GenMethHdr(final @NotNull  CompilerContext cctx, final @NotNull  MethHdrNode node, final @NotNull  GenBuffer gbn) {
 		final TextBuffer buf = gbn.moduleBufHdr(cctx.module());
 		buf.append_s(node.returnType().genType());
 		buf.append(node.genName());
@@ -180,7 +180,7 @@ public class FactorialR /* extends TestCase */ {
 		buf.append(");");
 	}
 
-	private void BeginMeth(final @NotNull CompilerContext cctx, final @NotNull MethHdrNode node, final @NotNull GenBuffer gbn) {
+	private void BeginMeth(final @NotNull  CompilerContext cctx, final @NotNull  MethHdrNode node, final @NotNull  GenBuffer gbn) {
 		// TODO Auto-generated method stub
 		final TextBuffer buf=gbn.moduleBufImpl(cctx.module());
 /*
@@ -209,7 +209,7 @@ public class FactorialR /* extends TestCase */ {
 		buf.incr_i();
 		}
 
-	private void BeginCaseStatement(final @NotNull CompilerContext cctx, final @NotNull CaseHdrNode node, final @NotNull GenBuffer gbn) {
+	private void BeginCaseStatement(final @NotNull  CompilerContext cctx, final @NotNull  CaseHdrNode node, final @NotNull  GenBuffer gbn) {
 		final TextBuffer buf = gbn.moduleBufImpl(cctx.module());
 		final boolean is_simple = node.getExpr().is_simple();
 		buf.append_s("switch (");
@@ -222,7 +222,7 @@ public class FactorialR /* extends TestCase */ {
 		buf.incr_i();
 	}
 
-	private void BeginCaseChoice(final @NotNull CompilerContext cctx, final @NotNull CaseChoiceNode node, final @NotNull GenBuffer gbn) {
+	private void BeginCaseChoice(final @NotNull  CompilerContext cctx, final @NotNull  CaseChoiceNode node, final @NotNull  GenBuffer gbn) {
 		// TODO Auto-generated method stub
 		final TextBuffer buf=gbn.moduleBufImpl(cctx.module());
 		final boolean is_simple = node.left.is_const_expr();
@@ -238,7 +238,7 @@ public class FactorialR /* extends TestCase */ {
 		}
 	}
 
-	private void GenReturnAgn(final @NotNull CompilerContext cctx, final @NotNull ReturnAgnNode node, final @NotNull GenBuffer gbn) {
+	private void GenReturnAgn(final @NotNull  CompilerContext cctx, final @NotNull  ReturnAgnNode node, final @NotNull  GenBuffer gbn) {
 		final TextBuffer buf=gbn.moduleBufImpl(cctx.module());
 		buf.append("vsr =");
 		buf.append(node.getExpr().genText(cctx));
@@ -246,7 +246,7 @@ public class FactorialR /* extends TestCase */ {
 		// if(node.usesRetKW()) {buf.append ("return vsr;");}
 	}
 
-	private void CloseCaseChoice(final @NotNull CompilerContext cctx, final CloseCaseNode node, final @NotNull GenBuffer gbn) {
+	private void CloseCaseChoice(final @NotNull  CompilerContext cctx, final CloseCaseNode node, final @NotNull  GenBuffer gbn) {
 		// TODO Auto-generated method stub
 		final TextBuffer buf = gbn.moduleBufImpl(cctx.module());
 		buf.decr_i();
@@ -254,7 +254,7 @@ public class FactorialR /* extends TestCase */ {
 //		buf.append_nl("} // close select ("+node.hdr_node.left.genName+")"); // TODO left was expr
 	}
 
-	private void BeginDefaultCaseStatement(final @NotNull CompilerContext cctx, final @NotNull CaseChoiceNode node, final @NotNull GenBuffer gbn) {
+	private void BeginDefaultCaseStatement(final @NotNull  CompilerContext cctx, final @NotNull  CaseChoiceNode node, final @NotNull  GenBuffer gbn) {
 		// TODO Auto-generated method stub
 		final TextBuffer buf=gbn.moduleBufImpl(cctx.module());
 		buf.incr_i();
@@ -289,7 +289,7 @@ public class FactorialR /* extends TestCase */ {
 		}
 	}
 
-	public static @NotNull TextBuffer BeginTmpSSACtx(final @NotNull CompilerContext cctx, final @NotNull TmpSSACtxNode node, final @NotNull GenBuffer gbn) {
+	public static @NotNull  TextBuffer BeginTmpSSACtx(final @NotNull  CompilerContext cctx, final @NotNull  TmpSSACtxNode node, final @NotNull  GenBuffer gbn) {
 		// TODO Auto-generated method stub
 		final TextBuffer buf=gbn.moduleBufImpl(cctx.module());
 		buf.incr_i();
@@ -305,7 +305,7 @@ public class FactorialR /* extends TestCase */ {
 		return buf;
 	}
 
-	public static @NotNull TextBuffer GenLocalAgn(final @NotNull CompilerContext cctx, final @NotNull LocalAgnTmpNode node, final @NotNull GenBuffer gbn) {
+	public static @NotNull  TextBuffer GenLocalAgn(final @NotNull  CompilerContext cctx, final @NotNull  LocalAgnTmpNode node, final @NotNull  GenBuffer gbn) {
 		// TODO Auto-generated method stub
 		final TextBuffer buf=gbn.moduleBufImpl(cctx.module());
 //		if (node instanceof LocalAgnTmpNode) {
@@ -322,19 +322,19 @@ public class FactorialR /* extends TestCase */ {
 		return buf;
 	}
 
-	private void CloseTmpCtx(final @NotNull CompilerContext cctx, final LocalAgnTmpNode lamn, final @NotNull GenBuffer gbn) {
+	private void CloseTmpCtx(final @NotNull  CompilerContext cctx, final LocalAgnTmpNode lamn, final @NotNull  GenBuffer gbn) {
 		final TextBuffer buf=gbn.moduleBufImpl(cctx.module());
 		buf.append_cb(""); // close-brace
 	}
 	
-	private void EndCaseStatement(final @NotNull CompilerContext cctx, final @NotNull CaseHdrNode node, final @NotNull GenBuffer gbn) {
+	private void EndCaseStatement(final @NotNull  CompilerContext cctx, final @NotNull  CaseHdrNode node, final @NotNull  GenBuffer gbn) {
 		// TODO Auto-generated method stub
 		final TextBuffer buf=gbn.moduleBufImpl(cctx.module());
 		buf.decr_i();
 		buf.append_nl("} // close select "+node.getExpr().genText());
 	}
 
-	private void EndMeth(final @NotNull CompilerContext cctx, final MethHdrNode mhn, final @NotNull GenBuffer gbn) {
+	private void EndMeth(final @NotNull  CompilerContext cctx, final MethHdrNode mhn, final @NotNull  GenBuffer gbn) {
 		final TextBuffer buf=gbn.moduleBufImpl(cctx.module());
 		buf.append_ln("return vsr;");
 		buf.decr_i();
@@ -342,7 +342,7 @@ public class FactorialR /* extends TestCase */ {
 	}
 
 	@Deprecated
-	private void GenReturnAgnSimpleInt(final @NotNull CompilerContext cctx, final @NotNull ReturnAgnSimpleIntNode rasin, final @NotNull GenBuffer gbn) {
+	private void GenReturnAgnSimpleInt(final @NotNull  CompilerContext cctx, final @NotNull  ReturnAgnSimpleIntNode rasin, final @NotNull  GenBuffer gbn) {
 		final TextBuffer buf=gbn.moduleBufImpl(cctx.module());
 		buf.append("vsr = ");
 		buf.append(((Integer)rasin.getValue()).toString());
@@ -355,7 +355,7 @@ public class FactorialR /* extends TestCase */ {
 		 */
 //		@Override
 		@Override
-		public void transform(final @NotNull ArgumentNode na, final @NotNull DefaultBuffer bufbldr) {
+		public void transform(final @NotNull  ArgumentNode na, final @NotNull  DefaultBuffer bufbldr) {
 			bufbldr.append_s(na.getGenType(), XX.SPACE);
 			bufbldr.append(na.getVarName());
 		}

--- a/typeinf/src/main/java/tripleo/elijah/typinf/TypInf.java
+++ b/typeinf/src/main/java/tripleo/elijah/typinf/TypInf.java
@@ -39,7 +39,7 @@ public class TypInf {
 	 * @param subst
 	 * @return
 	 */
-	static @Nullable HashMap<String, Type> unify_variable(@NotNull TypeVar v, Type typ, @NotNull HashMap<String, Type> subst) {
+	static @Nullable HashMap<String, Type> unify_variable(@NotNull  TypeVar v, Type typ, @NotNull  HashMap<String, Type> subst) {
 		if (subst.containsKey(v.name)) {
 			return unify(subst.get(v.name), typ, subst);
 		} else if ((typ instanceof TypeVar) && subst.containsKey(((TypeVar) typ).name)) {
@@ -53,7 +53,7 @@ public class TypInf {
 		}
 	}
 
-	private static @NotNull HashMap<String, Type> dict_combine(@NotNull HashMap<String, Type> a, HashMap<String, Type> b) {
+	private static @NotNull  HashMap<String, Type> dict_combine(@NotNull  HashMap<String, Type> a, HashMap<String, Type> b) {
 		HashMap<String, Type> r = new HashMap<String, Type>();
 		for (Map.Entry<String, Type> entry : a.entrySet()) {
 			r.put(entry.getKey(), entry.getValue());
@@ -64,7 +64,7 @@ public class TypInf {
 		return r;
 	}
 
-	static <K, V> @NotNull HashMap<K, V> mapping(K k, V v) {
+	static <K, V> @NotNull  HashMap<K, V> mapping(K k, V v) {
 		HashMap<K, V> r = new HashMap<K, V>();
 		r.put(k, v);
 		return r;
@@ -78,7 +78,7 @@ public class TypInf {
 	 * @param eqs
 	 * @return
 	 */
-	public static HashMap<String, Type> unify_all_equations(@NotNull List<TypeEquation> eqs) {
+	public static HashMap<String, Type> unify_all_equations(@NotNull  List<TypeEquation> eqs) {
 		HashMap<String, Type> subst = new HashMap<>();
 		for (TypeEquation eq : eqs) {
 			subst = unify(eq.left, eq.right, subst);
@@ -103,7 +103,7 @@ public class TypInf {
 	 * @param rename_types
 	 * @return
 	 */
-	public static Type get_expression_type(@NotNull AstNode expr, HashMap<String, Type> subst, boolean rename_types) {
+	public static Type get_expression_type(@NotNull  AstNode expr, HashMap<String, Type> subst, boolean rename_types) {
 		Type typ = apply_unifier(expr.get_type(), subst);
 		if (rename_types) {
 			Counter                 namecounter = new Counter();
@@ -394,7 +394,7 @@ public class TypInf {
 		return Helpers.String_join("\n", lines);
 	}
 
-	void show_rec(AstNode node, @NotNull List<String> lines) {
+	void show_rec(AstNode node, @NotNull  List<String> lines) {
 		lines.add(String.format("%60s %s", node, node.get_type()));
 		node.visit_children(node1 -> show_rec(node1, lines));
 	}

--- a/typeinf/src/test/java/tripleo/elijah/typinf/typing/TestFullInference.java
+++ b/typeinf/src/test/java/tripleo/elijah/typinf/typing/TestFullInference.java
@@ -51,7 +51,7 @@
 //		assertEquals(ty, str(inferred));
 //	}
 //
-//	public String str(@NotNull Object a) {
+//	public String str(@NotNull  Object a) {
 //		if (a instanceof IntType it) {
 //			return a.toString();
 //		}

--- a/typeinf/src/test/java/tripleo/elijah/typinf/typing/TestGenerateEquations.java
+++ b/typeinf/src/test/java/tripleo/elijah/typinf/typing/TestGenerateEquations.java
@@ -33,7 +33,7 @@
 //	public void test_decl() throws ParseError {
 //		Parser                             p         = new Parser();
 //		Decl_AST                           e         = p.parse_decl("foo f x = f(3) - f(x)");
-//		@NotNull List<TypInf.TypeEquation> equations = List_of();
+//		@NotNull  List<TypInf.TypeEquation> equations = List_of();
 //		TypInf.assign_typenames(e.expr);
 //		TypInf.generate_equations(e.expr, equations);
 //		assertTrue(has_equation(equations, "t1", "(Int -> t4)"));
@@ -48,7 +48,7 @@
 //	 * @param eqs
 //	 * @return
 //	 */
-//	boolean has_equation(@NotNull List<TypInf.TypeEquation> eqs, String left, String right) {
+//	boolean has_equation(@NotNull  List<TypInf.TypeEquation> eqs, String left, String right) {
 //		for (TypInf.TypeEquation e : eqs) {
 //			if (str(e.left()).equals(left) && str(e.right()).equals(right))
 //				return true;
@@ -61,7 +61,7 @@
 //		TypInf.reset_type_counter();
 //	}
 //
-//	public String str(@NotNull Object a) {
+//	public String str(@NotNull  Object a) {
 //		return a.toString();
 //	}
 //

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/ci/CiExpression.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/ci/CiExpression.java
@@ -1,10 +1,12 @@
 package tripleo.elijah.ci;
 
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.UnintendedUseException;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.*;
 
 public interface CiExpression {
-	@NotNull ExpressionKind getKind();
+	@NotNull
+	ExpressionKind getKind();
 
 	CiExpression getLeft();
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/ci/CiExpressionList.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/ci/CiExpressionList.java
@@ -1,17 +1,20 @@
 package tripleo.elijah.ci;
 
-import org.jetbrains.annotations.*;
-
 import java.util.*;
+
+import org.jetbrains.annotations.*;
 
 public interface CiExpressionList {
 	void add(CiExpression aExpr);
 
-	@NotNull Collection<CiExpression> expressions();
+	@NotNull
+	Collection<CiExpression> expressions();
 
-	@NotNull Iterator<CiExpression> iterator();
+	@NotNull
+	Iterator<CiExpression> iterator();
 
-	@NotNull CiExpression next(/*@NotNull*/ CiExpression aExpr);
+	@NotNull
+	CiExpression next(/* @NotNull */ CiExpression aExpr);
 
 	int size();
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/ci/cil/FloatExpressionImpl.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/ci/cil/FloatExpressionImpl.java
@@ -14,17 +14,11 @@
  */
 package tripleo.elijah.ci.cil;
 
-import antlr.Token;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.UnintendedUseException;
-import tripleo.elijah.ci.CiExpression;
-import tripleo.elijah.ci.CiExpressionList;
-import tripleo.elijah.ci.ExpressionKind;
-import tripleo.elijah.ci.cii.FloatExpression;
-import tripleo.elijah.util.NotImplementedException;
-
-
-import java.util.List;
+import antlr.*;
+import tripleo.elijah.*;
+import tripleo.elijah.ci.*;
+import tripleo.elijah.ci.cii.*;
+import tripleo.elijah.util.*;
 
 public class FloatExpressionImpl implements FloatExpression {
 	private final Token n;
@@ -35,7 +29,7 @@ public class FloatExpressionImpl implements FloatExpression {
 		carrier = Float.parseFloat(n.getText());
 	}
 
-	//public @NotNull List<FormalArgListItem> getArgs() {
+	// public @NotNull List<FormalArgListItem> getArgs() {
 	//	return null;
 	//}
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/ci/cil/IdentExpressionImpl.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/ci/cil/IdentExpressionImpl.java
@@ -1,13 +1,11 @@
 package tripleo.elijah.ci.cil;
 
-import antlr.Token;
-import tripleo.elijah.ci.CiExpression;
-import tripleo.elijah.ci.CiExpressionList;
-import tripleo.elijah.ci.ExpressionKind;
-import tripleo.elijah.ci.cii.IdentExpression;
-import tripleo.elijah.util.SimplePrintLoggerToRemoveSoon;
+import java.io.*;
 
-import java.io.File;
+import antlr.*;
+import tripleo.elijah.ci.*;
+import tripleo.elijah.ci.cii.*;
+import tripleo.elijah.util.*;
 
 /**
  * @author Tripleo(sb)
@@ -29,7 +27,7 @@ public class IdentExpressionImpl implements IdentExpression {
 	//}
 
 
-	//public @NotNull List<FormalArgListItem> getArgs() {
+	// public @NotNull List<FormalArgListItem> getArgs() {
 	//	return null;
 	//}
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/ci/cil/NumericExpressionImpl.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/ci/cil/NumericExpressionImpl.java
@@ -1,16 +1,14 @@
 package tripleo.elijah.ci.cil;
 
-import antlr.Token;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.UnintendedUseException;
-import tripleo.elijah.ci.CiExpression;
-import tripleo.elijah.ci.CiExpressionList;
-import tripleo.elijah.ci.ExpressionKind;
-import tripleo.elijah.ci.cii.NumericExpression;
-import tripleo.elijah.util.NotImplementedException;
+import java.io.*;
 
+import org.jetbrains.annotations.*;
 
-import java.io.File;
+import antlr.*;
+import tripleo.elijah.*;
+import tripleo.elijah.ci.*;
+import tripleo.elijah.ci.cii.*;
+import tripleo.elijah.util.*;
 
 public class NumericExpressionImpl implements NumericExpression {
 
@@ -26,7 +24,7 @@ public class NumericExpressionImpl implements NumericExpression {
 		carrier = Integer.parseInt(n.getText());
 	}
 
-	//public @NotNull List<FormalArgListItem> getArgs() {
+	// public @NotNull List<FormalArgListItem> getArgs() {
 	//	return null;
 	//}
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/ci/cil/ProcedureCallExpressionImpl.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/ci/cil/ProcedureCallExpressionImpl.java
@@ -8,11 +8,8 @@
  */
 package tripleo.elijah.ci.cil;
 
-import tripleo.elijah.ci.CiExpression;
-import tripleo.elijah.ci.CiExpressionList;
-import tripleo.elijah.ci.ExpressionKind;
-import tripleo.elijah.ci.cii.ProcedureCallExpression;
-import tripleo.elijah.ci.cii.Qualident;
+import tripleo.elijah.ci.*;
+import tripleo.elijah.ci.cii.*;
 
 // TODO is ExpressionList an CiExpression?
 public class ProcedureCallExpressionImpl implements ProcedureCallExpression {
@@ -49,7 +46,7 @@ public class ProcedureCallExpressionImpl implements ProcedureCallExpression {
 	// region kind
 
 //	@Override
-//	public @NotNull List<FormalArgListItem> getArgs() {
+// public @NotNull List<FormalArgListItem> getArgs() {
 //		return args;
 //	}
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/ci/cil/QualidentImpl.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/ci/cil/QualidentImpl.java
@@ -1,20 +1,17 @@
 package tripleo.elijah.ci.cil;
 
-import antlr.Token;
-import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.ci.CiExpression;
-import tripleo.elijah.ci.CiExpressionList;
-import tripleo.elijah.ci.ExpressionKind;
-import tripleo.elijah.ci.cii.DotExpression;
-import tripleo.elijah.ci.cii.IdentExpression;
-import tripleo.elijah.ci.cii.Qualident;
-
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.Objects;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.*;
+
+import com.google.common.base.*;
+import com.google.common.collect.*;
+
+import antlr.*;
+import tripleo.elijah.ci.*;
+import tripleo.elijah.ci.cii.*;
 
 /**
  * Created Mar 27, 2019 at 2:24:09 PM
@@ -83,7 +80,7 @@ public class QualidentImpl implements Qualident {
 		return true;// Objects.equals(_type, qualident._type);
 	}
 
-	//public @NotNull List<FormalArgListItem> getArgs() {
+	// public @NotNull List<FormalArgListItem> getArgs() {
 	//	return null;
 	//}
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/Compilation0.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/Compilation0.java
@@ -1,11 +1,15 @@
 package tripleo.elijah.comp;
 
+import java.util.*;
+import java.util.function.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.ci.*;
 import tripleo.elijah.comp.graph.i.*;
 import tripleo.elijah.comp.i.*;
 import tripleo.elijah.comp.i.extra.*;
-import tripleo.elijah.comp.nextgen.i.CP_Paths;
+import tripleo.elijah.comp.nextgen.i.*;
 import tripleo.elijah.comp.nextgen.pn.*;
 import tripleo.elijah.comp.nextgen.pw.*;
 import tripleo.elijah.comp.specs.*;
@@ -15,9 +19,6 @@ import tripleo.elijah.nextgen.inputtree.*;
 import tripleo.elijah.nextgen.outputtree.*;
 import tripleo.elijah.util.*;
 
-import java.util.*;
-import java.util.function.Supplier;
-
 public interface Compilation0 /*extends GCompilation*/ {
 
     //	CompilerBeginning beginning(final CompilationRunner compilationRunner);
@@ -26,9 +27,9 @@ public interface Compilation0 /*extends GCompilation*/ {
 
     int errorCount();
 
-    void feedCmdLine(@NotNull List<String> args) throws Exception;
+	void feedCmdLine(@NotNull List<String> args) throws Exception;
 
-    void feedInputs(@NotNull List<CompilerInput> inputs, CompilerController controller);
+	void feedInputs(@NotNull List<CompilerInput> inputs, CompilerController controller);
 
     CompilationClosure getCompilationClosure();
 
@@ -42,7 +43,7 @@ public interface Compilation0 /*extends GCompilation*/ {
     @Contract(pure = true)
     List<CompilerInput> getInputs();
 
-    OS_Package getPackage(@NotNull Qualident pkg_name);
+	OS_Package getPackage(@NotNull Qualident pkg_name);
 
     String getProjectName();
 
@@ -50,13 +51,13 @@ public interface Compilation0 /*extends GCompilation*/ {
 
     void setRootCI(CompilerInstructions aRoot);
 
-    boolean isPackage(@NotNull String pkg);
+	boolean isPackage(@NotNull String pkg);
 
     OS_Package makePackage(Qualident pkg_name);
 
     void pushItem(CompilerInstructions aci);
 
-    void use(@NotNull CompilerInstructions compilerInstructions, USE_Reasoning aReasoning);
+	void use(@NotNull CompilerInstructions compilerInstructions, USE_Reasoning aReasoning);
 
     ElijahCache use_elijahCache();
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/ICompilerInstructionsObserver.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/ICompilerInstructionsObserver.java
@@ -1,12 +1,13 @@
 package tripleo.elijah.comp;
 
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.ci.CompilerInstructions;
-import tripleo.elijah.util.Ok;
-import tripleo.elijah.util.Operation;
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.ci.*;
+import tripleo.elijah.util.*;
 
 public interface ICompilerInstructionsObserver {
-	@NotNull Operation<Ok> almostComplete();
+	@NotNull
+	Operation<Ok> almostComplete();
 
 	void onComplete();
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/IO.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/IO.java
@@ -1,25 +1,25 @@
 package tripleo.elijah.comp;
 
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.nextgen.inputtree.*;
 import tripleo.elijah.util.*;
 import tripleo.elijah.util.io.*;
-
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Path;
-import java.util.List;
-
 import tripleo.wrap.File;
 
 public interface IO {
-	@Nullable CharSource openRead(@NotNull Path p);
+	@Nullable
+	CharSource openRead(@NotNull Path p);
 
-	@NotNull DisposableCharSink openWrite(@NotNull Path p) throws IOException;
+	@NotNull
+	DisposableCharSink openWrite(@NotNull Path p) throws IOException;
 
-	@NotNull InputStream readFile(@NotNull tripleo.wrap.File f) throws FileNotFoundException;
+	@NotNull
+	InputStream readFile(@NotNull tripleo.wrap.File f) throws FileNotFoundException;
 
 	_IO_ReadFile readFile2(@NotNull File f) throws FileNotFoundException;
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/i/CompilerDriver.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/i/CompilerDriver.java
@@ -1,8 +1,10 @@
 package tripleo.elijah.comp.i;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.util.*;
 
 public interface CompilerDriver {
-	@NotNull Operation<CompilerDriven> get(DriverToken aToken);
+	@NotNull
+	Operation<CompilerDriven> get(DriverToken aToken);
 }

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/nextgen/i/CP_Paths.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/nextgen/i/CP_Paths.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.comp.nextgen.i;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.nextgen.*;
 
 public interface CP_Paths {
@@ -8,7 +9,9 @@ public interface CP_Paths {
 
 	CP_Path outputRoot();
 	CP_Path preludeRoot();
-	@NotNull CP_StdlibPath stdlibRoot();
+
+	@NotNull
+	CP_StdlibPath stdlibRoot();
 	CP_Path sourcesRoot();
 
 	void renderNodes();

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/nextgen/i/CP_StdlibPath.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/nextgen/i/CP_StdlibPath.java
@@ -1,12 +1,11 @@
 package tripleo.elijah.comp.nextgen.i;
 
-import java.nio.file.Path;
+import java.nio.file.*;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.*;
 
-import tripleo.elijah.Eventual;
-import tripleo.wrap.File;
+import tripleo.elijah.*;
+import tripleo.wrap.*;
 
 public interface CP_StdlibPath extends CP_Path, _CP_RootPath {
 	@Override
@@ -19,22 +18,26 @@ public interface CP_StdlibPath extends CP_Path, _CP_RootPath {
 	@Nullable CP_Path getParent();
 
 	@Override
-	@NotNull Path getPath();
+	@NotNull
+	Path getPath();
 
 	@Override
-	@NotNull Eventual<Path> getPathPromise();
+	@NotNull
+	Eventual<Path> getPathPromise();
 
 	@Override
 	@Nullable File getRootFile();
 
 	@Override
-	@NotNull _CP_RootPath getRootPath();
+	@NotNull
+	_CP_RootPath getRootPath();
 
 	@Override
 	@Nullable CP_SubFile subFile(String aFile);
 
 	@Override
-	@NotNull File toFile();
+	@NotNull
+	File toFile();
 
 	@Override
 	String toString();

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/nextgen/i/CP_SubFile.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/nextgen/i/CP_SubFile.java
@@ -1,11 +1,12 @@
 package tripleo.elijah.comp.nextgen.i;
 
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
 
-import tripleo.wrap.File;
+import tripleo.wrap.*;
 
 public interface CP_SubFile {
 	CP_Path getPath();
 
-	@NotNull File toFile();
+	@NotNull
+	File toFile();
 }

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/nextgen/inputtree/EIT_ModuleInput.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/nextgen/inputtree/EIT_ModuleInput.java
@@ -1,17 +1,18 @@
 package tripleo.elijah.comp.nextgen.inputtree;
 
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
 
 import tripleo.elijah.g.*;
-import tripleo.elijah.nextgen.inputtree.EIT_Input;
-import tripleo.elijah.nextgen.inputtree.EIT_InputType;
-import tripleo.elijah.nextgen.model.SM_Module;
+import tripleo.elijah.nextgen.inputtree.*;
+import tripleo.elijah.nextgen.model.*;
 
 public interface EIT_ModuleInput extends EIT_Input {
-	@NotNull SM_Module computeSourceModel();
+	@NotNull
+	SM_Module computeSourceModel();
 
 	void doGenerate(GModuleGenerationRequest r);
 
 	@Override
-	@NotNull EIT_InputType getType();
+	@NotNull
+	EIT_InputType getType();
 }

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/specs/EzSpec.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/comp/specs/EzSpec.java
@@ -1,15 +1,16 @@
 package tripleo.elijah.comp.specs;
 
-import org.jetbrains.annotations.*;
-import tripleo.elijah.util.*;
-
 import java.io.*;
-import java.util.Objects;
+import java.util.*;
 
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.util.*;
 import tripleo.wrap.File;
 
 public interface EzSpec {
-	@NotNull Operation<String> absolute1();
+	@NotNull
+	Operation<String> absolute1();
 
 	String file_name();
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/ICaseContext.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/ICaseContext.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.contexts;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 
 public interface ICaseContext extends Context {
@@ -9,5 +10,5 @@ public interface ICaseContext extends Context {
 
 	@Override
 	LookupResultList lookup(String name, int level, LookupResultList Result,
-							@NotNull ISearchList alreadySearched, boolean one);
+			@NotNull ISearchList alreadySearched, boolean one);
 }

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/IClassContext.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/IClassContext.java
@@ -1,9 +1,10 @@
 package tripleo.elijah.contexts;
 
-import org.jetbrains.annotations.*;
-import tripleo.elijah.lang.i.*;
-
 import java.util.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.lang.i.*;
 
 public interface IClassContext extends Context {
 	ClassStatement getCarrier();
@@ -16,7 +17,7 @@ public interface IClassContext extends Context {
 	@Override
 	LookupResultList lookup(@NotNull String name,
 							int level,
-							@NotNull LookupResultList Result,
-							@NotNull ISearchList alreadySearched,
+			@NotNull LookupResultList Result,
+			@NotNull ISearchList alreadySearched,
 							boolean one);
 }

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/IFunctionContext.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/IFunctionContext.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.contexts;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 
 public interface IFunctionContext extends Context {
@@ -9,5 +10,5 @@ public interface IFunctionContext extends Context {
 
 	@Override
 	LookupResultList lookup(String name, int level, @NotNull LookupResultList Result,
-							@NotNull ISearchList alreadySearched, boolean one);
+			@NotNull ISearchList alreadySearched, boolean one);
 }

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/ILoopContext.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/ILoopContext.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.contexts;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 
 public interface ILoopContext extends Context {
@@ -9,5 +10,5 @@ public interface ILoopContext extends Context {
 
 	@Override
 	LookupResultList lookup(@NotNull String name, int level, @NotNull LookupResultList Result,
-							@NotNull ISearchList alreadySearched, boolean one);
+			@NotNull ISearchList alreadySearched, boolean one);
 }

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/IPackageContext.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/IPackageContext.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.contexts;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 
 public interface IPackageContext extends tripleo.elijah.lang.i.Context {
@@ -10,10 +11,11 @@ public interface IPackageContext extends tripleo.elijah.lang.i.Context {
 	@Override
 	LookupResultList lookup(String name,
 							int level,
-							@NotNull LookupResultList Result,
-							@NotNull ISearchList alreadySearched,
+			@NotNull LookupResultList Result,
+			@NotNull ISearchList alreadySearched,
 							boolean one);
 
 	@Override
-	@NotNull OS_Module module();
+	@NotNull
+	OS_Module module();
 }

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/ISyntacticBlockContext.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/ISyntacticBlockContext.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.contexts;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 
 public interface ISyntacticBlockContext extends tripleo.elijah.lang.i.Context {
@@ -9,5 +10,5 @@ public interface ISyntacticBlockContext extends tripleo.elijah.lang.i.Context {
 
 	@Override
 	LookupResultList lookup(String name, int level, @NotNull LookupResultList Result,
-							@NotNull ISearchList alreadySearched, boolean one);
+			@NotNull ISearchList alreadySearched, boolean one);
 }

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/IWithContext.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/IWithContext.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.contexts;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 
 public interface IWithContext extends Context {
@@ -9,5 +10,5 @@ public interface IWithContext extends Context {
 
 	@Override
 	LookupResultList lookup(String name, int level, @NotNull LookupResultList Result,
-							@NotNull ISearchList alreadySearched, boolean one);
+			@NotNull ISearchList alreadySearched, boolean one);
 }

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/IfConditionalContext.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/IfConditionalContext.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.contexts;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 
 public interface IfConditionalContext extends tripleo.elijah.lang.i.Context {
@@ -9,5 +10,5 @@ public interface IfConditionalContext extends tripleo.elijah.lang.i.Context {
 
 	@Override
 	LookupResultList lookup(String name, int level, @NotNull LookupResultList Result,
-							@NotNull ISearchList alreadySearched, boolean one);
+			@NotNull ISearchList alreadySearched, boolean one);
 }

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/MatchContext.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/MatchContext.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.contexts;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 
 public interface MatchContext extends Context {
@@ -9,5 +10,5 @@ public interface MatchContext extends Context {
 
 	@Override
 	LookupResultList lookup(String name, int level, LookupResultList Result,
-							@NotNull ISearchList alreadySearched, boolean one);
+			@NotNull ISearchList alreadySearched, boolean one);
 }

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/ModuleContext.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/ModuleContext.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.contexts;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 
 public interface ModuleContext extends Context {
@@ -11,7 +12,7 @@ public interface ModuleContext extends Context {
 
 	@Override
 	LookupResultList lookup(String name, int level, @NotNull LookupResultList Result,
-							@NotNull ISearchList alreadySearched, boolean one);
+			@NotNull ISearchList alreadySearched, boolean one);
 
 	void setCarrier(OS_Module aCarrier);
 }

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/NamespaceContext.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/NamespaceContext.java
@@ -1,6 +1,7 @@
 package tripleo.elijah.contexts;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 
 public interface NamespaceContext extends Context {
@@ -9,5 +10,5 @@ public interface NamespaceContext extends Context {
 
 	@Override
 	LookupResultList lookup(String name, int level, @NotNull LookupResultList Result,
-							@NotNull ISearchList alreadySearched, boolean one);
+			@NotNull ISearchList alreadySearched, boolean one);
 }

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/OS_TypeNameElement.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/contexts/OS_TypeNameElement.java
@@ -1,12 +1,14 @@
 package tripleo.elijah.contexts;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.lang2.*;
 
 public interface OS_TypeNameElement extends OS_Element {
 	@Override
-	@NotNull Context getContext();
+	@NotNull
+	Context getContext();
 
 	@Override
 	OS_Element getParent();

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/lang/i/CaseScope.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/lang/i/CaseScope.java
@@ -1,11 +1,12 @@
 package tripleo.elijah.lang.i;
 
-import antlr.*;
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
+import antlr.*;
 import tripleo.elijah.contexts.*;
 import tripleo.elijah.lang2.*;
-
-import java.util.*;
 
 public interface CaseScope extends OS_Container, OS_Element, CaseConditional {
 	/*
@@ -55,7 +56,8 @@ public interface CaseScope extends OS_Container, OS_Element, CaseConditional {
 	 * @see tripleo.elijah.lang.impl.CaseConditional#getParent()
 	 */
 	@Override
-	@NotNull OS_Element getParent();
+	@NotNull
+	OS_Element getParent();
 
 	@Override
 	@Nullable HashMap<IExpression, CaseScope> getScopes();

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/lang/i/IMatchConditionalPart2.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/lang/i/IMatchConditionalPart2.java
@@ -1,10 +1,11 @@
 package tripleo.elijah.lang.i;
 
-import antlr.*;
-import org.jetbrains.annotations.*;
-import tripleo.elijah.lang2.*;
-
 import java.util.*;
+
+import org.jetbrains.annotations.*;
+
+import antlr.*;
+import tripleo.elijah.lang2.*;
 
 public interface IMatchConditionalPart2 extends MC1 {
 	void add(FunctionItem aItem);
@@ -14,14 +15,17 @@ public interface IMatchConditionalPart2 extends MC1 {
 	void expr(IExpression expr);
 
 	@Override
-	@NotNull Context getContext();
+	@NotNull
+	Context getContext();
 
 	@Override
-	@NotNull List<FunctionItem> getItems();
+	@NotNull
+	List<FunctionItem> getItems();
 
 	IExpression getMatchingExpression();
 
-	@NotNull OS_Element getParent();
+	@NotNull
+	OS_Element getParent();
 
 	void scope(Scope3 sco);
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/lang/i/ISearchList.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/lang/i/ISearchList.java
@@ -1,12 +1,14 @@
 package tripleo.elijah.lang.i;
 
-import com.google.common.collect.ImmutableList;
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
+
+import com.google.common.collect.*;
 
 public interface ISearchList {
 	void add(Context c);
 
 	boolean contains(Context context);
 
-	@NotNull ImmutableList<Context> getList();
+	@NotNull
+	ImmutableList<Context> getList();
 }

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/lang/i/MatchArm_TypeMatch.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/lang/i/MatchArm_TypeMatch.java
@@ -1,8 +1,10 @@
 package tripleo.elijah.lang.i;
 
-import antlr.*;
-import org.jetbrains.annotations.*;
 import java.util.*;
+
+import org.jetbrains.annotations.*;
+
+import antlr.*;
 
 public interface MatchArm_TypeMatch extends MC1 {
 	@Override
@@ -12,15 +14,18 @@ public interface MatchArm_TypeMatch extends MC1 {
 	void addDocString(Token text);
 
 	@Override
-	@NotNull Context getContext();
+	@NotNull
+	Context getContext();
 
 	IdentExpression getIdent();
 
 	@Override
-	@NotNull List<FunctionItem> getItems();
+	@NotNull
+	List<FunctionItem> getItems();
 
 	@Override
-	@NotNull OS_Element getParent();
+	@NotNull
+	OS_Element getParent();
 
 	TypeName getTypeName();
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/lang/i/MatchConditional.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/lang/i/MatchConditional.java
@@ -1,10 +1,11 @@
 package tripleo.elijah.lang.i;
 
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.contexts.*;
 import tripleo.elijah.lang2.*;
-
-import java.util.*;
 
 public interface MatchConditional extends OS_Element, StatementItem, FunctionItem {
 
@@ -20,7 +21,8 @@ public interface MatchConditional extends OS_Element, StatementItem, FunctionIte
 
 	List<MC1> getParts();
 
-	@NotNull IMatchConditionalPart2 normal();
+	@NotNull
+	IMatchConditionalPart2 normal();
 
 	void postConstruct();
 
@@ -36,7 +38,8 @@ public interface MatchConditional extends OS_Element, StatementItem, FunctionIte
 	//
 	//
 	//
-	@NotNull MatchArm_TypeMatch typeMatch();
+	@NotNull
+	MatchArm_TypeMatch typeMatch();
 
 	MatchConditionalPart3 valNormal();
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/lang/i/MatchConditionalPart3.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/lang/i/MatchConditionalPart3.java
@@ -1,8 +1,10 @@
 package tripleo.elijah.lang.i;
 
-import antlr.*;
-import org.jetbrains.annotations.*;
 import java.util.*;
+
+import org.jetbrains.annotations.*;
+
+import antlr.*;
 
 public interface MatchConditionalPart3 extends MC1 {
 	@Override
@@ -14,13 +16,16 @@ public interface MatchConditionalPart3 extends MC1 {
 	void expr(IdentExpression expr);
 
 	@Override
-	@NotNull Context getContext();
+	@NotNull
+	Context getContext();
 
 	@Override
-	@NotNull List<FunctionItem> getItems();
+	@NotNull
+	List<FunctionItem> getItems();
 
 	@Override
-	@NotNull OS_Element getParent();
+	@NotNull
+	OS_Element getParent();
 
 	void scope(Scope3 sco);
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/lang/types/OS_FuncType.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/lang/types/OS_FuncType.java
@@ -1,20 +1,24 @@
 package tripleo.elijah.lang.types;
 
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.lang.i.*;
 
 public interface OS_FuncType extends OS_Type {
 	boolean _isEqual(@NotNull OS_Type aType);
 
-	@NotNull String asString();
+	@NotNull
+	String asString();
 
 	@Override
 	OS_Element getElement();
 
 	@Override
-	@NotNull Type getType();
+	@NotNull
+	Type getType();
 
-	@NotNull boolean resolvedFunction(GClosure_OS_FuncType_resolvedFunction0 cl);
+	@NotNull
+	boolean resolvedFunction(GClosure_OS_FuncType_resolvedFunction0 cl);
 
 	@Override
 	String toString();

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/nextgen/ClassDefinition.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/nextgen/ClassDefinition.java
@@ -1,17 +1,18 @@
 package tripleo.elijah.nextgen;
 
+import java.util.*;
+
 import org.jetbrains.annotations.*;
-import tripleo.elijah.g.GClassInvocation;
-import tripleo.elijah.g.GEvaClass;
+
+import tripleo.elijah.g.*;
 import tripleo.elijah.lang.i.*;
 import tripleo.elijah.nextgen.composable.*;
-
-import java.util.*;
 
 public interface ClassDefinition {
 	IComposable getComposable();
 
-	@NotNull Set<ClassStatement> getExtended();
+	@NotNull
+	Set<ClassStatement> getExtended();
 
 	GClassInvocation getInvocation();
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/nextgen/outputtree/EOT_OutputFile.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/nextgen/outputtree/EOT_OutputFile.java
@@ -1,15 +1,17 @@
 package tripleo.elijah.nextgen.outputtree;
 
+import java.util.*;
+
 import org.jetbrains.annotations.*;
+
 import tripleo.elijah.nextgen.inputtree.*;
 import tripleo.elijah.nextgen.outputstatement.*;
-
-import java.util.*;
 
 public interface EOT_OutputFile {
 	String getFilename();
 
-	@NotNull List<EIT_Input> getInputs();
+	@NotNull
+	List<EIT_Input> getInputs();
 
 	EG_Statement getStatementSequence();
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/nextgen/outputtree/EOT_OutputTree.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/nextgen/outputtree/EOT_OutputTree.java
@@ -1,15 +1,16 @@
 package tripleo.elijah.nextgen.outputtree;
 
-import org.jetbrains.annotations.*;
-
 import java.util.*;
+
+import org.jetbrains.annotations.*;
 
 public interface EOT_OutputTree {
 	void add(@NotNull EOT_OutputFile aOff);
 
 	void addAll(@NotNull List<EOT_OutputFile> aLeof);
 
-	@NotNull List<EOT_OutputFile> getList();
+	@NotNull
+	List<EOT_OutputFile> getList();
 
 	void recompute();
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/stages/logging/ElLog.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/stages/logging/ElLog.java
@@ -1,11 +1,12 @@
 package tripleo.elijah.stages.logging;
 
-import org.jetbrains.annotations.*;
-
 import java.util.*;
 
+import org.jetbrains.annotations.*;
+
 public interface ElLog {
-	@NotNull List<LogEntry> getEntries();
+	@NotNull
+	List<LogEntry> getEntries();
 
 	String getFileName();
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/work/WorkList.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/elijah/work/WorkList.java
@@ -1,12 +1,14 @@
 package tripleo.elijah.work;
 
-import com.google.common.collect.*;
 import org.jetbrains.annotations.*;
+
+import com.google.common.collect.*;
 
 public interface WorkList {
 	void addJob(WorkJob aJob);
 
-	@NotNull ImmutableList<WorkJob> getJobs();
+	@NotNull
+	ImmutableList<WorkJob> getJobs();
 
 	boolean isDone();
 

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/vendor/org_apache_commons_cli/OptionBuilder.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/vendor/org_apache_commons_cli/OptionBuilder.java
@@ -17,8 +17,7 @@
 
 package tripleo.vendor.org_apache_commons_cli;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.*;
 
 /**
  * OptionBuilder allows the user to create Options using descriptive methods.

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/vendor/org_apache_commons_cli/OptionGroup.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/vendor/org_apache_commons_cli/OptionGroup.java
@@ -17,14 +17,10 @@
 
 package tripleo.vendor.org_apache_commons_cli;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import java.io.*;
+import java.util.*;
 
-import java.io.Serializable;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import org.jetbrains.annotations.*;
 
 /**
  * A group of mutually exclusive options.

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/vendor/org_apache_commons_cli/Options.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/vendor/org_apache_commons_cli/Options.java
@@ -17,10 +17,10 @@
 
 package tripleo.vendor.org_apache_commons_cli;
 
-import org.jetbrains.annotations.NotNull;
-
-import java.io.Serializable;
+import java.io.*;
 import java.util.*;
+
+import org.jetbrains.annotations.*;
 
 /**
  * Main entry-point into the library.

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/vendor/org_apache_commons_cli/Parser.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/vendor/org_apache_commons_cli/Parser.java
@@ -17,10 +17,9 @@
 
 package tripleo.vendor.org_apache_commons_cli;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import java.util.*;
+
+import org.jetbrains.annotations.*;
 
 /**
  * {@code Parser} creates {@link CommandLine}s.

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/vendor/org_apache_commons_cli/PatternOptionBuilder.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/vendor/org_apache_commons_cli/PatternOptionBuilder.java
@@ -17,13 +17,11 @@
 
 package tripleo.vendor.org_apache_commons_cli;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import java.io.*;
+import java.net.*;
+import java.util.*;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.net.URL;
-import java.util.Date;
+import org.jetbrains.annotations.*;
 
 /**
  * Allows Options to be created from a single String. The pattern contains

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/vendor/org_apache_commons_cli/PosixParser.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/vendor/org_apache_commons_cli/PosixParser.java
@@ -80,7 +80,8 @@
 //	 * @param stopAtNonOption Specifies whether to stop processing at the first
 //	 *                        non-Option encountered.
 //	 */
-//	protected void burstToken(final @NotNull String token, final boolean stopAtNonOption) {
+// protected void burstToken(final @NotNull String token, final boolean
+/// stopAtNonOption) {
 //		for (int i = 1; i < token.length(); i++) {
 //			final String ch = String.valueOf(token.charAt(i));
 //
@@ -142,7 +143,8 @@
 //	 * @return The flattened {@code arguments} String array.
 //	 */
 //	@Override
-//	protected String @NotNull [] flatten(final @NotNull Options options, final String[] arguments,
+// protected String @NotNull [] flatten(final @NotNull Options options, final
+/// String[] arguments,
 //			final boolean stopAtNonOption) throws ParseException {
 //		init();
 //		this.options = options;
@@ -209,7 +211,7 @@
 //	 *
 //	 * @param iter An iterator over the remaining tokens
 //	 */
-//	private void gobble(final @NotNull Iterator<String> iter) {
+// private void gobble(final @NotNull Iterator<String> iter) {
 //		if (eatTheRest) {
 //			while (iter.hasNext()) {
 //				tokens.add(iter.next());
@@ -227,7 +229,8 @@
 //	}
 //
 //	@Override
-//	public CommandLine parse(Options options, @NotNull List<CompilerInput> aInputs) {
+// public CommandLine parse(Options options, @NotNull List<CompilerInput>
+/// aInputs) {
 //		throw new NotImplementedException();
 //	}
 //

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/vendor/org_apache_commons_cli/TypeHandler.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/vendor/org_apache_commons_cli/TypeHandler.java
@@ -17,14 +17,11 @@
 
 package tripleo.vendor.org_apache_commons_cli;
 
-import org.jetbrains.annotations.NotNull;
+import java.io.*;
+import java.net.*;
+import java.util.*;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Date;
+import org.jetbrains.annotations.*;
 
 /**
  * This is a temporary implementation. TypeHandler will handle the pluggableness

--- a/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/vendor/org_apache_commons_cli/Util.java
+++ b/xxx-elijah-core-api/elijah-core-api/src/main/java/tripleo/vendor/org_apache_commons_cli/Util.java
@@ -17,8 +17,7 @@
 
 package tripleo.vendor.org_apache_commons_cli;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.*;
 
 /**
  * Contains useful helper methods for classes within this package.

--- a/xxx-elijah-core-api/elijah-ek/src/main/java/tripleo/vendor/batoull22/EK_ExpertSystem.java
+++ b/xxx-elijah-core-api/elijah-ek/src/main/java/tripleo/vendor/batoull22/EK_ExpertSystem.java
@@ -1,10 +1,11 @@
 package tripleo.vendor.batoull22;
 
-import org.jetbrains.annotations.NotNull;
-import tripleo.elijah.util.Operation;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
+import java.io.*;
+import java.util.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.elijah.util.*;
 
 /**
  * @author batoul

--- a/xxx-elijah-core-api/elijah-ek/src/main/java/tripleo/vendor/batoull22/EK_Fact.java
+++ b/xxx-elijah-core-api/elijah-ek/src/main/java/tripleo/vendor/batoull22/EK_Fact.java
@@ -1,7 +1,6 @@
 package tripleo.vendor.batoull22;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
 
 /**
  * @author tripleo

--- a/xxx-elijah-core-api/elijah-ek/src/main/java/tripleo/vendor/batoull22/EK_Factarray.java
+++ b/xxx-elijah-core-api/elijah-ek/src/main/java/tripleo/vendor/batoull22/EK_Factarray.java
@@ -1,9 +1,8 @@
 package tripleo.vendor.batoull22;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import java.util.*;
 
-import java.util.Objects;
+import org.jetbrains.annotations.*;
 
 /**
  * @author tripleo

--- a/xxx-elijah-core-api/elijah-ek/src/main/java/tripleo/vendor/batoull22/EK_Production.java
+++ b/xxx-elijah-core-api/elijah-ek/src/main/java/tripleo/vendor/batoull22/EK_Production.java
@@ -1,11 +1,8 @@
 package tripleo.vendor.batoull22;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
 
 /**
  * @author tripleo

--- a/xxx-elijah-core-api/elijah-nextgen-outputstatement/src/main/java/tripleo/elijah/nextgen/outputstatement/EG_CompoundStatement.java
+++ b/xxx-elijah-core-api/elijah-nextgen-outputstatement/src/main/java/tripleo/elijah/nextgen/outputstatement/EG_CompoundStatement.java
@@ -1,7 +1,6 @@
 package tripleo.elijah.nextgen.outputstatement;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
 
 /**
  * @author Tripleo Nova
@@ -10,16 +9,16 @@ public class EG_CompoundStatement implements EG_Statement {
 
 	private final @NotNull EG_SingleStatement beginning;
 	private final @NotNull EG_SingleStatement ending;
-	private final @NotNull EX_Explanation     explanation;
+	private final @NotNull EX_Explanation explanation;
 	private final          boolean            indent;
-	private final @NotNull EG_Statement       middle;
+	private final @NotNull EG_Statement middle;
 
 	@Contract(pure = true)
 	public EG_CompoundStatement(final @NotNull EG_SingleStatement aBeginning,
-								final @NotNull EG_SingleStatement aEnding,
-								final @NotNull EG_Statement aMiddle,
+			final @NotNull EG_SingleStatement aEnding,
+			final @NotNull EG_Statement aMiddle,
 								final boolean aIndent,
-								final @NotNull EX_Explanation aExplanation) {
+			final @NotNull EX_Explanation aExplanation) {
 		beginning   = aBeginning;
 		ending      = aEnding;
 		middle      = aMiddle;

--- a/xxx-elijah-core-api/elijah-nextgen-outputstatement/src/main/java/tripleo/elijah/nextgen/outputstatement/EG_DottedStatement.java
+++ b/xxx-elijah-core-api/elijah-nextgen-outputstatement/src/main/java/tripleo/elijah/nextgen/outputstatement/EG_DottedStatement.java
@@ -1,8 +1,8 @@
 package tripleo.elijah.nextgen.outputstatement;
 
-import org.jetbrains.annotations.NotNull;
+import java.util.*;
 
-import java.util.List;
+import org.jetbrains.annotations.*;
 
 public class EG_DottedStatement implements EG_Statement {
 	private final EX_Explanation explanation;

--- a/xxx-elijah-core-api/elijah-nextgen-outputstatement/src/main/java/tripleo/elijah/nextgen/outputstatement/EG_SingleStatement.java
+++ b/xxx-elijah-core-api/elijah-nextgen-outputstatement/src/main/java/tripleo/elijah/nextgen/outputstatement/EG_SingleStatement.java
@@ -4,8 +4,7 @@
  */
 package tripleo.elijah.nextgen.outputstatement;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.*;
 
 /**
  * @author Tripleo Nova

--- a/xxx-elijah-core-api/elijah-nextgen-outputstatement/src/main/java/tripleo/elijah/nextgen/outputstatement/EG_Statement.java
+++ b/xxx-elijah-core-api/elijah-nextgen-outputstatement/src/main/java/tripleo/elijah/nextgen/outputstatement/EG_Statement.java
@@ -1,7 +1,6 @@
 package tripleo.elijah.nextgen.outputstatement;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
 
 /**
  * @author Tripleo Nova

--- a/xxx-elijah-core-api/elijah-nextgen-outputstatement/src/main/java/tripleo/elijah/nextgen/outputstatement/EG_SyntheticStatement.java
+++ b/xxx-elijah-core-api/elijah-nextgen-outputstatement/src/main/java/tripleo/elijah/nextgen/outputstatement/EG_SyntheticStatement.java
@@ -4,11 +4,9 @@
  */
 package tripleo.elijah.nextgen.outputstatement;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import tripleo.small.ES_Item;
-import tripleo.small.ES_String;
-import tripleo.small.ES_Symbol;
+import org.jetbrains.annotations.*;
+
+import tripleo.small.*;
 
 /**
  * @author Tripleo Nova

--- a/xxx-elijah-core-api/elijah-nextgen-outputstatement/src/main/java/tripleo/elijah/nextgen/outputstatement/EX_Explanation.java
+++ b/xxx-elijah-core-api/elijah-nextgen-outputstatement/src/main/java/tripleo/elijah/nextgen/outputstatement/EX_Explanation.java
@@ -1,6 +1,6 @@
 package tripleo.elijah.nextgen.outputstatement;
 
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.*;
 
 public interface EX_Explanation {
 	static @NotNull EX_Explanation withMessage(final @NotNull String message) {

--- a/xxx-elijah-core-api/elijah-nextgen-outputstatement/src/main/java/tripleo/elijah/nextgen/outputstatement/EX_SingleElementExplanation.java
+++ b/xxx-elijah-core-api/elijah-nextgen-outputstatement/src/main/java/tripleo/elijah/nextgen/outputstatement/EX_SingleElementExplanation.java
@@ -6,19 +6,19 @@
 //
 //public class EX_SingleElementExplanation implements EX_Explanation {
 //
-//	private final @NotNull OS_Element _element;
+// private final @NotNull OS_Element _element;
 //
 //	@Contract(pure = true)
-//	public EX_SingleElementExplanation(final @NotNull OS_Element aElement) {
+// public EX_SingleElementExplanation(final @NotNull OS_Element aElement) {
 //		_element = aElement;
 //	}
 //
-//	public @NotNull OS_Element getElement() {
+// public @NotNull OS_Element getElement() {
 //		return _element;
 //	}
 //
 //	@Override
-//	public @NotNull String message() {
+// public @NotNull String message() {
 //		return "EX_SingleElementExplanation";
 //	}
 //}

--- a/xxx-elijah-core-api/elijah-nextgen-outputstatement/src/main/java/tripleo/elijah/nextgen/outputstatement/GE_BuffersStatement.java
+++ b/xxx-elijah-core-api/elijah-nextgen-outputstatement/src/main/java/tripleo/elijah/nextgen/outputstatement/GE_BuffersStatement.java
@@ -1,11 +1,11 @@
 package tripleo.elijah.nextgen.outputstatement;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import tripleo.util.buffer.Buffer;
-
 import java.util.*;
-import java.util.stream.Collectors;
+import java.util.stream.*;
+
+import org.jetbrains.annotations.*;
+
+import tripleo.util.buffer.*;
 
 // TODO 11/29 looks a little bit like it doesn't belong
 public class GE_BuffersStatement implements EG_Statement {

--- a/xxx-elijah-core-api/elijah-stateful/src/main/java/tripleo/elijah/stateful/DefaultStateful.java
+++ b/xxx-elijah-core-api/elijah-stateful/src/main/java/tripleo/elijah/stateful/DefaultStateful.java
@@ -1,7 +1,6 @@
 package tripleo.elijah.stateful;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.*;
 
 public abstract class DefaultStateful implements Stateful {
 	private State _state;

--- a/xxx-elijah-core-api/elijah-stateful/src/main/java/tripleo/elijah/stateful/StateRegistrationToken.java
+++ b/xxx-elijah-core-api/elijah-stateful/src/main/java/tripleo/elijah/stateful/StateRegistrationToken.java
@@ -1,9 +1,8 @@
 package tripleo.elijah.stateful;
 
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
+import java.util.*;
 
-import java.util.Objects;
+import org.jetbrains.annotations.*;
 
 public final class StateRegistrationToken {
 	private final int token;

--- a/xxx-elijah-core-api/elijah-stateful/src/main/java/tripleo/elijah/stateful/Stateful.java
+++ b/xxx-elijah-core-api/elijah-stateful/src/main/java/tripleo/elijah/stateful/Stateful.java
@@ -1,7 +1,6 @@
 package tripleo.elijah.stateful;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.*;
 
 public interface Stateful {
 	void mvState(@Nullable State aBeginState, @NotNull State aState);

--- a/xxx-elijah-core-api/elijah-stateful/src/main/java/tripleo/elijah/stateful/_RegistrationTarget.java
+++ b/xxx-elijah-core-api/elijah-stateful/src/main/java/tripleo/elijah/stateful/_RegistrationTarget.java
@@ -1,9 +1,8 @@
 package tripleo.elijah.stateful;
 
-import org.jetbrains.annotations.NotNull;
+import java.util.*;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.jetbrains.annotations.*;
 
 public abstract class _RegistrationTarget {
 	public State registerState(final @NotNull State aState) {

--- a/xxx-elijah-core-api/elijah-stateful/src/main/java/tripleo/elijah/stateful/annotation/processor/StatefulProcessor.java
+++ b/xxx-elijah-core-api/elijah-stateful/src/main/java/tripleo/elijah/stateful/annotation/processor/StatefulProcessor.java
@@ -1,21 +1,18 @@
 package tripleo.elijah.stateful.annotation.processor;
 
-import com.google.auto.service.AutoService;
-import org.jetbrains.annotations.NotNull;
+import java.io.*;
+import java.util.*;
+import java.util.stream.*;
 
 import javax.annotation.processing.*;
-import javax.lang.model.SourceVersion;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.ExecutableType;
-import javax.tools.Diagnostic;
-import javax.tools.JavaFileObject;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
+import javax.lang.model.*;
+import javax.lang.model.element.*;
+import javax.lang.model.type.*;
+import javax.tools.*;
+
+import org.jetbrains.annotations.*;
+
+import com.google.auto.service.*;
 
 @SupportedAnnotationTypes("tripleo.elijah.stateful.annotation.processor.StatefulProperty")
 @SupportedSourceVersion(SourceVersion.RELEASE_8)

--- a/xxx-elijah-core-api/elijah-util/src/main/java/tripleo/elijah/diagnostic/Diagnostic.java
+++ b/xxx-elijah-core-api/elijah-util/src/main/java/tripleo/elijah/diagnostic/Diagnostic.java
@@ -9,10 +9,10 @@
 
 package tripleo.elijah.diagnostic;
 
-import org.jetbrains.annotations.*;
-
 import java.io.*;
 import java.util.*;
+
+import org.jetbrains.annotations.*;
 
 /**
  * Created 12/26/20 5:31 AM

--- a/xxx-elijah-core-api/elijah-util/src/main/java/tripleo/elijah/diagnostic/ExceptionDiagnostic.java
+++ b/xxx-elijah-core-api/elijah-util/src/main/java/tripleo/elijah/diagnostic/ExceptionDiagnostic.java
@@ -1,9 +1,9 @@
 package tripleo.elijah.diagnostic;
 
-import org.jetbrains.annotations.*;
-
 import java.io.*;
 import java.util.*;
+
+import org.jetbrains.annotations.*;
 
 public class ExceptionDiagnostic implements Diagnostic {
 	private final Throwable e;

--- a/xxx-elijah-core-api/elijah-util/src/main/java/tripleo/elijah/diagnostic/FileNotFoundDiagnostic.java
+++ b/xxx-elijah-core-api/elijah-util/src/main/java/tripleo/elijah/diagnostic/FileNotFoundDiagnostic.java
@@ -1,10 +1,9 @@
 package tripleo.elijah.diagnostic;
 
-import org.jetbrains.annotations.NotNull;
+import java.io.*;
+import java.util.*;
 
-import java.io.File;
-import java.io.PrintStream;
-import java.util.List;
+import org.jetbrains.annotations.*;
 
 public class FileNotFoundDiagnostic implements Diagnostic {
 	private final File f;


### PR DESCRIPTION
- **[parity] Evenutal: Add onFail and reject**
- **Make Operation use throwable i/o Exception**
- **Add DiagnosticException from elko-work/240806**
- **Make ExceptionDiagnostic use throwable i/o Exception**
- **Fix verbiage**
- **Use promises in DeclTarget**
- **Lazily use Diagnostic in GenericPart**
- **Lazily add DefaultEventualRegister from congenial-lein**
- **Add EventualExtract from elko-work/240806**
- **[parity] Make DeducePhase an EventualRegister**
- **fix: qualification**
- **fix: qualification**
- **fix: qualification**
- **fix: qualification**
- **Add Eventual shortcut**
- **[slim] Introducing DW_onExitFunction and _A_Active**
- **Use dt2#eventual in ClassInvocationMake**
- **Remove "noise"**
- **Add accessor**
- **Add accessors**
- **,**
- **Add Adder from elko-work/240806**
- **Use Adder i/o Consumer**
- **[idea] Use USE_SINGLE_CLASS_IMPORTS**
- **#adviseContext**
- **Remove generatedFunction and DT2 params**
- **[cj-ify] Introducing logProgressRunnable**
- **ProgramIsLikelyWrong: Add message constructor**
- **Make Adder shim Consumer**
- **Make Adder shim Consumer**
- **[debug]**
- **bdl**
- **Move DefaultDeduced***
- **Move DefaultDeduced***
- **??**
- **Convenience method**
- **Convenience method (and note, all is well)**
- **"Just" remove it**
- **"Just" remove it**
- **[minor/style]**
- **Look upon thee in awe of reminder to study text extraction**
- **fix: (interim) visibility**
- **unlower WhyNotGarish_Namespace**
- **unlower WhyNotGarish_Item**
- **unlower WhyNotGarish_Function**
- **unlower WhyNotGarish_Constructor**
- **unlower WhyNotGarish_Class**
- **Add cheat for WhyNotGarish_Class**
- **Make Utility class**
- **[minor] Cleanup**
- **[minor] visibility**
- **[minor] visibility and naming**
- **[minor] visibility**
- **[minor] visibility**
- **Remove GNCoded**
- **Move VarTableEntry to new file**
- **Remove GNCoded**
- **idea seems to be stuck (I)**
- **Missing raise and raise_stop for some reason**
- **use 17.0.12-tem**
- **Make LivingFunction#getCode return Eventual<Integer>**
- **Use flep callbacks**
- **Change method name**
- **Make IEvaFunctionBase extend EvaNode**
- **Basically removing #{get/set}Code from EvaNode***
- **Removals**
- **{+C} {I} Interesting how there is no #setCode**
- **Don't ci on push**
- **2024-08-11 018: [DeduceTypes2] Split into separate classes**
- **2024-08-11 018b: glarg!!!**
- **2024-08-11 018c: Fix "doubling" of param/field references**
- **2024-08-11 019: [eclipse-formatter] fix: method invocation alignment**
- **2024-08-11 021: [eclipse-formatter] fix: assignment alignment**
